### PR TITLE
Run PR workflows also on push to develop

### DIFF
--- a/.github/workflows/python_coding_norms.yml
+++ b/.github/workflows/python_coding_norms.yml
@@ -1,8 +1,14 @@
 name: Python Coding Norms
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
-    types: [opened, synchronize, reopened]
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   pycodestyle:

--- a/.github/workflows/yaml_coding_norms.yml
+++ b/.github/workflows/yaml_coding_norms.yml
@@ -1,8 +1,14 @@
 name: YAML Coding Norms
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
-      types: [opened, synchronize, reopened]
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 # This validation is equivalent to running on the command line:
 #   yamllint -d relaxed --no-warnings


### PR DESCRIPTION
## Description

Run the coding norm workflows on push to develop to avoid the badges showing a failure when there's a failure in one of the PRs.