### PR TITLE
Added the yaml file for amsr2_gcom-w1.

### DIFF
--- a/src/swell/configuration/observation_operators/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/observation_operators/amsr2_gcom-w1.yaml
@@ -1,0 +1,195 @@
+obs space:
+  name: amsr2_gcom-w1
+  obsdatain:
+    obsfile: $(cycle_dir)/amsr2_gcom-w1.{{window_begin}}.nc4
+  obsdataout:
+    obsfile: $(cycle_dir)/$(experiment_id).amsr2_gcom-w1.{{window_begin}}.nc4
+  simulated variables: [brightness_temperature]
+  channels: &amsr2_gcom-w1_channels 1-14
+obs operator:
+  name: CRTM
+  Absorbers: [H2O,O3,CO2]
+# Clouds: [Water, Ice, Rain, Snow]
+  Clouds: [Water, Ice]
+  Cloud_Fraction: 1.0
+  linear obs operator:
+    Absorbers: [H2O,O3,CO2]
+    Clouds: [Water]
+  obs options:
+    Sensor_ID: amsr2_gcom-w1
+    EndianType: little_endian
+    CoefficientPath: $(crtm_coeff_dir)
+obs bias:
+  input file: $(cycle_dir)/amsr2_gcom-w1.{{background_time}}.satbias.nc4
+  variational bc:
+    predictors:
+    - name: constant
+    - name: lapse_rate
+      order: 2
+      tlapse: &amsr2_gcom-w1_tlapse $(cycle_dir)/amsr2_gcom-w1.{{background_time}}.tlapse.txt
+    - name: lapse_rate
+      tlapse: *amsr2_gcom-w1_tlapse
+    - name: emissivity
+    - name: scan_angle
+      var_name: scan_position
+      order: 4
+    - name: scan_angle
+      var_name: scan_position
+      order: 3
+    - name: scan_angle
+      var_name: scan_position
+      order: 2
+    - name: scan_angle
+      var_name: scan_position
+obs filters:
+- filter: Bounds Check
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-14
+  minvalue: 50.0
+  maxvalue: 340.0
+- filter: Domain Check
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-14
+  where:
+  - variable:
+      name: water_area_fraction@GeoVaLs
+    minvalue: 0.999
+  - variable:
+      name: surface_temperature_where_sea@GeoVaLs
+    minvalue: 275
+  - variable:
+      name: surface_wind_speed@GeoVaLs
+    maxvalue: 12
+  - variable:
+      name: latitude@MetaData
+    minvalue: -60.0
+    maxvalue: 60.0
+- filter: Bounds Check
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-14
+  test variables:
+  - name: TotalColumnVaporGuess@ObsFunction
+  minvalue: 10.0
+- filter: Bounds Check
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-14
+  test variables:
+  - name: SunGlintAngle@ObsFunction
+  minvalue: 20.0
+#  Ckeck CLW retrievals from observations 
+- filter: Bounds Check
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-14
+  test variables:
+  - name: CLWRetMW@ObsFunction
+    options:
+      clwret_ch18v: 7
+      clwret_ch18h: 8
+      clwret_ch36v: 11
+      clwret_ch36h: 12
+      sys_bias: &amsr2_sys_bias [0.4800, 3.0737, 0.7433, 3.6430,
+                                 3.5304, 4.4270, 5.1448, 5.0785,
+                                 4.9763, 9.3215, 2.5789, 5.5274,
+                                 0.6641, 1.3674]
+      clwret_types: [ObsValue]
+  maxvalue: 1.0
+#  Ckeck CLW retrievals from HofX
+- filter: Bounds Check
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-14
+  test variables:
+  - name: CLWRetMW@ObsFunction
+    options:
+      clwret_ch18v: 7
+      clwret_ch18h: 8
+      clwret_ch36v: 11
+      clwret_ch36h: 12
+      sys_bias: *amsr2_sys_bias
+      clwret_types: [HofX]
+  maxvalue: 1.0
+- filter: Difference Check
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-14
+  value:
+    name: CLWRetMW@ObsFunction
+    options:
+      clwret_ch18v: 7
+      clwret_ch18h: 8
+      clwret_ch36v: 11
+      clwret_ch36h: 12
+      sys_bias: *amsr2_sys_bias
+      clwret_types: [ObsValue]
+  reference:
+    name: CLWRetMW@ObsFunction
+    options:
+      clwret_ch18v: 7
+      clwret_ch18h: 8
+      clwret_ch36v: 11
+      clwret_ch36h: 12
+      sys_bias: *amsr2_sys_bias
+      clwret_types: [HofX]
+  minvalue: -0.5
+  maxvalue: 0.5
+- filter: BlackList
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-14
+  action:
+    name: assign error
+    error function:
+      name: ObsErrorModelRamp@ObsFunction
+      channels: 1-14
+      options:
+        channels: 1-14
+        xvar:
+          name: CLWRetSymmetricMW@ObsFunction
+          options:
+            clwret_ch18v: 7
+            clwret_ch18h: 8
+            clwret_ch36v: 11
+            clwret_ch36h: 12
+            sys_bias: *amsr2_sys_bias
+            clwret_types: [ObsValue, HofX]
+        x0:    [ 0.05,  0.05, 0.05, 0.05, 0.10, 0.10,
+                 0.05,  0.05, 0.05, 0.05, 0.05, 0.05,       
+                 0.05,  0.05]
+        x1:    [ 0.60,  0.60, 0.60, 0.60, 0.60, 0.50,
+                 0.30,  0.30, 0.30, 0.30, 0.30, 0.30,
+                 0.30,  0.30]
+        err0:  [  0.8,  0.9,  0.8,  0.9,  1.0, 1.1,
+                  2.0,  3.5,  3.0,  4.8,  5.0, 6.0,
+                  4.5,  6.3]
+        err1:  [  5.0,  5.0,  5.0,  5.0,  5.0, 18.5,
+                 20.0, 40.0, 20.0, 25.0, 30.0, 30.0,
+                 30.0, 20.0]
+- filter: Background Check
+  apply at iterations: 0, 1
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-14
+  threshold: 2.0
+  action:
+    name: reject
+- filter: Background Check
+  apply at iterations: 0, 1
+  filter variables:
+  - name: brightness_temperature
+    channels: 7-10
+  absolute threshold: 30
+  action:
+    name: reject
+- filter: Background Check
+  apply at iterations: 0, 1
+  filter variables:
+  - name: brightness_temperature
+    channels: 11-14
+  absolute threshold: 50
+  action:
+    name: reject

--- a/src/swell/suites/hofx/experiment.yaml
+++ b/src/swell/suites/hofx/experiment.yaml
@@ -180,6 +180,7 @@ crtm_coeff_dir: /discover/nobackup/projects/gmao/share/gmao_ops/fvInput_4dvar/gs
 OBSERVATIONS:
   - yaml::$(swell_dir)/configuration/observation_operators/aircraft.yaml
   #- yaml::$(swell_dir)/configuration/observation_operators/airs_aqua.yaml
+  #- yaml::$(swell_dir)/configuration/observation_operators/amsr2_gcom-w1.yaml
   #- yaml::$(swell_dir)/configuration/observation_operators/amsua_aqua.yaml
   #- yaml::$(swell_dir)/configuration/observation_operators/amsua_metop-a.yaml
   #- yaml::$(swell_dir)/configuration/observation_operators/amsua_metop-b.yaml


### PR DESCRIPTION
Added the observational operator for AMSR2_GCOM-W1 data. This operator is fully tested in UFO and is able to exactly reproduce GEOS forward processing, observational error functions and quality control. However, clouds are limited to "qi" and "ql", and the operator is yet tested with GEOS data in Swell at the time of this PR.     