### PR TITLE
Feature/jjin3/ufo tests x0048 assign error

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
@@ -78,7 +78,7 @@ obs filters:
     action:
       name: reject
 # Assign obs error
-  - filter: Bounds Check
+  - filter: Perform Action
     filter variables:
     - name: brightnessTemperature
       channels: 1-15

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-a.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-a.yaml
@@ -80,7 +80,7 @@ obs filters:
     action:
       name: reject
 # Assign obs error
-  - filter: Bounds Check
+  - filter: Perform Action
     filter variables:
     - name: brightnessTemperature
       channels: 1-15

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
@@ -80,7 +80,7 @@ obs filters:
     action:
       name: reject
 # Assign obs error
-  - filter: Bounds Check
+  - filter: Perform Action
     filter variables:
     - name: brightnessTemperature
       channels: 1-15

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
@@ -80,7 +80,7 @@ obs filters:
     action:
       name: reject
 # Assign obs error
-  - filter: Bounds Check
+  - filter: Perform Action
     filter variables:
     - name: brightnessTemperature
       channels: 1-15

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
@@ -80,7 +80,7 @@ obs filters:
     action:
       name: reject
 # Assign obs error
-  - filter: Bounds Check
+  - filter: Perform Action
     filter variables:
     - name: brightnessTemperature
       channels: 1-15

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
@@ -80,7 +80,7 @@ obs filters:
     action:
       name: reject
 # Assign obs error
-  - filter: Bounds Check
+  - filter: Perform Action
     filter variables:
     - name: brightnessTemperature
       channels: 1-15

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
@@ -80,7 +80,7 @@ obs filters:
     action:
       name: reject
 # Assign obs error
-  - filter: Bounds Check
+  - filter: Perform Action
     filter variables:
     - name: brightnessTemperature
       channels: 1-15

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
@@ -78,7 +78,7 @@ obs filters:
     action:
       name: reject
 # Assign obs error
-  - filter: Bounds Check
+  - filter: Perform Action
     filter variables:
     - name: brightnessTemperature
       channels: atms_n20_channels

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
@@ -78,7 +78,7 @@ obs filters:
     action:
       name: reject
 # Assign obs error
-  - filter: Bounds Check
+  - filter: Perform Action
     filter variables:
     - name: brightnessTemperature
       channels: atms_npp_channels


### PR DESCRIPTION
Changed the name of the filter to assign observational error to "Perform Action", so that the variable "ObsError" is not required for AMSUA and ATMS observations. It was not required for GMI, AMST2, and MHS data. However, it still is required for IR observations at the moment.  