### PR TITLE
Feature/stage abort

### DIFF
--- a/src/swell/tasks/stage.py
+++ b/src/swell/tasks/stage.py
@@ -121,7 +121,7 @@ class Stage(taskBase):
             if os.path.islink(dest):
                 os.remove(dest)
             if os.path.isfile(dest):
-                self.logger.abort('File already exists: "' + dest + '"')
+                self.logger.abort('File exists where link expected: "' + dest + '"')
             if not os.path.isfile(dest):
                 os.symlink(src, dest)
         except Exception:

--- a/src/swell/tasks/stage.py
+++ b/src/swell/tasks/stage.py
@@ -64,10 +64,13 @@ class Stage(taskBase):
 
                 filelist = glob.glob(src)
 
+                if not filelist:
+                    self.logger.abort('Source inputs not found "' + src + '"')
+
                 try:
-                    os.makedirs(dir, 0o755)
+                    os.makedirs(dir, 0o755, exist_ok=True)
                 except Exception:
-                    pass
+                    self.logger.abort('Unable to create "' + dir + '"')
 
                 for file in filelist:
                     dest = os.path.join(dir, os.path.basename(file))
@@ -93,7 +96,7 @@ class Stage(taskBase):
 
         try:
             copyfile(src, dest)
-        except:
+        except Exception:
             self.logger.abort('Unable to copy "' + src + '" to "' + dest + '"')
 
     # ----------------------------------------------------------------------------------------------
@@ -121,5 +124,5 @@ class Stage(taskBase):
                 self.logger.abort('File already exists: "' + dest + '"')
             if not os.path.isfile(dest):
                 os.symlink(src, dest)
-        except:
+        except Exception:
             self.logger.abort('Unable to link "' + dest + '" to "' + src + '"')

--- a/src/swell/tasks/stage.py
+++ b/src/swell/tasks/stage.py
@@ -89,8 +89,12 @@ class Stage(taskBase):
 
         self.logger.info("Copying " + src + " to " + dest)
         if not os.path.isfile(src):
-            return
-        copyfile(src, dest)
+            self.logger.abort('Source file does not exist: "' + src + '"')
+
+        try:
+            copyfile(src, dest)
+        except:
+            self.logger.abort('Unable to copy "' + src + '" to "' + dest + '"')
 
     # ----------------------------------------------------------------------------------------------
 
@@ -106,8 +110,16 @@ class Stage(taskBase):
              Destination link file to be created.
         """
 
-        self.logger.info("Linking " + dest + " to " + src)
-        if os.path.islink(dest):
-            os.remove(dest)
-        if not os.path.isfile(dest):
-            os.symlink(src, dest)
+        self.logger.info('Linking "' + dest + '" to "' + src + '"')
+        if not os.path.isfile(src):
+            self.logger.abort('Source file does not exist: "' + src + '"')
+
+        try:
+            if os.path.islink(dest):
+                os.remove(dest)
+            if os.path.isfile(dest):
+                self.logger.abort('File already exists: "' + dest + '"')
+            if not os.path.isfile(dest):
+                os.symlink(src, dest)
+        except:
+            self.logger.abort('Unable to link "' + dest + '" to "' + src + '"')


### PR DESCRIPTION
Error checking was added to the stage task:

(1) Source file(s) do not exist
(2) Cannot create directory
(3) File already exists (destination is a link but a file exists with the same name)

All errors were simulated using a CYLC executed experiment and verified. In addition, an experiment was executed with stage files already copied. No errors were encountered as expected. The stage task will not abort if files already exist. 