### PR TITLE
add omps-nm and add coeff fix for o3 total column sensors.

### DIFF
--- a/src/swell/configuration/observation_operators/omi_aura.yaml
+++ b/src/swell/configuration/observation_operators/omi_aura.yaml
@@ -43,7 +43,7 @@ obs filters:
   minvalue: 3
   maxvalue: 24
   action:
-    name: reject     
+    name: reject
 
  # Gross check
 - filter: Background Check
@@ -52,4 +52,3 @@ obs filters:
   threshold: 5.0
   action:
     name: reject
-

--- a/src/swell/configuration/observation_operators/ompsnm_npp.yaml
+++ b/src/swell/configuration/observation_operators/ompsnm_npp.yaml
@@ -1,9 +1,9 @@
 obs space:
-  name: omi_aura
+  name: ompsnm_npp
   obsdatain:
-    obsfile: $(cycle_dir)/omi_aura.{{window_begin}}.nc4
+    obsfile: $(cycle_dir)/ompsnm_npp.{{window_begin}}.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).omi_aura.{{window_begin}}.nc4
+    obsfile: $(cycle_dir)/$(experiment_id).ompsnm_npp.{{window_begin}}.nc4
   simulated variables: [integrated_layer_ozone_in_air]
 obs operator:
   name: AtmVertInterpLay
@@ -34,22 +34,10 @@ obs filters:
   maxvalue: 84.
   action:
     name: reject
-# Reject rows 25+ (somewhat stringent but thats what we do in GEOS)
-- filter: Bounds Check
-  filter variables:
-  - name: integrated_layer_ozone_in_air
-  test variables:
-  - name: scan_position@MetaData
-  minvalue: 3
-  maxvalue: 24
-  action:
-    name: reject     
-
- # Gross check
+# Gross check
 - filter: Background Check
   filter variables:
   - name: integrated_layer_ozone_in_air
   threshold: 5.0
   action:
-    name: reject
-
+    name: reject  

--- a/src/swell/configuration/observation_operators/ompsnm_npp.yaml
+++ b/src/swell/configuration/observation_operators/ompsnm_npp.yaml
@@ -40,4 +40,4 @@ obs filters:
   - name: integrated_layer_ozone_in_air
   threshold: 5.0
   action:
-    name: reject  
+    name: reject


### PR DESCRIPTION
## Description
As discussed in Issue #93 and Issue #71, this replaces the `coefficients` value in the yaml to produce the correct result. Also, this duplicates the QC done in the GSI.  

## Dependencies
None

## Impact
Swell