### PR TITLE
Generation of modules-csh out of order

### DIFF
--- a/src/swell/deployment/bin/swell_create_experiment.py
+++ b/src/swell/deployment/bin/swell_create_experiment.py
@@ -109,10 +109,6 @@ def main(config, clean):
     # ---------------------------------------
     set_swell_path_in_modules(logger, experiment_dict)
 
-    # Create csh modules file for csh users to use when debugging
-    # -----------------------------------------------------------
-    create_modules_csh(logger, experiment_dict)
-
     # Clone the git repos needed for the yaml file explosion
     # ------------------------------------------------------
     # User chosen clones
@@ -173,6 +169,10 @@ def main(config, clean):
 
     with open(r2d2_conf_path, 'w') as r2d2_file_open:
         r2d2_file_open.write(r2d2_file_str)
+
+    # Create csh modules file for csh users to use when debugging
+    # -----------------------------------------------------------
+    create_modules_csh(logger, experiment_dict)
 
     # Write out launch command for convenience
     # ----------------------------------------


### PR DESCRIPTION
## Description

The csh modules file doesn't include the R2D2 config part. This change has no impact since the modules files is only used in an offline sense by csh users. A quick visual review of the code should suffice.