### PR TITLE
Customize the bundles which get built in BuildJedi task

### DIFF
--- a/src/swell/deployment/bin/swell_create_experiment.py
+++ b/src/swell/deployment/bin/swell_create_experiment.py
@@ -45,7 +45,7 @@ def main(config):
     # Generate the configuration file
     # -------------------------------
     if config is None:
-        config_file = prepare_config('cli', 'hofx', 'nccs_discover', False)
+        config_file = prepare_config('cli', 'hofx', 'nccs_discover')
     else:
         config_file = config
 

--- a/src/swell/deployment/prep_config.py
+++ b/src/swell/deployment/prep_config.py
@@ -24,7 +24,7 @@ from swell.utilities.jinja2 import template_string_jinja2
 # --------------------------------------------------------------------------------------------------
 
 
-def prepare_config(method, suite, platform, override):
+def prepare_config(method, suite, platform, override=None):
 
     # Create a logger
     # ---------------

--- a/src/swell/suites/build_jedi/suites-build_jedi.yaml
+++ b/src/swell/suites/build_jedi/suites-build_jedi.yaml
@@ -22,3 +22,13 @@ existing_build_directory:
   depends:
     key: jedi_build_method
     value: use_existing
+
+# Bundles to build
+bundles:
+  default_value: ['fv3-jedi', 'soca', 'iodaconv']
+  prompt: List the bundles that you wish to build
+  type: string-check-list
+  options: use_method  # This method would ask jedi_bundle for the default bundles
+  depends:
+    key: jedi_build_method
+    value: create

--- a/src/swell/tasks/build_jedi.py
+++ b/src/swell/tasks/build_jedi.py
@@ -43,7 +43,6 @@ class BuildJedi(taskBase):
         if jedi_build_method == 'create':
 
             # Determine which bundles need to be build
-            bundles = get_bundles()
             model_components = self.config_get('model_components', None)
             if model_components is not None:
                 bundles = []
@@ -51,6 +50,9 @@ class BuildJedi(taskBase):
                     # Open the metadata config for interface
                     meta = self.open_jedi_interface_meta_config_file(model_component)
                     bundles.append(meta['jedi_interface'])
+            else:
+                bundles_default = get_bundles()
+                bundles = self.config_get('bundles', bundles_default)
 
             # Generate the build dictionary
             jedi_bundle_dict = set_jedi_bundle_config(bundles, jedi_bundle_source_path,

--- a/src/swell/tasks/clone_jedi.py
+++ b/src/swell/tasks/clone_jedi.py
@@ -51,7 +51,6 @@ class CloneJedi(taskBase):
         elif jedi_build_method == 'create':
 
             # Determine which bundles need to be build
-            bundles = get_bundles()
             model_components = self.config_get('model_components', None)
             if model_components is not None:
                 bundles = []
@@ -59,6 +58,9 @@ class CloneJedi(taskBase):
                     # Open the metadata config for interface
                     meta = self.open_jedi_interface_meta_config_file(model_component)
                     bundles.append(meta['jedi_interface'])
+            else:
+                bundles_default = get_bundles()
+                bundles = self.config_get('bundles', bundles_default)
 
             # Generate the build dictionary
             jedi_bundle_dict = set_jedi_bundle_config(bundles, jedi_bundle_source_path,


### PR DESCRIPTION
## Description

Instead of building all available bundles, let the user choose which bundles they want to build. Set the default in the sample suite to build fv3-jedi, soca and iodaconv, which are the only bundles that swell currently uses.

In a single test the build took 53 minutes of the 4 hours permitted.

`/home/drholdaw/cylc-run/swell-build_jedi-suite/run1/log/job/1/BuildJedi/01/job.out`

## Dependencies

N/A

## Impact

N/A
