### PR TITLE
default to running two cycles

### DIFF
--- a/src/swell/suites/hofx/experiment.yaml
+++ b/src/swell/suites/hofx/experiment.yaml
@@ -9,7 +9,7 @@ executable: fv3jedi_hofx.x
 suite:
   platform: nccs_discover
   intial cylc point: 2020-12-15T00
-  final cylc point: 2020-12-15T00
+  final cylc point: 2020-12-15T06
   runahead limit: PT24H
   suite name: hofx
   scheduling:


### PR DESCRIPTION
## Description

This makes the default mode of running two concurrent cycles. This should be the default way of testing the workflow.