### PR TITLE
Feature/c idev

### DIFF
--- a/.github/workflows/discover-tier1-hofx.yml
+++ b/.github/workflows/discover-tier1-hofx.yml
@@ -9,5 +9,7 @@ defaults:
     shell: bash
 
 jobs:
+  
   swell-discover-tier1-hofx:
+    if: ${{ github.event.label.name == 'run-ci-discover (authorized users)' }}
     uses: GEOS-ESM/CI-workflows/.github/workflows/swell-discover-tier1-hofx.yml@main

--- a/.github/workflows/discover-tier1-hofx.yml
+++ b/.github/workflows/discover-tier1-hofx.yml
@@ -11,5 +11,4 @@ defaults:
 jobs:
   
   swell-discover-tier1-hofx:
-    if: ${{ github.event.label.name == 'run-ci-discover (authorized users)' }}
     uses: GEOS-ESM/CI-workflows/.github/workflows/swell-discover-tier1-hofx.yml@main

--- a/.github/workflows/discover-tier1-hofx.yml
+++ b/.github/workflows/discover-tier1-hofx.yml
@@ -1,0 +1,13 @@
+# SWELL Discover Tier1 HOFX
+
+name: swell-discover-tier1-hofx
+
+on: workflow_dispatch
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  swell-discover-tier1-hofx:
+    uses: GEOS-ESM/CI-workflows/.github/workflows/swell-discover-tier1-hofx.yml@main

--- a/.github/workflows/discover-tier1-hofx.yml
+++ b/.github/workflows/discover-tier1-hofx.yml
@@ -9,6 +9,6 @@ defaults:
     shell: bash
 
 jobs:
-  
+
   swell-discover-tier1-hofx:
     uses: GEOS-ESM/CI-workflows/.github/workflows/swell-discover-tier1-hofx.yml@main

--- a/.github/workflows/discover_nightly.yml
+++ b/.github/workflows/discover_nightly.yml
@@ -4,7 +4,7 @@ name: discover-nightly
 
 on:
   workflow_dispatch:
-  
+
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 0 * * *'

--- a/.github/workflows/discover_nightly.yml
+++ b/.github/workflows/discover_nightly.yml
@@ -3,6 +3,8 @@
 name: discover-nightly
 
 on:
+  workflow_dispatch:
+  
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 0 * * *'


### PR DESCRIPTION
## Description

A new workflow was added for running the SWELL Tier-1 HOFX experiment using the latest nightly JEDI Build. This workflow and the nightly workflow can be manually launched. However, it is not clear if labels can be used to constrain initiation of manual workflows. This PR will enable all authorized users to execute a workflow.

Some other important points:

(1) We may want to add additional triggers to the un-scheduled workflows that we develop. Do we want the Tier-1 HOFX experiment to automatically execute on a PR?

(2) Manual execution of the nightly CI workflow will block other manual runs and the scheduled run if overlap occurs.

(3) The workflows are now configured to acquire the SWELL code from the branch that initiates the workflow. Scheduled workflows will always use the main branch unless we explicitly encode the branch name to acquire in the CI workflows. 

(4) Please note that the CI workflow for the nightly run (under the CI-workflows repo) was modified to only update the "latest" build pointer if the Tier-1 HOFX experiment succeeds.