### PR TITLE
Fixes for the use of cycle_times in the suite preparation step

### DIFF
--- a/src/swell/suites/3dvar/geos_ocean/suites-3dvar-geos_ocean.yaml
+++ b/src/swell/suites/3dvar/geos_ocean/suites-3dvar-geos_ocean.yaml
@@ -69,7 +69,7 @@ observations:
 
   # Processor layout
 total_processors:
-  default_value: '24'
+  default_value: '6'
   prompt: What is the total number of required processors for JEDI?
   type: string
 


### PR DESCRIPTION
## Description

The changes that went in with the cycling actually broke the build suites since there is no concept of model components or cycle times for these suites.
