### PR TITLE
Add timeouts to run steps

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -14,5 +14,9 @@ jobs:
       with:
         python-version: '3.9'
         cache: 'pip'
+
     - run: pip install -r requirements.txt
+      timeout-minutes: 1
+
     - run: python3 pycodestyle_run.py
+      timeout-minutes: 2


### PR DESCRIPTION
## Description

Per https://www.scivision.dev/github-actions-timeout/, you can add
timeouts to run steps in GitHub Actions. As he talks about,
`pip install` shouldn't take more than a minute, if so, you're building
from source which isn't good. And the codestyle step shouldn't take more
than a minute or two even in the worst case, so if it does, abort the
job.

### Issue(s) addressed

The only issue is in my head...

## Acceptance Criteria (Definition of Done)

If the CI passes, it's good!

## Dependencies

No dependencies.

## Impact

No impact. CI only.