### PR TITLE
Use skylab 3 modules on Discover to maintain compatibility with JEDI

### DIFF
--- a/src/swell/__init__.py
+++ b/src/swell/__init__.py
@@ -9,4 +9,4 @@ import os
 repo_directory = os.path.dirname(__file__)
 
 # Set the version for swell
-__version__ = '1.2.1'
+__version__ = '1.2.2'

--- a/src/swell/deployment/platforms/nccs_discover/modules
+++ b/src/swell/deployment/platforms/nccs_discover/modules
@@ -17,7 +17,7 @@ umask 022
 module use /discover/swdev/jcsda/spack-stack/modulefiles
 module load miniconda/3.9.7
 module load ecflow/5.8.4
-module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-2.0.0-intel-2022.0.1/install/modulefiles/Core
+module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-v1/envs/skylab-3.0.0-intel-2022.0.1/install/modulefiles/Core
 module load stack-intel/2022.0.1
 module load stack-intel-oneapi-mpi/2021.5.0
 module load stack-python/3.9.7

--- a/src/swell/deployment/platforms/nccs_discover/modules
+++ b/src/swell/deployment/platforms/nccs_discover/modules
@@ -37,7 +37,7 @@ module use -a /discover/nobackup/drholdaw/JediOpt/modulefiles/core
 module load solo/swell-1.0.0
 module load r2d2/swell-1.0.5
 module load eva/1.3.2
-module load jedi_bundle/1.0.7
+module load jedi_bundle/1.0.8
 
 # Set the swell paths
 # -------------------


### PR DESCRIPTION
## Description

The nightly showed a build failure of JEDI. This is because recent changes to JEDI make the Skylab3 modules a requirement. This PR moves to using 1.0.8 of jedi_bundle, which in turn uses sylab 3.0.0.
