### PR TITLE
add mls ozone yaml.

### DIFF
--- a/src/swell/configuration/observation_operators/mls55_aura.yaml
+++ b/src/swell/configuration/observation_operators/mls55_aura.yaml
@@ -9,12 +9,19 @@ obs operator:
   name: VertInterp
   vertical coordinate: ["air_pressure"]
   geovals: [mole_fraction_of_ozone_in_air]
-#obs filters:
-#  # range sanity check
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: mole_fraction_layer_ozone_in_air
-#    minvalue: 0
-#    maxvalue: 10000
-#    action:
-#      name: reject
+obs filters:
+  # range sanity check
+  - filter: Bounds Check
+    filter variables:
+    - name: mole_fraction_of_ozone_in_air
+    minvalue: 0
+    maxvalue: 10000
+    action:
+      name: reject
+  # threshold is really threshold*observation error (threshold= relative threshold)
+  - filter: Background Check
+    filter variables:
+    - name: mole_fraction_of_ozone_in_air
+    threshold: 5.0
+    action:
+      name: reject

--- a/src/swell/configuration/observation_operators/mls55_aura.yaml
+++ b/src/swell/configuration/observation_operators/mls55_aura.yaml
@@ -1,0 +1,20 @@
+obs space:
+  name: mls55_aura
+  obsdatain:
+    obsfile: $(cycle_dir)/mls55_aura.{{window_begin}}.nc4
+  obsdataout:
+    obsfile: $(cycle_dir)/$(experiment_id).mls55_aura.{{window_begin}}.nc4 
+  simulated variables: [mole_fraction_of_ozone_in_air]
+obs operator:
+  name: VertInterp
+  vertical coordinate: ["air_pressure"]
+  geovals: [mole_fraction_of_ozone_in_air]
+#obs filters:
+#  # range sanity check
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: mole_fraction_layer_ozone_in_air
+#    minvalue: 0
+#    maxvalue: 10000
+#    action:
+#      name: reject


### PR DESCRIPTION
Adding mls55_aura.yaml , which adds the ozone level instrument microwave limb sounder on aura satellite. Includes a sanity check (<10000), and gross check following the GEOS-FP GSI configuration with a threshold of 5.0*sigma_o.
