### PR TITLE
Update CRTM coefficient path

### DIFF
--- a/src/swell/configuration/observation_operators/airs_aqua.yaml
+++ b/src/swell/configuration/observation_operators/airs_aqua.yaml
@@ -33,7 +33,7 @@ obs operator:
   obs options:
     Sensor_ID: airs_aqua
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/airs_aqua.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/amsua_aqua.yaml
+++ b/src/swell/configuration/observation_operators/amsua_aqua.yaml
@@ -14,7 +14,7 @@ obs operator:
   obs options:
     Sensor_ID: amsua_aqua
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/amsua_aqua.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/amsua_metop-a.yaml
+++ b/src/swell/configuration/observation_operators/amsua_metop-a.yaml
@@ -14,7 +14,7 @@ obs operator:
   obs options:
     Sensor_ID: amsua_metop-a
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/amsua_metop-a.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/amsua_metop-b.yaml
+++ b/src/swell/configuration/observation_operators/amsua_metop-b.yaml
@@ -14,7 +14,7 @@ obs operator:
   obs options:
     Sensor_ID: amsua_metop-b
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/amsua_metop-b.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/amsua_metop-c.yaml
+++ b/src/swell/configuration/observation_operators/amsua_metop-c.yaml
@@ -14,7 +14,7 @@ obs operator:
   obs options:
     Sensor_ID: amsua_metop-c
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/amsua_metop-c.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/amsua_n15.yaml
+++ b/src/swell/configuration/observation_operators/amsua_n15.yaml
@@ -14,7 +14,7 @@ obs operator:
   obs options:
     Sensor_ID: amsua_n15
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/amsua_n15.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/amsua_n18.yaml
+++ b/src/swell/configuration/observation_operators/amsua_n18.yaml
@@ -14,7 +14,7 @@ obs operator:
   obs options:
     Sensor_ID: amsua_n18
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/amsua_n18.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/amsua_n19.yaml
+++ b/src/swell/configuration/observation_operators/amsua_n19.yaml
@@ -14,7 +14,7 @@ obs operator:
   obs options:
     Sensor_ID: amsua_n19
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/amsua_n19.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/atms_n20.yaml
+++ b/src/swell/configuration/observation_operators/atms_n20.yaml
@@ -14,7 +14,7 @@ obs operator:
   obs options:
     Sensor_ID: atms_n20
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/atms_n20.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/atms_npp.yaml
+++ b/src/swell/configuration/observation_operators/atms_npp.yaml
@@ -14,7 +14,7 @@ obs operator:
   obs options:
     Sensor_ID: atms_npp
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/atms_npp.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/avhrr3_metop-a.yaml
+++ b/src/swell/configuration/observation_operators/avhrr3_metop-a.yaml
@@ -12,7 +12,7 @@ obs operator:
   obs options:
     Sensor_ID: avhrr3_metop-a
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/avhrr3_metop-a.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/avhrr3_n18.yaml
+++ b/src/swell/configuration/observation_operators/avhrr3_n18.yaml
@@ -12,7 +12,7 @@ obs operator:
   obs options:
     Sensor_ID: avhrr3_n18
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/avhrr3_n18.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/cris-fsr_n20.yaml
+++ b/src/swell/configuration/observation_operators/cris-fsr_n20.yaml
@@ -43,7 +43,7 @@ obs operator:
   obs options:
     Sensor_ID: cris-fsr_n20
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/cris-fsr_n20.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/cris-fsr_npp.yaml
+++ b/src/swell/configuration/observation_operators/cris-fsr_npp.yaml
@@ -43,7 +43,7 @@ obs operator:
   obs options:
     Sensor_ID: cris-fsr_npp
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/cris-fsr_npp.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/iasi_metop-a.yaml
+++ b/src/swell/configuration/observation_operators/iasi_metop-a.yaml
@@ -60,7 +60,7 @@ obs operator:
   obs options:
     Sensor_ID: iasi_metop-a
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/iasi_metop-a.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/iasi_metop-b.yaml
+++ b/src/swell/configuration/observation_operators/iasi_metop-b.yaml
@@ -60,7 +60,7 @@ obs operator:
   obs options:
     Sensor_ID: iasi_metop-b
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/iasi_metop-b.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/mhs_metop-b.yaml
+++ b/src/swell/configuration/observation_operators/mhs_metop-b.yaml
@@ -12,7 +12,7 @@ obs operator:
   obs options:
     Sensor_ID: mhs_metop-b
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/mhs_metop-b.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/mhs_metop-c.yaml
+++ b/src/swell/configuration/observation_operators/mhs_metop-c.yaml
@@ -12,7 +12,7 @@ obs operator:
   obs options:
     Sensor_ID: mhs_metop-c
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/mhs_metop-c.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/mhs_n19.yaml
+++ b/src/swell/configuration/observation_operators/mhs_n19.yaml
@@ -12,7 +12,7 @@ obs operator:
   obs options:
     Sensor_ID: mhs_n19
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/mhs_n19.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/seviri_m11.yaml
+++ b/src/swell/configuration/observation_operators/seviri_m11.yaml
@@ -12,7 +12,7 @@ obs operator:
   obs options:
     Sensor_ID: seviri_m11
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/seviri_m11.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/configuration/observation_operators/ssmis_f17.yaml
+++ b/src/swell/configuration/observation_operators/ssmis_f17.yaml
@@ -12,7 +12,7 @@ obs operator:
   obs options:
     Sensor_ID: ssmis_f17
     EndianType: little_endian
-    CoefficientPath: $(jedi_build_dir)/ufo/test/Data/
+    CoefficientPath: $(crtm_coeff_dir)
 obs bias:
   input file: $(cycle_dir)/ssmis_f17.{{background_time}}.satbias.nc4
   variational bc:

--- a/src/swell/suites/hofx/experiment.yaml
+++ b/src/swell/suites/hofx/experiment.yaml
@@ -175,6 +175,7 @@ R2D2:
 obs_experiment: x0044
 update channels from database: false
 use geos satellite channel database: true
+crtm_coeff_dir: /discover/nobackup/projects/gmao/share/gmao_ops/fvInput_4dvar/gsi/etc/fix_ncep20210525/REL-2.2.3-r60152_local-rev_5/CRTM_Coeffs/Little_Endian/
 
 OBSERVATIONS:
   - yaml::$(swell_dir)/configuration/observation_operators/aircraft.yaml


### PR DESCRIPTION
## Description

Update the path used for the CRTM coefficients.

- Allow the path to be set in the experiment.yaml instead of the individual observation operator YAML files.
- Set the default experiment-wide path to the one used in other GMAO experiments.