### PR TITLE
Feature/refactor yaml

### DIFF
--- a/src/swell/configuration/observation_operators/aircraft.yaml
+++ b/src/swell/configuration/observation_operators/aircraft.yaml
@@ -6,7 +6,7 @@ obs space:
     engine:
       type: H5File
       obsfile: $(cycle_dir)/aircraft.window_begin.nc4
-      obsgrouping:
+    obsgrouping:
       group variables: ["station_id"]
       sort variable: "air_pressure"
       sort order: "descending"

--- a/src/swell/configuration/observation_operators/aircraft.yaml
+++ b/src/swell/configuration/observation_operators/aircraft.yaml
@@ -3,13 +3,17 @@ obs operator:
 obs space:
   name: Aircraft
   obsdatain:
-    obsfile: $(cycle_dir)/aircraft.{{window_begin}}.nc4
-    obsgrouping:
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/aircraft.window_begin.nc4
+      obsgrouping:
       group variables: ["station_id"]
       sort variable: "air_pressure"
       sort order: "descending"
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).aircraft.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).aircraft.window_begin.nc4
   simulated variables: [eastward_wind, northward_wind, air_temperature]
 obs filters:
 #--------------------------------------------------------------------------------------------------------------------

--- a/src/swell/configuration/observation_operators/aircraft.yaml
+++ b/src/swell/configuration/observation_operators/aircraft.yaml
@@ -5,7 +5,7 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/aircraft.window_begin.nc4
+      obsfile: $(cycle_dir)/aircraft.{{window_begin}}.nc4
     obsgrouping:
       group variables: ["station_id"]
       sort variable: "air_pressure"
@@ -13,7 +13,7 @@ obs space:
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).aircraft.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).aircraft.{{window_begin}}.nc4
   simulated variables: [eastward_wind, northward_wind, air_temperature]
 obs filters:
 #--------------------------------------------------------------------------------------------------------------------

--- a/src/swell/configuration/observation_operators/airs_aqua.yaml
+++ b/src/swell/configuration/observation_operators/airs_aqua.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/airs_aqua.window_begin.nc4
+      obsfile: $(cycle_dir)/airs_aqua.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).airs_aqua.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).airs_aqua.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &airs_aqua_channels 1, 6, 7, 10, 11, 15, 16, 17, 20, 21, 22, 24,
             27, 28, 30, 36, 39, 40, 42, 51, 52, 54, 55, 56, 59, 62, 63, 68, 69, 71,

--- a/src/swell/configuration/observation_operators/airs_aqua.yaml
+++ b/src/swell/configuration/observation_operators/airs_aqua.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: airs_aqua
   obsdatain:
-    obsfile: $(cycle_dir)/airs_aqua.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/airs_aqua.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).airs_aqua.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).airs_aqua.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &airs_aqua_channels 1, 6, 7, 10, 11, 15, 16, 17, 20, 21, 22, 24,
             27, 28, 30, 36, 39, 40, 42, 51, 52, 54, 55, 56, 59, 62, 63, 68, 69, 71,

--- a/src/swell/configuration/observation_operators/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/observation_operators/amsr2_gcom-w1.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/amsr2_gcom-w1.window_begin.nc4
+      obsfile: $(cycle_dir)/amsr2_gcom-w1.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).amsr2_gcom-w1.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).amsr2_gcom-w1.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &amsr2_gcom-w1_channels 1-14
 obs operator:

--- a/src/swell/configuration/observation_operators/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/observation_operators/amsr2_gcom-w1.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: amsr2_gcom-w1
   obsdatain:
-    obsfile: $(cycle_dir)/amsr2_gcom-w1.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/amsr2_gcom-w1.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).amsr2_gcom-w1.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).amsr2_gcom-w1.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &amsr2_gcom-w1_channels 1-14
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_aqua.yaml
+++ b/src/swell/configuration/observation_operators/amsua_aqua.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: amsua_aqua
   obsdatain:
-    obsfile: $(cycle_dir)/amsua_aqua.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/amsua_aqua.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).amsua_aqua.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_aqua.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_aqua_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_aqua.yaml
+++ b/src/swell/configuration/observation_operators/amsua_aqua.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/amsua_aqua.window_begin.nc4
+      obsfile: $(cycle_dir)/amsua_aqua.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).amsua_aqua.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_aqua.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_aqua_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_metop-a.yaml
+++ b/src/swell/configuration/observation_operators/amsua_metop-a.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/amsua_metop-a.window_begin.nc4
+      obsfile: $(cycle_dir)/amsua_metop-a.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-a.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-a.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_metop-a_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_metop-a.yaml
+++ b/src/swell/configuration/observation_operators/amsua_metop-a.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: amsua_metop-a
   obsdatain:
-    obsfile: $(cycle_dir)/amsua_metop-a.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/amsua_metop-a.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-a.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-a.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_metop-a_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_metop-b.yaml
+++ b/src/swell/configuration/observation_operators/amsua_metop-b.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: amsua_metop-b
   obsdatain:
-    obsfile: $(cycle_dir)/amsua_metop-b.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/amsua_metop-b.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-b.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-b.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_metop-b_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_metop-b.yaml
+++ b/src/swell/configuration/observation_operators/amsua_metop-b.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/amsua_metop-b.window_begin.nc4
+      obsfile: $(cycle_dir)/amsua_metop-b.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-b.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-b.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_metop-b_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_metop-c.yaml
+++ b/src/swell/configuration/observation_operators/amsua_metop-c.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/amsua_metop-c.window_begin.nc4
+      obsfile: $(cycle_dir)/amsua_metop-c.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-c.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-c.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_metop-c_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_metop-c.yaml
+++ b/src/swell/configuration/observation_operators/amsua_metop-c.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: amsua_metop-c
   obsdatain:
-    obsfile: $(cycle_dir)/amsua_metop-c.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/amsua_metop-c.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-c.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_metop-c.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_metop-c_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_n15.yaml
+++ b/src/swell/configuration/observation_operators/amsua_n15.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/amsua_n15.window_begin.nc4
+      obsfile: $(cycle_dir)/amsua_n15.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).amsua_n15.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_n15.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_n15_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_n15.yaml
+++ b/src/swell/configuration/observation_operators/amsua_n15.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: amsua_n15
   obsdatain:
-    obsfile: $(cycle_dir)/amsua_n15.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/amsua_n15.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).amsua_n15.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_n15.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_n15_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_n18.yaml
+++ b/src/swell/configuration/observation_operators/amsua_n18.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/amsua_n18.window_begin.nc4
+      obsfile: $(cycle_dir)/amsua_n18.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).amsua_n18.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_n18.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_n18_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_n18.yaml
+++ b/src/swell/configuration/observation_operators/amsua_n18.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: amsua_n18
   obsdatain:
-    obsfile: $(cycle_dir)/amsua_n18.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/amsua_n18.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).amsua_n18.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_n18.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_n18_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_n19.yaml
+++ b/src/swell/configuration/observation_operators/amsua_n19.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/amsua_n19.window_begin.nc4
+      obsfile: $(cycle_dir)/amsua_n19.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).amsua_n19.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_n19.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_n19_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/amsua_n19.yaml
+++ b/src/swell/configuration/observation_operators/amsua_n19.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: amsua_n19
   obsdatain:
-    obsfile: $(cycle_dir)/amsua_n19.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/amsua_n19.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).amsua_n19.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).amsua_n19.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_n19_channels 1-15
 obs operator:

--- a/src/swell/configuration/observation_operators/atms_n20.yaml
+++ b/src/swell/configuration/observation_operators/atms_n20.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: atms_n20
   obsdatain:
-    obsfile: $(cycle_dir)/atms_n20.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/atms_n20.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).atms_n20.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).atms_n20.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &atms_n20_channels 1-22
 obs operator:

--- a/src/swell/configuration/observation_operators/atms_n20.yaml
+++ b/src/swell/configuration/observation_operators/atms_n20.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/atms_n20.window_begin.nc4
+      obsfile: $(cycle_dir)/atms_n20.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).atms_n20.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).atms_n20.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &atms_n20_channels 1-22
 obs operator:

--- a/src/swell/configuration/observation_operators/atms_npp.yaml
+++ b/src/swell/configuration/observation_operators/atms_npp.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: atms_npp
   obsdatain:
-    obsfile: $(cycle_dir)/atms_npp.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/atms_npp.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).atms_npp.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).atms_npp.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &atms_npp_channels 1-22
 obs operator:

--- a/src/swell/configuration/observation_operators/atms_npp.yaml
+++ b/src/swell/configuration/observation_operators/atms_npp.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/atms_npp.window_begin.nc4
+      obsfile: $(cycle_dir)/atms_npp.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).atms_npp.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).atms_npp.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &atms_npp_channels 1-22
 obs operator:

--- a/src/swell/configuration/observation_operators/avhrr3_metop-a.yaml
+++ b/src/swell/configuration/observation_operators/avhrr3_metop-a.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/avhrr3_metop-a.window_begin.nc4
+      obsfile: $(cycle_dir)/avhrr3_metop-a.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).avhrr3_metop-a.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).avhrr3_metop-a.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &avhrr3_metop-a_channels 3,4,5
 obs operator:

--- a/src/swell/configuration/observation_operators/avhrr3_metop-a.yaml
+++ b/src/swell/configuration/observation_operators/avhrr3_metop-a.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: avhrr3_metop-a
   obsdatain:
-    obsfile: $(cycle_dir)/avhrr3_metop-a.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/avhrr3_metop-a.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).avhrr3_metop-a.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).avhrr3_metop-a.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &avhrr3_metop-a_channels 3,4,5
 obs operator:

--- a/src/swell/configuration/observation_operators/avhrr3_n18.yaml
+++ b/src/swell/configuration/observation_operators/avhrr3_n18.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/avhrr3_n18.window_begin.nc4
+      obsfile: $(cycle_dir)/avhrr3_n18.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).avhrr3_n18.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).avhrr3_n18.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &avhrr3_n18_channels 3,4,5
 obs operator:

--- a/src/swell/configuration/observation_operators/avhrr3_n18.yaml
+++ b/src/swell/configuration/observation_operators/avhrr3_n18.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: avhrr3_n18
   obsdatain:
-    obsfile: $(cycle_dir)/avhrr3_n18.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/avhrr3_n18.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).avhrr3_n18.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).avhrr3_n18.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &avhrr3_n18_channels 3,4,5
 obs operator:

--- a/src/swell/configuration/observation_operators/cris-fsr_n20.yaml
+++ b/src/swell/configuration/observation_operators/cris-fsr_n20.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: cris-fsr_n20
   obsdatain:
-    obsfile: $(cycle_dir)/cris-fsr_n20.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/cris-fsr_n20.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).cris-fsr_n20.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).cris-fsr_n20.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &cris-fsr_n20_channels 19, 24, 26, 27, 28, 31, 32, 33, 37, 39, 42, 44, 47, 49, 50,
             51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,

--- a/src/swell/configuration/observation_operators/cris-fsr_n20.yaml
+++ b/src/swell/configuration/observation_operators/cris-fsr_n20.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/cris-fsr_n20.window_begin.nc4
+      obsfile: $(cycle_dir)/cris-fsr_n20.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).cris-fsr_n20.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).cris-fsr_n20.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &cris-fsr_n20_channels 19, 24, 26, 27, 28, 31, 32, 33, 37, 39, 42, 44, 47, 49, 50,
             51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,

--- a/src/swell/configuration/observation_operators/cris-fsr_npp.yaml
+++ b/src/swell/configuration/observation_operators/cris-fsr_npp.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/cris-fsr_npp.window_begin.nc4
+      obsfile: $(cycle_dir)/cris-fsr_npp.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).cris-fsr_npp.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).cris-fsr_npp.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &cris-fsr_npp_channels 19, 24, 26, 27, 28, 31, 32, 33, 37, 39, 42, 44, 47, 49, 50,
             51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,

--- a/src/swell/configuration/observation_operators/cris-fsr_npp.yaml
+++ b/src/swell/configuration/observation_operators/cris-fsr_npp.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: cris-fsr_npp
   obsdatain:
-    obsfile: $(cycle_dir)/cris-fsr_npp.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/cris-fsr_npp.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).cris-fsr_npp.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).cris-fsr_npp.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &cris-fsr_npp_channels 19, 24, 26, 27, 28, 31, 32, 33, 37, 39, 42, 44, 47, 49, 50,
             51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,

--- a/src/swell/configuration/observation_operators/gmi_gpm.yaml
+++ b/src/swell/configuration/observation_operators/gmi_gpm.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: gmi_gpm
   obsdatain:
-    obsfile: $(cycle_dir)/gmi_gpm.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/gmi_gpm.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).gmi_gpm.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).gmi_gpm.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &gmi_gpm_channels 1-13
 obs operator:

--- a/src/swell/configuration/observation_operators/gmi_gpm.yaml
+++ b/src/swell/configuration/observation_operators/gmi_gpm.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/gmi_gpm.window_begin.nc4
+      obsfile: $(cycle_dir)/gmi_gpm.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).gmi_gpm.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).gmi_gpm.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &gmi_gpm_channels 1-13
 obs operator:

--- a/src/swell/configuration/observation_operators/gnssrobndnbam.yaml
+++ b/src/swell/configuration/observation_operators/gnssrobndnbam.yaml
@@ -4,7 +4,7 @@ obs space:
     engine:
       type: H5File
       obsfile: $(cycle_dir)/gnssrobndnbam.window_begin.nc4
-      obsgrouping:
+    obsgrouping:
       group variables: [ 'record_number' ]
       sort variable: 'impact_height'
       sort order: 'ascending'

--- a/src/swell/configuration/observation_operators/gnssrobndnbam.yaml
+++ b/src/swell/configuration/observation_operators/gnssrobndnbam.yaml
@@ -1,13 +1,17 @@
 obs space:
   name: gnssrobndnbam
   obsdatain:
-    obsfile: $(cycle_dir)/gnssrobndnbam.{{window_begin}}.nc4
-    obsgrouping:
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/gnssrobndnbam.window_begin.nc4
+      obsgrouping:
       group variables: [ 'record_number' ]
       sort variable: 'impact_height'
       sort order: 'ascending'
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).gnssrobndnbam.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).gnssrobndnbam.window_begin.nc4
   simulated variables: [bending_angle]
 obs operator:
   name: GnssroBndNBAM

--- a/src/swell/configuration/observation_operators/gnssrobndnbam.yaml
+++ b/src/swell/configuration/observation_operators/gnssrobndnbam.yaml
@@ -3,7 +3,7 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/gnssrobndnbam.window_begin.nc4
+      obsfile: $(cycle_dir)/gnssrobndnbam.{{window_begin}}.nc4
     obsgrouping:
       group variables: [ 'record_number' ]
       sort variable: 'impact_height'
@@ -11,7 +11,7 @@ obs space:
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).gnssrobndnbam.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).gnssrobndnbam.{{window_begin}}.nc4
   simulated variables: [bending_angle]
 obs operator:
   name: GnssroBndNBAM

--- a/src/swell/configuration/observation_operators/iasi_metop-a.yaml
+++ b/src/swell/configuration/observation_operators/iasi_metop-a.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/iasi_metop-a.window_begin.nc4
+      obsfile: $(cycle_dir)/iasi_metop-a.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).iasi_metop-a.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).iasi_metop-a.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &iasi_metop-a_channels 16, 29, 32, 35, 38, 41, 44, 47, 49, 50, 51, 53,
             55, 56, 57, 59, 61, 62, 63, 66, 68, 70, 72, 74, 76, 78, 79, 81, 82, 83,

--- a/src/swell/configuration/observation_operators/iasi_metop-a.yaml
+++ b/src/swell/configuration/observation_operators/iasi_metop-a.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: iasi_metop-a
   obsdatain:
-    obsfile: $(cycle_dir)/iasi_metop-a.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/iasi_metop-a.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).iasi_metop-a.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).iasi_metop-a.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &iasi_metop-a_channels 16, 29, 32, 35, 38, 41, 44, 47, 49, 50, 51, 53,
             55, 56, 57, 59, 61, 62, 63, 66, 68, 70, 72, 74, 76, 78, 79, 81, 82, 83,

--- a/src/swell/configuration/observation_operators/iasi_metop-b.yaml
+++ b/src/swell/configuration/observation_operators/iasi_metop-b.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/iasi_metop-b.window_begin.nc4
+      obsfile: $(cycle_dir)/iasi_metop-b.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).iasi_metop-b.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).iasi_metop-b.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &iasi_metop-b_channels 16, 29, 32, 35, 38, 41, 44, 47, 49, 50, 51, 53,
             55, 56, 57, 59, 61, 62, 63, 66, 68, 70, 72, 74, 76, 78, 79, 81, 82, 83,

--- a/src/swell/configuration/observation_operators/iasi_metop-b.yaml
+++ b/src/swell/configuration/observation_operators/iasi_metop-b.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: iasi_metop-b
   obsdatain:
-    obsfile: $(cycle_dir)/iasi_metop-b.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/iasi_metop-b.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).iasi_metop-b.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).iasi_metop-b.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &iasi_metop-b_channels 16, 29, 32, 35, 38, 41, 44, 47, 49, 50, 51, 53,
             55, 56, 57, 59, 61, 62, 63, 66, 68, 70, 72, 74, 76, 78, 79, 81, 82, 83,

--- a/src/swell/configuration/observation_operators/mhs_metop-b.yaml
+++ b/src/swell/configuration/observation_operators/mhs_metop-b.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/mhs_metop-b.window_begin.nc4
+      obsfile: $(cycle_dir)/mhs_metop-b.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).mhs_metop-b.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).mhs_metop-b.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &mhs_metop-b_channels 1-5
 obs operator:

--- a/src/swell/configuration/observation_operators/mhs_metop-b.yaml
+++ b/src/swell/configuration/observation_operators/mhs_metop-b.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: mhs_metop-b
   obsdatain:
-    obsfile: $(cycle_dir)/mhs_metop-b.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/mhs_metop-b.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).mhs_metop-b.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).mhs_metop-b.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &mhs_metop-b_channels 1-5
 obs operator:

--- a/src/swell/configuration/observation_operators/mhs_metop-c.yaml
+++ b/src/swell/configuration/observation_operators/mhs_metop-c.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: mhs_metop-c
   obsdatain:
-    obsfile: $(cycle_dir)/mhs_metop-c.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/mhs_metop-c.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).mhs_metop-c.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).mhs_metop-c.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &mhs_metop-c_channels 1-5
 obs operator:

--- a/src/swell/configuration/observation_operators/mhs_metop-c.yaml
+++ b/src/swell/configuration/observation_operators/mhs_metop-c.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/mhs_metop-c.window_begin.nc4
+      obsfile: $(cycle_dir)/mhs_metop-c.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).mhs_metop-c.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).mhs_metop-c.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &mhs_metop-c_channels 1-5
 obs operator:

--- a/src/swell/configuration/observation_operators/mhs_n19.yaml
+++ b/src/swell/configuration/observation_operators/mhs_n19.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: mhs_n19
   obsdatain:
-    obsfile: $(cycle_dir)/mhs_n19.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/mhs_n19.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).mhs_n19.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).mhs_n19.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: 1-5
 obs operator:

--- a/src/swell/configuration/observation_operators/mhs_n19.yaml
+++ b/src/swell/configuration/observation_operators/mhs_n19.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/mhs_n19.window_begin.nc4
+      obsfile: $(cycle_dir)/mhs_n19.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).mhs_n19.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).mhs_n19.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: 1-5
 obs operator:

--- a/src/swell/configuration/observation_operators/mls55_aura.yaml
+++ b/src/swell/configuration/observation_operators/mls55_aura.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: mls55_aura
   obsdatain:
-    obsfile: $(cycle_dir)/mls55_aura.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/mls55_aura.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).mls55_aura.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).mls55_aura.window_begin.nc4
   simulated variables: [mole_fraction_of_ozone_in_air]
 obs operator:
   name: VertInterp

--- a/src/swell/configuration/observation_operators/mls55_aura.yaml
+++ b/src/swell/configuration/observation_operators/mls55_aura.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/mls55_aura.window_begin.nc4
+      obsfile: $(cycle_dir)/mls55_aura.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).mls55_aura.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).mls55_aura.{{window_begin}}.nc4
   simulated variables: [mole_fraction_of_ozone_in_air]
 obs operator:
   name: VertInterp

--- a/src/swell/configuration/observation_operators/omi_aura.yaml
+++ b/src/swell/configuration/observation_operators/omi_aura.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: omi_aura
   obsdatain:
-    obsfile: $(cycle_dir)/omi_aura.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/omi_aura.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).omi_aura.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).omi_aura.window_begin.nc4
   simulated variables: [integrated_layer_ozone_in_air]
 obs operator:
   name: AtmVertInterpLay

--- a/src/swell/configuration/observation_operators/omi_aura.yaml
+++ b/src/swell/configuration/observation_operators/omi_aura.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/omi_aura.window_begin.nc4
+      obsfile: $(cycle_dir)/omi_aura.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).omi_aura.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).omi_aura.{{window_begin}}.nc4
   simulated variables: [integrated_layer_ozone_in_air]
 obs operator:
   name: AtmVertInterpLay

--- a/src/swell/configuration/observation_operators/ompslpnc_npp.yaml
+++ b/src/swell/configuration/observation_operators/ompslpnc_npp.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: ompslpnc_npp
   obsdatain:
-    obsfile: $(cycle_dir)/ompslpnc_npp.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/ompslpnc_npp.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).ompslpnc_npp.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).ompslpnc_npp.window_begin.nc4
   simulated variables: [mole_fraction_of_ozone_in_air]
 obs operator:
   name: VertInterp

--- a/src/swell/configuration/observation_operators/ompslpnc_npp.yaml
+++ b/src/swell/configuration/observation_operators/ompslpnc_npp.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/ompslpnc_npp.window_begin.nc4
+      obsfile: $(cycle_dir)/ompslpnc_npp.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).ompslpnc_npp.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).ompslpnc_npp.{{window_begin}}.nc4
   simulated variables: [mole_fraction_of_ozone_in_air]
 obs operator:
   name: VertInterp

--- a/src/swell/configuration/observation_operators/ompsnm_npp.yaml
+++ b/src/swell/configuration/observation_operators/ompsnm_npp.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: ompsnm_npp
   obsdatain:
-    obsfile: $(cycle_dir)/ompsnm_npp.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/ompsnm_npp.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).ompsnm_npp.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).ompsnm_npp.window_begin.nc4
   simulated variables: [integrated_layer_ozone_in_air]
 obs operator:
   name: AtmVertInterpLay

--- a/src/swell/configuration/observation_operators/ompsnm_npp.yaml
+++ b/src/swell/configuration/observation_operators/ompsnm_npp.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/ompsnm_npp.window_begin.nc4
+      obsfile: $(cycle_dir)/ompsnm_npp.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).ompsnm_npp.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).ompsnm_npp.{{window_begin}}.nc4
   simulated variables: [integrated_layer_ozone_in_air]
 obs operator:
   name: AtmVertInterpLay

--- a/src/swell/configuration/observation_operators/rass_tv.yaml
+++ b/src/swell/configuration/observation_operators/rass_tv.yaml
@@ -5,9 +5,9 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/rass_tv.window_begin.nc4
+      obsfile: $(cycle_dir)/rass_tv.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).rass_tv.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).rass_tv.{{window_begin}}.nc4
   simulated variables: [virtual_temperature]

--- a/src/swell/configuration/observation_operators/rass_tv.yaml
+++ b/src/swell/configuration/observation_operators/rass_tv.yaml
@@ -3,7 +3,11 @@ obs operator:
 obs space:
   name: rass_tv
   obsdatain:
-    obsfile: $(cycle_dir)/rass_tv.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/rass_tv.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).rass_tv.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).rass_tv.window_begin.nc4
   simulated variables: [virtual_temperature]

--- a/src/swell/configuration/observation_operators/satwind.yaml
+++ b/src/swell/configuration/observation_operators/satwind.yaml
@@ -5,11 +5,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/satwind.window_begin.nc4
+      obsfile: $(cycle_dir)/satwind.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).satwind.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).satwind.{{window_begin}}.nc4
   simulated variables: [eastward_wind, northward_wind]
 obs filters:
 #

--- a/src/swell/configuration/observation_operators/satwind.yaml
+++ b/src/swell/configuration/observation_operators/satwind.yaml
@@ -3,9 +3,13 @@ obs operator:
 obs space:
   name: satwind
   obsdatain:
-    obsfile: $(cycle_dir)/satwind.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/satwind.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).satwind.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).satwind.window_begin.nc4
   simulated variables: [eastward_wind, northward_wind]
 obs filters:
 #

--- a/src/swell/configuration/observation_operators/scatwind.yaml
+++ b/src/swell/configuration/observation_operators/scatwind.yaml
@@ -5,11 +5,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/scatwind.window_begin.nc4
+      obsfile: $(cycle_dir)/scatwind.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).scatwind.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).scatwind.{{window_begin}}.nc4
   simulated variables: [eastward_wind, northward_wind]
 obs filters:
 # Reject all obs with PreQC mark already set above 3

--- a/src/swell/configuration/observation_operators/scatwind.yaml
+++ b/src/swell/configuration/observation_operators/scatwind.yaml
@@ -3,9 +3,13 @@ obs operator:
 obs space:
   name: scatwind
   obsdatain:
-    obsfile: $(cycle_dir)/scatwind.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/scatwind.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).scatwind.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).scatwind.window_begin.nc4
   simulated variables: [eastward_wind, northward_wind]
 obs filters:
 # Reject all obs with PreQC mark already set above 3

--- a/src/swell/configuration/observation_operators/seviri_m11.yaml
+++ b/src/swell/configuration/observation_operators/seviri_m11.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: seviri_m11
   obsdatain:
-    obsfile: $(cycle_dir)/seviri_m11.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/seviri_m11.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).seviri_m11.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).seviri_m11.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &seviri_m11_channels 4-11
 obs operator:

--- a/src/swell/configuration/observation_operators/seviri_m11.yaml
+++ b/src/swell/configuration/observation_operators/seviri_m11.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/seviri_m11.window_begin.nc4
+      obsfile: $(cycle_dir)/seviri_m11.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).seviri_m11.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).seviri_m11.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &seviri_m11_channels 4-11
 obs operator:

--- a/src/swell/configuration/observation_operators/sfc.yaml
+++ b/src/swell/configuration/observation_operators/sfc.yaml
@@ -8,11 +8,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/sfc.window_begin.nc4
+      obsfile: $(cycle_dir)/sfc.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).sfc.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).sfc.{{window_begin}}.nc4
   simulated variables: [surface_pressure] #, air_temperature]
 obs filters:
 # Observation Range Sanity Check

--- a/src/swell/configuration/observation_operators/sfc.yaml
+++ b/src/swell/configuration/observation_operators/sfc.yaml
@@ -6,9 +6,13 @@ obs operator:
 obs space:
   name: sfc
   obsdatain:
-    obsfile: $(cycle_dir)/sfc.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/sfc.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).sfc.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).sfc.window_begin.nc4
   simulated variables: [surface_pressure] #, air_temperature]
 obs filters:
 # Observation Range Sanity Check

--- a/src/swell/configuration/observation_operators/sfcship.yaml
+++ b/src/swell/configuration/observation_operators/sfcship.yaml
@@ -6,11 +6,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/sfcship.window_begin.nc4
+      obsfile: $(cycle_dir)/sfcship.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).sfcship.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).sfcship.{{window_begin}}.nc4
   simulated variables: [surface_pressure] #, air_temperature, specific_humidity]
 obs filters:
 # Observation Range Sanity Check

--- a/src/swell/configuration/observation_operators/sfcship.yaml
+++ b/src/swell/configuration/observation_operators/sfcship.yaml
@@ -4,9 +4,13 @@ obs operator:
 obs space:
   name: sfcship
   obsdatain:
-    obsfile: $(cycle_dir)/sfcship.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/sfcship.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).sfcship.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).sfcship.window_begin.nc4
   simulated variables: [surface_pressure] #, air_temperature, specific_humidity]
 obs filters:
 # Observation Range Sanity Check

--- a/src/swell/configuration/observation_operators/sondes.yaml
+++ b/src/swell/configuration/observation_operators/sondes.yaml
@@ -1,13 +1,17 @@
 obs space:
   name: sondes
   obsdatain:
-    obsfile: $(cycle_dir)/sondes.{{window_begin}}.nc4
-    obsgrouping:
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/sondes.window_begin.nc4
+      obsgrouping:
       group variables: ["station_id", "LaunchTime"]
       sort variable: "air_pressure"
       sort order: "descending"
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).sondes.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).sondes.window_begin.nc4
   simulated variables: [air_temperature, specific_humidity, eastward_wind, northward_wind, surface_pressure]
 obs operator:
   name: Composite

--- a/src/swell/configuration/observation_operators/sondes.yaml
+++ b/src/swell/configuration/observation_operators/sondes.yaml
@@ -4,7 +4,7 @@ obs space:
     engine:
       type: H5File
       obsfile: $(cycle_dir)/sondes.window_begin.nc4
-      obsgrouping:
+    obsgrouping:
       group variables: ["station_id", "LaunchTime"]
       sort variable: "air_pressure"
       sort order: "descending"

--- a/src/swell/configuration/observation_operators/sondes.yaml
+++ b/src/swell/configuration/observation_operators/sondes.yaml
@@ -3,7 +3,7 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/sondes.window_begin.nc4
+      obsfile: $(cycle_dir)/sondes.{{window_begin}}.nc4
     obsgrouping:
       group variables: ["station_id", "LaunchTime"]
       sort variable: "air_pressure"
@@ -11,7 +11,7 @@ obs space:
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).sondes.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).sondes.{{window_begin}}.nc4
   simulated variables: [air_temperature, specific_humidity, eastward_wind, northward_wind, surface_pressure]
 obs operator:
   name: Composite

--- a/src/swell/configuration/observation_operators/ssmis_f17.yaml
+++ b/src/swell/configuration/observation_operators/ssmis_f17.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/ssmis_f17.window_begin.nc4
+      obsfile: $(cycle_dir)/ssmis_f17.{{window_begin}}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).ssmis_f17.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).ssmis_f17.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &ssmis_f17_channels 1-24
 obs operator:

--- a/src/swell/configuration/observation_operators/ssmis_f17.yaml
+++ b/src/swell/configuration/observation_operators/ssmis_f17.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: ssmis_f17
   obsdatain:
-    obsfile: $(cycle_dir)/ssmis_f17.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/ssmis_f17.window_begin.nc4
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).ssmis_f17.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).ssmis_f17.window_begin.nc4
   simulated variables: [brightness_temperature]
   channels: &ssmis_f17_channels 1-24
 obs operator:

--- a/src/swell/configuration/observation_operators/vadwind.yaml
+++ b/src/swell/configuration/observation_operators/vadwind.yaml
@@ -5,7 +5,7 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/vadwind.window_begin.nc4
+      obsfile: $(cycle_dir)/vadwind.{{window_begin}}.nc4
     obsgrouping:
       group variables: ["station_id", "datetime"]
       sort variable: "air_pressure"
@@ -13,7 +13,7 @@ obs space:
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(cycle_dir)/$(experiment_id).vadwind.window_begin.nc4
+      obsfile: $(cycle_dir)/$(experiment_id).vadwind.{{window_begin}}.nc4
   simulated variables: [eastward_wind, northward_wind]
 #--------------------------------------------------------------------------------------------------------------------
 obs filters:

--- a/src/swell/configuration/observation_operators/vadwind.yaml
+++ b/src/swell/configuration/observation_operators/vadwind.yaml
@@ -6,7 +6,7 @@ obs space:
     engine:
       type: H5File
       obsfile: $(cycle_dir)/vadwind.window_begin.nc4
-      obsgrouping:
+    obsgrouping:
       group variables: ["station_id", "datetime"]
       sort variable: "air_pressure"
       sort order: "descending"

--- a/src/swell/configuration/observation_operators/vadwind.yaml
+++ b/src/swell/configuration/observation_operators/vadwind.yaml
@@ -3,13 +3,17 @@ obs operator:
 obs space:
   name: vadwind
   obsdatain:
-    obsfile: $(cycle_dir)/vadwind.{{window_begin}}.nc4
-    obsgrouping:
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/vadwind.window_begin.nc4
+      obsgrouping:
       group variables: ["station_id", "datetime"]
       sort variable: "air_pressure"
       sort order: "descending"
   obsdataout:
-    obsfile: $(cycle_dir)/$(experiment_id).vadwind.{{window_begin}}.nc4
+    engine:
+      type: H5File
+      obsfile: $(cycle_dir)/$(experiment_id).vadwind.window_begin.nc4
   simulated variables: [eastward_wind, northward_wind]
 #--------------------------------------------------------------------------------------------------------------------
 obs filters:

--- a/src/swell/deployment/platforms/nccs_discover/modules
+++ b/src/swell/deployment/platforms/nccs_discover/modules
@@ -20,8 +20,8 @@ module load jedi-fv3-env/1.0.0
 module load nco/5.0.6
 module load sp/2.3.3
 
-module use -a /discover/nobackup/drholdaw/JediSwell/bundle/modulefiles/compiler/intel/2022.0.1/
-module load jedi-swell/1.0.7
+module use -a /discover/nobackup/jardizzo/CI/swell/nightly/modulefiles
+module load jedi-swell/latest
 
 # Load workflow modules
 # ---------------------

--- a/src/swell/suites/hofx/experiment.yaml
+++ b/src/swell/suites/hofx/experiment.yaml
@@ -54,7 +54,7 @@ processors:
   - 6
 
 build jedi:
-  existing build directory: /discover/nobackup/drholdaw/JediSwell/bundle/1.0.7/build-intel-release/
+  existing build directory: /discover/nobackup/jardizzo/CI/swell/nightly/latest/jedi_build/build-intel-release
   build options:
     - release    # release, debug, relwithdebug
   packages:

--- a/src/swell/tasks/eva_driver.py
+++ b/src/swell/tasks/eva_driver.py
@@ -44,7 +44,7 @@ class EvaDriver(taskBase):
         for observer in observers:
 
             # Split the full path into path and filename
-            obs_path_file = observer['obs space']['obsdataout']['obsfile']
+            obs_path_file = observer['obs space']['obsdataout']['engine']['obsfile']
             cycle_dir, obs_file = os.path.split(obs_path_file)
 
             # Get instrument ioda and full name

--- a/src/swell/tasks/get_observations.py
+++ b/src/swell/tasks/get_observations.py
@@ -50,7 +50,7 @@ class GetObservations(taskBase):
             # Fetch observation files
             # -----------------------
             name = ob['obs space']['name']
-            target_file = ob['obs space']['obsdatain']['obsfile']
+            target_file = ob['obs space']['obsdatain']['engine']['obsfile']
             logger.info("Processing observation file "+target_file)
 
             fetch(date=window_begin,

--- a/src/swell/tasks/jedi_config.py
+++ b/src/swell/tasks/jedi_config.py
@@ -171,7 +171,7 @@ class JediConfig(taskBase):
 
             for ob in obs:
                 # Extract normal output filename
-                cycle_dir, obs_file = os.path.split(ob['obs space']['obsdataout']['obsfile'])
+                cycle_dir, obs_file = os.path.split(ob['obs space']['obsdataout']['engine']['obsfile'])
                 # Append instrument name with geovals
                 instrument = find_instrument_from_string(obs_file, self.logger)
                 geovals_file = obs_file.replace(instrument, instrument+'.geovals')

--- a/src/swell/tasks/jedi_config.py
+++ b/src/swell/tasks/jedi_config.py
@@ -171,7 +171,8 @@ class JediConfig(taskBase):
 
             for ob in obs:
                 # Extract normal output filename
-                cycle_dir, obs_file = os.path.split(ob['obs space']['obsdataout']['engine']['obsfile'])
+                cycle_dir, obs_file = os.path.split(
+                    ob['obs space']['obsdataout']['engine']['obsfile'])
                 # Append instrument name with geovals
                 instrument = find_instrument_from_string(obs_file, self.logger)
                 geovals_file = obs_file.replace(instrument, instrument+'.geovals')

--- a/src/swell/tasks/merge_ioda_files.py
+++ b/src/swell/tasks/merge_ioda_files.py
@@ -59,7 +59,7 @@ class MergeIodaFiles(taskBase):
             data_to_write = False
 
             # Split the full obs output path into path and filename
-            cycle_dir, obs_file = os.path.split(observer['obs space']['obsdataout']['obsfile'])
+            cycle_dir, obs_file = os.path.split(observer['obs space']['obsdataout']['engine']['obsfile'])
 
             # Read in the observation output files if the pool is larger than 1
             # -----------------------------------------------------------------

--- a/src/swell/tasks/merge_ioda_files.py
+++ b/src/swell/tasks/merge_ioda_files.py
@@ -59,7 +59,8 @@ class MergeIodaFiles(taskBase):
             data_to_write = False
 
             # Split the full obs output path into path and filename
-            cycle_dir, obs_file = os.path.split(observer['obs space']['obsdataout']['engine']['obsfile'])
+            cycle_dir, obs_file = os.path.split(
+                observer['obs space']['obsdataout']['engine']['obsfile'])
 
             # Read in the observation output files if the pool is larger than 1
             # -----------------------------------------------------------------

--- a/src/swell/tasks/save_obs_diags.py
+++ b/src/swell/tasks/save_obs_diags.py
@@ -39,7 +39,7 @@ class SaveObsDiags(taskBase):
             # Store observation files
             # -----------------------
             name = ob['obs space']['name']
-            source_file = ob['obs space']['obsdataout']['obsfile']
+            source_file = ob['obs space']['obsdataout']['engine']['obsfile']
 
             store(date=window_begin,
                   provider='ncdiag',


### PR DESCRIPTION
## Description

This PR has updated YAML files consistent with the following description:

Replace ObsIo class and parameters structures with new Reader and Writer parameters and class structures
https://github.com/JCSDA-internal/ioda/pull/776

A supplied refactoring utility (refactor-yaml.py) was applied to the YAML files under configuration/observation_operators. However, it did not properly handle the "obsgrouping" parameter block. The following files were manually corrected:

gnssrobndnbam.yaml
aircraft.yaml
vadwind.yaml
sondes.yaml

Additional codes were modified to reference the obsfile parameter with a new qualified YAML path that includes the "engine" path node: 

swell/tasks/eva_driver.py:            obs_path_file = observer['obs space']['obsdataout']['engine']['obsfile']
swell/tasks/jedi_config.py:                cycle_dir, obs_file = os.path.split(ob['obs space']['obsdataout']['engine']['obsfile'])
swell/tasks/save_obs_diags.py:            source_file = ob['obs space']['obsdataout']['engine']['obsfile']
swell/tasks/merge_ioda_files.py:            cycle_dir, obs_file = os.path.split(observer['obs space']['obsdataout']['engine']['obsfile'])
swell/tasks/get_observations.py:            target_file = ob['obs space']['obsdatain']['engine']['obsfile']

## Dependencies

This PR cannot be merged without updating the default JEDI build used by encoded experiment files. For example:

suites/hofx/experiment.yaml:  existing build directory: /discover/nobackup/drholdaw/JediSwell/bundle/1.0.7/build-intel-release

Also, it is noted here that there is a coupled dependency for the JEDI build located in:

deployment/platforms/nccs_discover/modules:

module use -a /discover/nobackup/drholdaw/JediSwell/bundle/modulefiles/compiler/intel/2022.0.1/
module load jedi-swell/1.0.7

This load statement will conflict with any user-supplied build specified in the experiment.yaml file.

## Testing

This PR was tested using a modified version of the following use-case:

src/work/swell/src/swell/suites/hofx/experiment.yaml

The existing build was replaced with an updated JEDI build:

existing build directory: /discover/nobackup/jardizzo/CI/swell/nightly/latest/jedi_build/build-intel-release

Please note that you must remove the load statements mentioned above from the module files:

#module use -a /discover/nobackup/drholdaw/JediSwell/bundle/modulefiles/compiler/intel/2022.0.1/
#module load jedi-swell/1.0.7

Results of this test can be found on Discover:

/discover/nobackup/jardizzo/SwellExperiments/ci-6-swell-experiment/ci-6-swell-experiment-suite
/discover/nobackup/jardizzo/workflow/cylc-run/ci-6-swell-experiment-suite

Additional testing will be needed once the new default JEDI build is installed for the SWELL repo.

