### PR TITLE
Update discover_nightly.yml

### DIFF
--- a/.github/workflows/discover_nightly.yml
+++ b/.github/workflows/discover_nightly.yml
@@ -5,7 +5,7 @@ name: discover-nightly
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0,15,30,45 * * * *'
+    - cron:  '0 0 * * *'
 
 defaults:
   run:
@@ -13,4 +13,4 @@ defaults:
 
 jobs:
   run-discover-nightly:
-    uses: GEOS-ESM/CI-workflows/.github/workflows/swell-workflow01.yml@main
+    uses: GEOS-ESM/CI-workflows/.github/workflows/swell-discover-nightly.yml@main


### PR DESCRIPTION
The SWELL Nightly Workflow will now run at 00Z of each day.

## Description

This update schedules the SWELL Nightly CICD workflow to run every night at 00Z.
