### PR TITLE
Use skylake or cascade lake for the default nodes

### DIFF
--- a/src/swell/__init__.py
+++ b/src/swell/__init__.py
@@ -9,4 +9,4 @@ import os
 repo_directory = os.path.dirname(__file__)
 
 # Set the version for swell
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/src/swell/deployment/prep_suite.py
+++ b/src/swell/deployment/prep_suite.py
@@ -59,6 +59,7 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
     render_dictionary['scheduling']['BuildJedi']['qos'] = 'allnccs'
     render_dictionary['scheduling']['BuildJedi']['nodes'] = 1
     render_dictionary['scheduling']['BuildJedi']['ntasks_per_node'] = 24
+    render_dictionary['scheduling']['BuildJedi']['constraint'] = 'cas|sky'
 
     render_dictionary['scheduling']['BuildGeos'] = {}
     render_dictionary['scheduling']['BuildGeos']['execution_time_limit'] = 'PT1H'
@@ -66,6 +67,7 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
     render_dictionary['scheduling']['BuildGeos']['qos'] = 'allnccs'
     render_dictionary['scheduling']['BuildGeos']['nodes'] = 1
     render_dictionary['scheduling']['BuildGeos']['ntasks_per_node'] = 24
+    render_dictionary['scheduling']['BuildGeos']['constraint'] = 'cas|sky'
 
     render_dictionary['scheduling']['GenerateBClimatology'] = {}
     render_dictionary['scheduling']['GenerateBClimatology']['execution_time_limit'] = 'PT15M'
@@ -73,6 +75,7 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
     render_dictionary['scheduling']['GenerateBClimatology']['qos'] = 'allnccs'
     render_dictionary['scheduling']['GenerateBClimatology']['nodes'] = 1
     render_dictionary['scheduling']['GenerateBClimatology']['ntasks_per_node'] = 24
+    render_dictionary['scheduling']['GenerateBClimatology']['constraint'] = 'cas|sky'
 
     render_dictionary['scheduling']['RunJediHofxExecutable'] = {}
     render_dictionary['scheduling']['RunJediHofxExecutable']['execution_time_limit'] = 'PT2H'
@@ -80,6 +83,7 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
     render_dictionary['scheduling']['RunJediHofxExecutable']['qos'] = 'allnccs'
     render_dictionary['scheduling']['RunJediHofxExecutable']['nodes'] = 1
     render_dictionary['scheduling']['RunJediHofxExecutable']['ntasks_per_node'] = 24
+    render_dictionary['scheduling']['RunJediHofxExecutable']['constraint'] = 'cas|sky'
 
     render_dictionary['scheduling']['RunJediVariationalExecutable'] = {}
     render_dictionary['scheduling']['RunJediVariationalExecutable']['execution_time_limit'] = 'PT1H'
@@ -87,6 +91,7 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
     render_dictionary['scheduling']['RunJediVariationalExecutable']['qos'] = 'allnccs'
     render_dictionary['scheduling']['RunJediVariationalExecutable']['nodes'] = 1
     render_dictionary['scheduling']['RunJediVariationalExecutable']['ntasks_per_node'] = 24
+    render_dictionary['scheduling']['RunJediVariationalExecutable']['constraint'] = 'cas|sky'
 
     render_dictionary['scheduling']['RunGeosExecutable'] = {}
     render_dictionary['scheduling']['RunGeosExecutable']['execution_time_limit'] = 'PT2H'
@@ -94,6 +99,7 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
     render_dictionary['scheduling']['RunGeosExecutable']['qos'] = 'allnccs'
     render_dictionary['scheduling']['RunGeosExecutable']['nodes'] = 1
     render_dictionary['scheduling']['RunGeosExecutable']['ntasks_per_node'] = 24
+    render_dictionary['scheduling']['RunGeosExecutable']['constraint'] = 'cas|sky'
 
     # Render the template
     # -------------------

--- a/src/swell/suites/3dvar/flow.cylc
+++ b/src/swell/suites/3dvar/flow.cylc
@@ -116,6 +116,7 @@
             --job-name = BuildJedi
             --nodes={{scheduling["BuildJedi"]["nodes"]}}
             --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
+            --constraint={{scheduling["BuildJedi"]["constraint"]}}
 
     {% for model_component in model_components %}
     [[StageJedi-{{model_component}}]]
@@ -143,6 +144,7 @@
             --job-name = RunJediVariationalExecutable
             --nodes={{scheduling["RunJediVariationalExecutable"]["nodes"]}}
             --ntasks-per-node={{scheduling["RunJediVariationalExecutable"]["ntasks_per_node"]}}
+            --constraint={{scheduling["RunJediVariationalExecutable"]["constraint"]}}
 
     [[MergeIodaFiles-{{model_component}}]]
         script = "swell_task MergeIodaFiles $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/build_jedi/flow.cylc
+++ b/src/swell/suites/build_jedi/flow.cylc
@@ -54,5 +54,6 @@
             --job-name = SwellBuildJedi
             --nodes={{scheduling["BuildJedi"]["nodes"]}}
             --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
+            --constraint={{scheduling["BuildJedi"]["constraint"]}}
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/hofx/flow.cylc
+++ b/src/swell/suites/hofx/flow.cylc
@@ -109,6 +109,7 @@
             --job-name = BuildJedi
             --nodes={{scheduling["BuildJedi"]["nodes"]}}
             --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
+            --constraint={{scheduling["BuildJedi"]["constraint"]}}
 
     {% for model_component in model_components %}
     [[StageJedi-{{model_component}}]]
@@ -133,6 +134,7 @@
             --job-name = RunJediHofxExecutable
             --nodes={{scheduling["RunJediHofxExecutable"]["nodes"]}}
             --ntasks-per-node={{scheduling["RunJediHofxExecutable"]["ntasks_per_node"]}}
+            --constraint={{scheduling["RunJediHofxExecutable"]["constraint"]}}
 
     [[EvaObservations-{{model_component}}]]
         script = "swell_task EvaObservations $config -d $datetime -m {{model_component}}"


### PR DESCRIPTION
## Description

Batch jobs on Discover still seem to be using Haswell unless specified otherwise. This is leading to longer queue times than necessary. This PR allows jobs to choose either Cascade Lake or Skylake nodes. Eliminating Haswell, since these are being decommissioned. 

Hopefully this will eliminate long queue times on 

## Dependencies

N/A

## Impact

N/A
