### PR TITLE
Update the testing to be compatible with new nightly

### DIFF
--- a/.github/workflows/tier1_application_discover.yml
+++ b/.github/workflows/tier1_application_discover.yml
@@ -1,6 +1,9 @@
 name: Tier 1 Applications Tests (Discover)
 
 on:
+  push:
+    branches:
+      - develop
   workflow_dispatch:
 
 defaults:
@@ -9,4 +12,4 @@ defaults:
 
 jobs:
   run-tier1-apps-discover:
-    uses: GEOS-ESM/CI-workflows/.github/workflows/swell-tier1_application_discover.yml@feature/ufo_tests
+    uses: GEOS-ESM/CI-workflows/.github/workflows/swell-tier1_application_discover.yml@develop

--- a/.github/workflows/tier2_application_discover.yml
+++ b/.github/workflows/tier2_application_discover.yml
@@ -13,4 +13,4 @@ defaults:
 
 jobs:
   run-tier2-apps-discover:
-    uses: GEOS-ESM/CI-workflows/.github/workflows/swell-tier2_application_discover.yml@feature/ufo_tests
+    uses: GEOS-ESM/CI-workflows/.github/workflows/swell-tier2_application_discover.yml@develop

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@
   width="50%"
 />
 
-[![Swell test suite](https://github.com/GEOS-ESM/swell/actions/workflows/test_suite.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/test_suite.yml)
+[![Swell code tests](https://github.com/GEOS-ESM/swell/actions/workflows/code_tests.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/code_tests.yml)
 [![Python coding norms](https://github.com/GEOS-ESM/swell/actions/workflows/python_coding_norms.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/python_coding_norms.yml)
 [![YAML coding norms](https://github.com/GEOS-ESM/swell/actions/workflows/yaml_coding_norms.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/yaml_coding_norms.yml)
-[![NCCS Discover Nightly](https://github.com/GEOS-ESM/swell/actions/workflows/discover_nightly.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/discover_nightly.yml)
+---
+[![Tier 1 Applications Tests (Discover)](https://github.com/GEOS-ESM/swell/actions/workflows/tier1_application_discover.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/tier1_application_discover.yml)
+[![Tier 2 Applications Tests (Discover)](https://github.com/GEOS-ESM/swell/actions/workflows/tier2_application_discover.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/tier2_application_discover.yml)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@
   width="50%"
 />
 
+#
+<br/>
+
 [![Swell code tests](https://github.com/GEOS-ESM/swell/actions/workflows/code_tests.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/code_tests.yml)
 [![Python coding norms](https://github.com/GEOS-ESM/swell/actions/workflows/python_coding_norms.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/python_coding_norms.yml)
 [![YAML coding norms](https://github.com/GEOS-ESM/swell/actions/workflows/yaml_coding_norms.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/yaml_coding_norms.yml)
----
+
 [![Tier 1 Applications Tests (Discover)](https://github.com/GEOS-ESM/swell/actions/workflows/tier1_application_discover.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/tier1_application_discover.yml)
 [![Tier 2 Applications Tests (Discover)](https://github.com/GEOS-ESM/swell/actions/workflows/tier2_application_discover.yml/badge.svg?branch=develop)](https://github.com/GEOS-ESM/swell/actions/workflows/tier2_application_discover.yml)
+
+#
 
 </div>
 

--- a/src/swell/deployment/platforms/nccs_discover/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover/task_questions.yaml
@@ -8,10 +8,10 @@ existing_geos_gcm_source_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.0.2/GEOSgcm
 
 existing_jedi_build_directory:
-  default_value: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/build-intel-release/
+  default_value: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/build/
 
 existing_jedi_source_directory:
-  default_value: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/
+  default_value: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/source/
 
 geos_experiment_directory:
   default_value: 5deg_v11

--- a/src/swell/test/suite_tests/3dvar-stable_build-ocean-5deg.yaml
+++ b/src/swell/test/suite_tests/3dvar-stable_build-ocean-5deg.yaml
@@ -1,8 +1,8 @@
 start_cycle_point: '2021-07-01T12:00:00Z'
 final_cycle_point: '2021-07-01T12:00:00Z'
 jedi_build_method: use_existing
-existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/
-existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/build-intel-release/
+existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/source/
+existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/build/
 model_components: ['geos_ocean']
 models:
   geos_ocean:

--- a/src/swell/test/suite_tests/3dvar_cycle-stable_build-ocean-5deg.yaml
+++ b/src/swell/test/suite_tests/3dvar_cycle-stable_build-ocean-5deg.yaml
@@ -1,8 +1,8 @@
 start_cycle_point: '2021-06-21T12:00:00Z'
 final_cycle_point: '2021-06-24T12:00:00Z'
 jedi_build_method: use_existing
-existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/
-existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/build-intel-release/
+existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/source/
+existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/build/
 geos_build_method: use_existing
 existing_geos_gcm_source_path: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.0.2/GEOSgcm
 existing_geos_gcm_build_path: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.0.2/GEOSgcm/install-Release

--- a/src/swell/test/suite_tests/convert_ncdiags-stable_build.yaml
+++ b/src/swell/test/suite_tests/convert_ncdiags-stable_build.yaml
@@ -1,7 +1,7 @@
 final_cycle_point: '2021-12-12T00:00:00Z'
 jedi_build_method: use_existing
-existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/
-existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/build-intel-release/
+existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/source/
+existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/build/
 bundles: REMOVE
 model_components: ['geos_atmosphere']
 models:

--- a/src/swell/test/suite_tests/geosadas-stable_build.yaml
+++ b/src/swell/test/suite_tests/geosadas-stable_build.yaml
@@ -1,6 +1,6 @@
 jedi_build_method: use_existing
-existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/
-existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/build-intel-release/
+existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/source/
+existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/build/
 bundles: REMOVE
 model_components: ['geos_atmosphere']
 models:

--- a/src/swell/test/suite_tests/hofx-stable_build.yaml
+++ b/src/swell/test/suite_tests/hofx-stable_build.yaml
@@ -1,6 +1,6 @@
 jedi_build_method: use_existing
-existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/
-existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/build-intel-release/
+existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/source/
+existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/build/
 bundles: REMOVE
 models:
   geos_atmosphere:

--- a/src/swell/test/suite_tests/ufo_testing-stable_build.yaml
+++ b/src/swell/test/suite_tests/ufo_testing-stable_build.yaml
@@ -1,7 +1,7 @@
 final_cycle_point: '2021-12-12T00:00:00Z'
 jedi_build_method: use_existing
-existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/
-existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/nightly/latest/jedi_build/build-intel-release/
+existing_jedi_source_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/source/
+existing_jedi_build_directory: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/build/
 bundles: REMOVE
 model_components: ['geos_atmosphere']
 models:


### PR DESCRIPTION
## Description

Point the develop version of CI-workflows, pending merge. Update all suites to point to the new location of the nightly build.

*Merge should be synced with CI-workflows PR*

## Dependencies

- [ ] waiting on GEOS-ESM/CI-workflows/pull/4

## Impact

N/A
