### PR TITLE
Bug fix to allow only one obs operator to be used

### DIFF
--- a/src/swell/deployment/yaml_exploder.py
+++ b/src/swell/deployment/yaml_exploder.py
@@ -47,7 +47,7 @@ def recursive_yaml_expansion(experiment_dict):
                 exp_list.append(sub_yaml_dict)
 
             # Write the expanded list element to the original dictionary key
-            if len(exp_list) > 1:
+            if len(exp_list) > 1 or isinstance(experiment_item, list):
                 experiment_dict[k] = exp_list
             else:
                 experiment_dict[k] = exp_list[0]


### PR DESCRIPTION
## Description

A bug in create experiment was resulting in the list of observation operators being turned into a single item, breaking subsequent tasks.