### PR TITLE
updating yamls for airs avhrr cris-fsr iasi ssmis

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
@@ -1,71 +1,73 @@
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3,CO2]
-  linear obs operator:
+  obs operator:
+    name: CRTM
     Absorbers: [H2O,O3,CO2]
-  obs options:
-    Sensor_ID: &Sensor_ID airs_aqua
-    EndianType: little_endian
-    CoefficientPath: '{{crtm_coeff_dir}}'
-obs space:
-  name: *Sensor_ID
-  obsdatain:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/airs_aqua.{{window_begin}}.nc4'
-  obsdataout:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.airs_aqua.{{window_begin}}.nc4'
-  simulated variables: [brightnessTemperature]
-  channels: &airs_aqua_channels 1, 6, 7, 10, 11, 15, 16, 17, 20, 21, 22, 24,
-            27, 28, 30, 36, 39, 40, 42, 51, 52, 54, 55, 56, 59, 62, 63, 68, 69, 71,
-            72, 73, 74, 75, 76, 77, 78, 79, 80, 82, 83, 84, 86, 92, 93, 98, 99, 101,
-            104, 105, 108, 110, 111, 113, 116, 117, 123, 124, 128, 129, 138, 139,
-            144, 145, 150, 151, 156, 157, 159, 162, 165, 168, 169, 170, 172, 173,
-            174, 175, 177, 179, 180, 182, 185, 186, 190, 192, 198, 201, 204, 207,
-            210, 215, 216, 221, 226, 227, 232, 252, 253, 256, 257, 261, 262, 267,
-            272, 295, 299, 300, 305, 310, 321, 325, 333, 338, 355, 362, 375, 453,
-            475, 484, 497, 528, 587, 672, 787, 791, 843, 870, 914, 950, 1003, 1012,
-            1019, 1024, 1030, 1038, 1048, 1069, 1079, 1082, 1083, 1088, 1090, 1092,
-            1095, 1104, 1111, 1115, 1116, 1119, 1120, 1123, 1130, 1138, 1142, 1178,
-            1199, 1206, 1221, 1237, 1252, 1260, 1263, 1266, 1285, 1301, 1304, 1329,
-            1371, 1382, 1415, 1424, 1449, 1455, 1466, 1477, 1500, 1519, 1538, 1545,
-            1565, 1574, 1583, 1593, 1614, 1627, 1636, 1644, 1652, 1669, 1674, 1681,
-            1694, 1708, 1717, 1723, 1740, 1748, 1751, 1756, 1763, 1766, 1771, 1777,
-            1780, 1783, 1794, 1800, 1803, 1806, 1812, 1826, 1843, 1852, 1865, 1866,
-            1868, 1869, 1872, 1873, 1876, 1881, 1882, 1883, 1911, 1917, 1918, 1924,
-            1928, 1937, 1941, 2099, 2100, 2101, 2103, 2104, 2106, 2107, 2108, 2109,
-            2110, 2111, 2112, 2113, 2114, 2115, 2116, 2117, 2118, 2119, 2120, 2121,
-            2122, 2123, 2128, 2134, 2141, 2145, 2149, 2153, 2164, 2189, 2197, 2209,
-            2226, 2234, 2280, 2318, 2321, 2325, 2328, 2333, 2339, 2348, 2353, 2355,
-            2357, 2363, 2370, 2371, 2377
-obs bias:
-  input file: '{{cycle_dir}}/airs_aqua.{{background_time}}.satbias.nc4'
-  variational bc:
-    predictors:
-    - name: constant
-    - name: lapse_rate
-      order: 2
-      tlapse: &airs_aqua_tlapse '{{cycle_dir}}/airs_aqua.{{background_time}}.tlapse.txt'
-    - name: lapse_rate
-      tlapse: *airs_aqua_tlapse
-    - name: emissivity
-    - name: scan_angle
-      order: 4
-    - name: scan_angle
-      order: 3
-    - name: scan_angle
-      order: 2
-    - name: scan_angle
-obs filters:
-- filter: Perform Action
-  filter variables:
-  - name: brightnessTemperature
-    channels: *airs_aqua_channels
-  action:
-    name: assign error
-    error parameter vector: [ 1.2000, 1.2000, 1.3136, 1.4000, 1.4000, 1.2639, 1.4000, 1.4000, 1.1802, 1.2517,
+    linear obs operator:
+      Absorbers: [H2O,O3,CO2]
+#    SurfaceWindGeoVars: uv
+    obs options:
+      Sensor_ID: &Sensor_ID airs_aqua
+      EndianType: little_endian
+      CoefficientPath:  '{{crtm_coeff_dir}}'
+  obs space:
+    name: *Sensor_ID
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/airs_aqua.{{window_begin}}.nc4'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/{{experiment_id}}.airs_aqua.{{window_begin}}.nc4'
+    simulated variables: [brightnessTemperature]
+    channels: &airs_aqua_channels
+              1, 6, 7, 10, 11, 15, 16, 17, 20, 21, 22, 24,
+              27, 28, 30, 36, 39, 40, 42, 51, 52, 54, 55, 56, 59, 62, 63, 68, 69, 71,
+              72, 73, 74, 75, 76, 77, 78, 79, 80, 82, 83, 84, 86, 92, 93, 98, 99, 101,
+              104, 105, 108, 110, 111, 113, 116, 117, 123, 124, 128, 129, 138, 139,
+              144, 145, 150, 151, 156, 157, 159, 162, 165, 168, 169, 170, 172, 173,
+              174, 175, 177, 179, 180, 182, 185, 186, 190, 192, 198, 201, 204, 207,
+              210, 215, 216, 221, 226, 227, 232, 252, 253, 256, 257, 261, 262, 267,
+              272, 295, 299, 300, 305, 310, 321, 325, 333, 338, 355, 362, 375, 453,
+              475, 484, 497, 528, 587, 672, 787, 791, 843, 870, 914, 950, 1003, 1012,
+              1019, 1024, 1030, 1038, 1048, 1069, 1079, 1082, 1083, 1088, 1090, 1092,
+              1095, 1104, 1111, 1115, 1116, 1119, 1120, 1123, 1130, 1138, 1142, 1178,
+              1199, 1206, 1221, 1237, 1252, 1260, 1263, 1266, 1285, 1301, 1304, 1329,
+              1371, 1382, 1415, 1424, 1449, 1455, 1466, 1477, 1500, 1519, 1538, 1545,
+              1565, 1574, 1583, 1593, 1614, 1627, 1636, 1644, 1652, 1669, 1674, 1681,
+              1694, 1708, 1717, 1723, 1740, 1748, 1751, 1756, 1763, 1766, 1771, 1777,
+              1780, 1783, 1794, 1800, 1803, 1806, 1812, 1826, 1843, 1852, 1865, 1866,
+              1868, 1869, 1872, 1873, 1876, 1881, 1882, 1883, 1911, 1917, 1918, 1924,
+              1928, 1937, 1941, 2099, 2100, 2101, 2103, 2104, 2106, 2107, 2108, 2109,
+              2110, 2111, 2112, 2113, 2114, 2115, 2116, 2117, 2118, 2119, 2120, 2121,
+              2122, 2123, 2128, 2134, 2141, 2145, 2149, 2153, 2164, 2189, 2197, 2209,
+              2226, 2234, 2280, 2318, 2321, 2325, 2328, 2333, 2339, 2348, 2353, 2355,
+              2357, 2363, 2370, 2371, 2377
+  obs bias:
+    input file: '{{cycle_dir}}/airs_aqua.{{background_time}}.satbias.nc4'
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &airs_aqua_tlapse '{{cycle_dir}}/airs_aqua.{{background_time}}.tlapse.txt'
+      - name: lapse_rate
+        tlapse: *airs_aqua_tlapse
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+  obs filters:
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *airs_aqua_channels
+    action:
+      name: assign error
+      error parameter vector: [ 1.2000, 1.2000, 1.3136, 1.4000, 1.4000, 1.2639, 1.4000, 1.4000, 1.1802, 1.2517,
                     1.1719, 1.2000, 1.1728, 1.1442, 1.2000, 1.2000, 1.1500, 1.0801, 1.1500, 1.1500,
                     1.0396, 1.1500, 1.1500, 1.1500, 1.1500, 1.1500, 1.1500, 1.1500, 0.9946, 1.0500,
                     0.9217, 2.0000, 2.0000, 2.0000, 2.0000, 2.0000, 2.0000, 2.0000, 2.0000, 2.0000,
@@ -94,78 +96,90 @@ obs filters:
                     0.7500, 0.7750, 0.8000, 0.8250, 0.8000, 0.8000, 0.8000, 0.7500, 0.8000, 0.8000,
                     0.8000, 0.8000, 0.8000, 0.8500, 0.8000, 0.8000, 2.5000, 0.7500, 0.7500, 0.7500,
                     0.7500 ]
+# assign ObsError <---- ObsErrorData (Assigned in Yaml)
+  - filter: Variable Assignment
+    assignments:
+    - name: ObsError/brightnessTemperature
+      channels: *airs_aqua_channels
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature
+            channels: *airs_aqua_channels
 #  Wavenumber Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: 2122, 2123, 2128, 2134, 2141, 2145, 2149, 2153, 2164, 2189, 2197, 2209,
-              2226, 2234, 2280, 2318, 2321, 2325, 2328, 2333, 2339, 2348, 2353, 2355,
-              2357, 2363, 2370, 2371, 2377
-  where:
-  - variable:
-      name: MetaData/solarZenithAngle
-    maxvalue: 88.9999
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    minvalue: 1.0e-12
-  action:
-    name: reject
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *airs_aqua_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorWavenumIR
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: 2122, 2123, 2128, 2134, 2141, 2145, 2149, 2153, 2164, 2189, 2197, 2209,
+                2226, 2234, 2280, 2318, 2321, 2325, 2328, 2333, 2339, 2348, 2353, 2355,
+                2357, 2363, 2370, 2371, 2377
+    where:
+    - variable:
+        name: MetaData/solarZenithAngle
+      maxvalue: 88.9999
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0e-12
+    action:
+      name: reject
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *airs_aqua_channels
-      options:
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorWavenumIR
         channels: *airs_aqua_channels
+        options:
+          channels: *airs_aqua_channels
 #  Observation Range Sanity Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *airs_aqua_channels
-  minvalue: 50.00001
-  maxvalue: 549.99999
-  action:
-    name: reject
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *airs_aqua_channels
+    minvalue: 50.00001
+    maxvalue: 549.99999
+    action:
+      name: reject
 #  Topography Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *airs_aqua_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTopoRad
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *airs_aqua_channels
-      options:
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
         channels: *airs_aqua_channels
-        sensor: airs_aqua
+        options:
+          channels: *airs_aqua_channels
+          sensor: *Sensor_ID
 #  Transmittance Top Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *airs_aqua_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTransmitTopRad
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *airs_aqua_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTransmitTopRad
+        channels: *airs_aqua_channels
+        options:
+          channels: *airs_aqua_channels
+#  Cloud Detection Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *airs_aqua_channels
+    test variables:
+    - name: ObsFunction/CloudDetectMinResidualIR
       channels: *airs_aqua_channels
       options:
         channels: *airs_aqua_channels
-#  Cloud Detection Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *airs_aqua_channels
-  test variables:
-  - name: ObsFunction/CloudDetectMinResidualIR
-    channels: *airs_aqua_channels
-    options:
-      channels: *airs_aqua_channels
-      use_flag: &useflag_airs_aqua [ -1, -1,  1, -1, -1,  1, -1, -1,  1,  1,
+        use_flag: &useflag_airs_aqua [ -1, -1,  1, -1, -1,  1, -1, -1,  1,  1,
                      1, -1,  1,  1, -1, -1, -1,  1, -1, -1,
                      1, -1, -1, -1, -1, -1, -1, -1,  1, -1,
                      1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -194,7 +208,7 @@ obs filters:
                     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
                     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
                     -1 ]
-      use_flag_clddet: &clddet_airs_aqua [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        use_flag_clddet: &clddet_airs_aqua [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -223,119 +237,119 @@ obs filters:
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1 ]
-      obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
+        obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
 #  NSST Retrieval Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *airs_aqua_channels
-  test variables:
-  - name: ObsFunction/NearSSTRetCheckIR
-    channels: *airs_aqua_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *airs_aqua_channels
-      use_flag: *useflag_airs_aqua
-      obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
-      obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  Surface Jacobians Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *airs_aqua_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+    test variables:
+    - name: ObsFunction/NearSSTRetCheckIR
       channels: *airs_aqua_channels
       options:
         channels: *airs_aqua_channels
-        sensor: *Sensor_ID
+        use_flag: *useflag_airs_aqua
         obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
         obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
-#  Gross check
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *airs_aqua_channels
-  function absolute threshold:
-  - name: ObsFunction/ObsErrorBoundIR
-    channels: *airs_aqua_channels
-    options:
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  Surface Jacobians Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *airs_aqua_channels
-      obserr_bound_latitude:
-        name: ObsFunction/ObsErrorFactorLatRad
-        options:
-          latitude_parameters: [25.0, 0.5, 0.04, 1.0]
-      obserr_bound_transmittop:
-        name: ObsFunction/ObsErrorFactorTransmitTopRad
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
         channels: *airs_aqua_channels
         options:
           channels: *airs_aqua_channels
-      obserr_bound_max: [3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
-                         3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
-                         3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
-                         3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
-                         3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
-                         3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
-                         3.50, 3.50, 3.00, 3.00, 3.00, 3.00, 1.00, 1.00, 3.00, 1.00,
-                         3.00, 1.00, 1.00, 3.00, 1.00, 1.00, 1.00, 1.00, 3.00, 1.00,
-                         1.00, 3.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 3.00, 3.00,
-                         3.50, 3.00, 3.50, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
-                         3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
-                         3.50, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
-                         3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
-                         3.00, 1.70, 3.00, 1.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
-                         3.50, 1.25, 3.50, 3.50, 3.00, 3.00, 1.50, 3.00, 3.00, 3.00,
-                         1.50, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
-                         3.00, 3.50, 3.00, 3.50, 3.00, 3.00, 3.00, 3.00, 3.50, 3.00,
-                         4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50,
-                         4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50,
-                         4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50,
-                         4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50,
-                         4.50, 4.50, 4.50, 4.50, 2.50, 2.50, 2.50, 2.50, 2.50, 2.50,
-                         2.50, 2.50, 2.50, 2.50, 2.50, 2.50, 2.50, 2.50, 2.50, 3.50,
-                         3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
-                         3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
-                         3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
-                         3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
-                         3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
-                         3.00 ]
-  action:
-    name: reject
+          sensor: *Sensor_ID
+          obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+          obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
+#  Gross check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *airs_aqua_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundIR
+      channels: *airs_aqua_channels
+      options:
+        channels: *airs_aqua_channels
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [25.0, 0.5, 0.04, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *airs_aqua_channels
+          options:
+            channels: *airs_aqua_channels
+        obserr_bound_max: [3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
+                           3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
+                           3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
+                           3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
+                           3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
+                           3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
+                           3.50, 3.50, 3.00, 3.00, 3.00, 3.00, 1.00, 1.00, 3.00, 1.00,
+                           3.00, 1.00, 1.00, 3.00, 1.00, 1.00, 1.00, 1.00, 3.00, 1.00,
+                           1.00, 3.00, 1.00, 1.00, 1.00, 1.00, 1.00, 1.00, 3.00, 3.00,
+                           3.50, 3.00, 3.50, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
+                           3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
+                           3.50, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
+                           3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
+                           3.00, 1.70, 3.00, 1.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
+                           3.50, 1.25, 3.50, 3.50, 3.00, 3.00, 1.50, 3.00, 3.00, 3.00,
+                           1.50, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
+                           3.00, 3.50, 3.00, 3.50, 3.00, 3.00, 3.00, 3.00, 3.50, 3.00,
+                           4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50,
+                           4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50,
+                           4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50,
+                           4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50, 4.50,
+                           4.50, 4.50, 4.50, 4.50, 2.50, 2.50, 2.50, 2.50, 2.50, 2.50,
+                           2.50, 2.50, 2.50, 2.50, 2.50, 2.50, 2.50, 2.50, 2.50, 3.50,
+                           3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50, 3.50,
+                           3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
+                           3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
+                           3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
+                           3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00, 3.00,
+                           3.00 ]
+    action:
+      name: reject
 #  Surface Type Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *airs_aqua_channels
-  test variables:
-  - name: SurfTypeCheckRad@ObsFunction
-    channels: *airs_aqua_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *airs_aqua_channels
-      use_flag: *useflag_airs_aqua
-      use_flag_clddet: *clddet_airs_aqua
-  maxvalue: 1.0e-12
-  defer to post: true
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/SurfTypeCheckRad
+      channels: *airs_aqua_channels
+      options:
+        channels: *airs_aqua_channels
+        use_flag: *useflag_airs_aqua
+        use_flag_clddet: *clddet_airs_aqua
+    maxvalue: 1.0e-12
+    defer to post: true
+    action:
+      name: reject
 #  Useflag Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *airs_aqua_channels
-  test variables:
-  - name: ObsFunction/ChannelUseflagCheckRad
-    channels: *airs_aqua_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *airs_aqua_channels
-      use passive_bc: true
-      use_flag: *useflag_airs_aqua
-  minvalue: 1.0e-12
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *airs_aqua_channels
+      options:
+        channels: *airs_aqua_channels
+#        use passive_bc: true
+        use_flag: *useflag_airs_aqua
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-b.yaml
@@ -1,180 +1,201 @@
-obs space:
-  name: avhrr3_metop-b
-  obsdatain:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/avhrr3_metop-b.{{window_begin}}.nc4'
-  obsdataout:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.avhrr3_metop-b.{{window_begin}}.nc4'
-  simulated variables: [brightnessTemperature]
-  channels: &avhrr3_metop-b_channels 3,4,5
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3,CO2]
-  obs options:
-    Sensor_ID: &Sensor_ID avhrr3_metop-b
-    EndianType: little_endian
-    CoefficientPath: '{{crtm_coeff_dir}}'
-obs bias:
-  input file: '{{cycle_dir}}/avhrr3_metop-b.{{background_time}}.satbias.nc4'
-  variational bc:
-    predictors:
-    - name: constant
-    - name: lapse_rate
-      order: 2
-      tlapse: &avhrr3_metop-b_tlapse '{{cycle_dir}}/avhrr3_metop-b.{{background_time}}.tlapse.txt'
-    - name: lapse_rate
-      tlapse: *avhrr3_metop-b_tlapse
-    - name: emissivity
-    - name: scan_angle
-      order: 4
-    - name: scan_angle
-      order: 3
-    - name: scan_angle
-      order: 2
-    - name: scan_angle
-obs filters:
-#  Wavenumber Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: 3
-  where:
-  - variable:
-      name: MetaData/solarZenithAngle
-    maxvalue: 88.9999
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    minvalue: 1.0e-12
-  action:
-    name: reject
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_metop-b_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorWavenumIR
+  obs operator:
+    name: CRTM
+    Absorbers: [H2O,O3,CO2]
+    linear obs operator:
+      Absorbers: [H2O,O3,CO2]
+    obs options:
+      Sensor_ID: &Sensor_ID avhrr3_metop-b
+      EndianType: little_endian
+      CoefficientPath: '{{crtm_coeff_dir}}'
+  obs space:
+    name: *Sensor_ID
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/avhrr3_metop-b.{{window_begin}}.nc4'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/{{experiment_id}}.avhrr3_metop-b.{{window_begin}}.nc4'
+    simulated variables: [brightnessTemperature]
+    channels: &avhrr3_metop-b_channels 3,4,5
+  obs bias:
+    input file: '{{cycle_dir}}/avhrr3_metop-b.{{background_time}}.satbias.nc4'
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &avhrr3_metop-b_tlapse '{{cycle_dir}}/avhrr3_metop-b.{{background_time}}.tlapse.txt'
+      - name: lapse_rate
+        tlapse: *avhrr3_metop-b_tlapse
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+  obs filters:
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
       channels: *avhrr3_metop-b_channels
-      options:
-        channels: *avhrr3_metop-b_channels
-#  Topography Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_metop-b_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTopoRad
+    action:
+      name: assign error
+      error parameter vector: [ 0.6, 0.68, 0.72 ]
+# # assign ObsError <---- ObsErrorData (Assigned in Yaml)
+  - filter: Variable Assignment
+    assignments:
+    - name: ObsError/brightnessTemperature
       channels: *avhrr3_metop-b_channels
-      options:
-        channels: *avhrr3_metop-b_channels
-        sensor: avhrr3_metop-b
-#  Observation Range Sanity Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_metop-b_channels
-  minvalue: 0.00001
-  maxvalue: 1000.0
-  action:
-    name: reject
-#  Transmittance Top Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_metop-b_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTransmitTopRad
-      channels: *avhrr3_metop-b_channels
-      options:
-        channels: *avhrr3_metop-b_channels
-#  Cloud Detection Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_metop-b_channels
-  test variables:
-  - name: ObsFunction/CloudDetectMinResidualAVHRR
-    channels: *avhrr3_metop-b_channels
-    options:
-      channels: *avhrr3_metop-b_channels
-      use_flag: [ 1,  1,  1 ]
-      use_flag_clddet: [ 1,  1,  1 ]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  NSST Retrieval Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_metop-b_channels
-  test variables:
-  - name: ObsFunction/NearSSTRetCheckIR
-    channels: *avhrr3_metop-b_channels
-    options:
-      channels: *avhrr3_metop-b_channels
-      use_flag: [ 1,  1,  1 ]
-      obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  Surface Jacobians Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_metop-b_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
-      channels: *avhrr3_metop-b_channels
-      options:
-        channels: *avhrr3_metop-b_channels
-        sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
-        obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
-#  Gross check
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_metop-b_channels
-  function absolute threshold:
-  - name: ObsFunction/ObsErrorBoundIR
-    channels: *avhrr3_metop-b_channels
-    options:
-      channels: *avhrr3_metop-b_channels
-      obserr_bound_latitude:
-        name: ObsFunction/ObsErrorFactorLatRad
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
         options:
-          latitude_parameters: [25.0, 0.5, 0.04, 1.0]
-      obserr_bound_transmittop:
+          variables:
+          - name: ObsErrorData/brightnessTemperature
+            channels: *avhrr3_metop-b_channels
+#  Wavenumber Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: 3
+    where:
+    - variable:
+        name: MetaData/solarZenithAngle
+      maxvalue: 88.9999
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0e-12
+    action:
+      name: reject
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_metop-b_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorWavenumIR
+        channels: *avhrr3_metop-b_channels
+        options:
+          channels: *avhrr3_metop-b_channels
+#  Observation Range Sanity Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_metop-b_channels
+    minvalue: 0.00001
+    maxvalue: 1000.0
+    action:
+      name: reject
+#  Topography Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_metop-b_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
+        channels: *avhrr3_metop-b_channels
+        options:
+          channels: *avhrr3_metop-b_channels
+          sensor: *Sensor_ID
+#  Transmittance Top Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_metop-b_channels
+    action:
+      name: inflate error
+      inflation variable:
         name: ObsFunction/ObsErrorFactorTransmitTopRad
         channels: *avhrr3_metop-b_channels
         options:
           channels: *avhrr3_metop-b_channels
-      obserr_bound_max: [ 6.0, 6.0, 6.0 ]
-  action:
-    name: reject
-#  Useflag Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_metop-b_channels
-  test variables:
-  - name: ObsFunction/ChannelUseflagCheckRad
-    channels: *avhrr3_metop-b_channels
-    options:
+#  Cloud Detection Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *avhrr3_metop-b_channels
-      use_flag: [ 1,  1,  1 ]
-  minvalue: 1.0e-12
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/CloudDetectMinResidualAVHRR
+      channels: *avhrr3_metop-b_channels
+      options:
+        channels: *avhrr3_metop-b_channels
+        use_flag: &useflag_avhrr3_metop-b [ -1,  1,  1 ]
+        use_flag_clddet: [ 1,  1,  1 ]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  NSST Retrieval Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_metop-b_channels
+    test variables:
+    - name: ObsFunction/NearSSTRetCheckIR
+      channels: *avhrr3_metop-b_channels
+      options:
+        channels: *avhrr3_metop-b_channels
+        use_flag: *useflag_avhrr3_metop-b
+        obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  Surface Jacobians Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_metop-b_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
+        channels: *avhrr3_metop-b_channels
+        options:
+          channels: *avhrr3_metop-b_channels
+          sensor: *Sensor_ID
+          obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+          obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
+#  Gross check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_metop-b_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundIR
+      channels: *avhrr3_metop-b_channels
+      options:
+        channels: *avhrr3_metop-b_channels
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [25.0, 0.5, 0.04, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *avhrr3_metop-b_channels
+          options:
+            channels: *avhrr3_metop-b_channels
+        obserr_bound_max: [ 3.0, 3.0, 3.0 ]
+    action:
+      name: reject
+#  Useflag Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_metop-b_channels
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *avhrr3_metop-b_channels
+      options:
+        channels: *avhrr3_metop-b_channels
+        use_flag: *useflag_avhrr3_metop-b
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n18.yaml
@@ -1,181 +1,201 @@
-obs space:
-  name: avhrr3_n18
-  obsdatain:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/avhrr3_n18.{{window_begin}}.nc4'
-  obsdataout:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.avhrr3_n18.{{window_begin}}.nc4'
-  simulated variables: [brightnessTemperature]
-  channels: &avhrr3_n18_channels 3,4,5
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3,CO2]
-  obs options:
-    Sensor_ID: &Sensor_ID avhrr3_n18
-    EndianType: little_endian
-    CoefficientPath: '{{crtm_coeff_dir}}'
-obs bias:
-  input file: '{{cycle_dir}}/avhrr3_n18.{{background_time}}.satbias.nc4'
-  variational bc:
-    predictors:
-    - name: constant
-    - name: lapse_rate
-      order: 2
-      tlapse: &avhrr3_n18_tlapse '{{cycle_dir}}/avhrr3_n18.{{background_time}}.tlapse.txt'
-    - name: lapse_rate
-      tlapse: *avhrr3_n18_tlapse
-    - name: emissivity
-    - name: scan_angle
-      order: 4
-    - name: scan_angle
-      order: 3
-    - name: scan_angle
-      order: 2
-    - name: scan_angle
-obs filters:
-#  Wavenumber Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: 3
-  where:
-  - variable:
-      name: MetaData/solarZenithAngle
-    maxvalue: 88.9999
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    minvalue: 1.0e-12
-  action:
-    name: reject
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n18_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorWavenumIR
+  obs operator:
+    name: CRTM
+    Absorbers: [H2O,O3,CO2]
+    linear obs operator:
+      Absorbers: [H2O,O3,CO2]
+    obs options:
+      Sensor_ID: &Sensor_ID avhrr3_n18
+      EndianType: little_endian
+      CoefficientPath: '{{crtm_coeff_dir}}'
+  obs space:
+    name: *Sensor_ID
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/avhrr3_n18.{{window_begin}}.nc4'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/{{experiment_id}}.avhrr3_n18.{{window_begin}}.nc4'
+    simulated variables: [brightnessTemperature]
+    channels: &avhrr3_n18_channels 3,4,5
+  obs bias:
+    input file: '{{cycle_dir}}/avhrr3_n18.{{background_time}}.satbias.nc4'
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &avhrr3_n18_tlapse '{{cycle_dir}}/avhrr3_n18.{{background_time}}.tlapse.txt'
+      - name: lapse_rate
+        tlapse: *avhrr3_n18_tlapse
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+  obs filters:
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
       channels: *avhrr3_n18_channels
-      options:
-        channels: *avhrr3_n18_channels
-#  Topography Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n18_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTopoRad
+    action:
+      name: assign error
+      error parameter vector: [ 0.6, 0.68, 0.72 ]
+# # assign ObsError <---- ObsErrorData (Assigned in Yaml)
+  - filter: Variable Assignment
+    assignments:
+    - name: ObsError/brightnessTemperature
       channels: *avhrr3_n18_channels
-      options:
-        channels: *avhrr3_n18_channels
-        sensor: avhrr3_n18
-#  Observation Range Sanity Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n18_channels
-  minvalue: 0.00001
-  maxvalue: 1000.0
-  action:
-    name: reject
-#  Transmittance Top Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n18_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTransmitTopRad
-      channels: *avhrr3_n18_channels
-      options:
-        channels: *avhrr3_n18_channels
-#  Cloud Detection Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n18_channels
-  test variables:
-  - name: ObsFunction/CloudDetectMinResidualAVHRR
-    channels: *avhrr3_n18_channels
-    options:
-      channels: *avhrr3_n18_channels
-      use_flag: [ 1,  1,  1 ]
-      use_flag_clddet: [ 1,  1,  1 ]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  NSST Retrieval Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n18_channels
-  test variables:
-  - name: ObsFunction/NearSSTRetCheckIR
-    channels: *avhrr3_n18_channels
-    options:
-      channels: *avhrr3_n18_channels
-      use_flag: [ 1,  1,  1 ]
-      obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  Surface Jacobians Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n18_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
-      channels: *avhrr3_n18_channels
-      options:
-        channels: *avhrr3_n18_channels
-        sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
-        obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
-#  Gross check
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n18_channels
-  function absolute threshold:
-  - name: ObsFunction/ObsErrorBoundIR
-    channels: *avhrr3_n18_channels
-    options:
-      channels: *avhrr3_n18_channels
-      obserr_bound_latitude:
-        name: ObsFunction/ObsErrorFactorLatRad
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
         options:
-          latitude_parameters: [25.0, 0.5, 0.04, 1.0]
-      obserr_bound_transmittop:
+          variables:
+          - name: ObsErrorData/brightnessTemperature
+            channels: *avhrr3_n18_channels
+#  Wavenumber Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: 3
+    where:
+    - variable:
+        name: MetaData/solarZenithAngle
+      maxvalue: 88.9999
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0e-12
+    action:
+      name: reject
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n18_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorWavenumIR
+        channels: *avhrr3_n18_channels
+        options:
+          channels: *avhrr3_n18_channels
+#  Observation Range Sanity Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n18_channels
+    minvalue: 0.00001
+    maxvalue: 1000.0
+    action:
+      name: reject
+#  Topography Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n18_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
+        channels: *avhrr3_n18_channels
+        options:
+          channels: *avhrr3_n18_channels
+          sensor: *Sensor_ID
+#  Transmittance Top Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n18_channels
+    action:
+      name: inflate error
+      inflation variable:
         name: ObsFunction/ObsErrorFactorTransmitTopRad
         channels: *avhrr3_n18_channels
         options:
           channels: *avhrr3_n18_channels
-      obserr_bound_max: [ 6.0, 6.0, 6.0 ]
-  action:
-    name: reject
-#  Useflag Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n18_channels
-  test variables:
-  - name: ObsFunction/ChannelUseflagCheckRad
-    channels: *avhrr3_n18_channels
-    options:
+#  Cloud Detection Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *avhrr3_n18_channels
-      use_flag: [ 1,  1,  1 ]
-  minvalue: 1.0e-12
-  action:
-    name: reject
-
+    test variables:
+    - name: ObsFunction/CloudDetectMinResidualAVHRR
+      channels: *avhrr3_n18_channels
+      options:
+        channels: *avhrr3_n18_channels
+        use_flag: &useflag_avhrr3_n18 [ -1,  1,  1 ]
+        use_flag_clddet: [ 1,  1,  1 ]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  NSST Retrieval Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n18_channels
+    test variables:
+    - name: ObsFunction/NearSSTRetCheckIR
+      channels: *avhrr3_n18_channels
+      options:
+        channels: *avhrr3_n18_channels
+        use_flag: *useflag_avhrr3_n18
+        obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  Surface Jacobians Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n18_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
+        channels: *avhrr3_n18_channels
+        options:
+          channels: *avhrr3_n18_channels
+          sensor: *Sensor_ID
+          obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+          obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
+#  Gross check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n18_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundIR
+      channels: *avhrr3_n18_channels
+      options:
+        channels: *avhrr3_n18_channels
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [25.0, 0.5, 0.04, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *avhrr3_n18_channels
+          options:
+            channels: *avhrr3_n18_channels
+        obserr_bound_max: [ 3.0, 3.0, 3.0 ]
+    action:
+      name: reject
+#  Useflag Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n18_channels
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *avhrr3_n18_channels
+      options:
+        channels: *avhrr3_n18_channels
+        use_flag: *useflag_avhrr3_n18
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
@@ -1,181 +1,201 @@
-obs space:
-  name: avhrr3_n19
-  obsdatain:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/avhrr3_n19.{{window_begin}}.nc4'
-  obsdataout:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.avhrr3_n19.{{window_begin}}.nc4'
-  simulated variables: [brightnessTemperature]
-  channels: &avhrr3_n19_channels 3,4,5
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3,CO2]
-  obs options:
-    Sensor_ID: &Sensor_ID avhrr3_n19
-    EndianType: little_endian
-    CoefficientPath: '{{crtm_coeff_dir}}'
-obs bias:
-  input file: '{{cycle_dir}}/avhrr3_n19.{{background_time}}.satbias.nc4'
-  variational bc:
-    predictors:
-    - name: constant
-    - name: lapse_rate
-      order: 2
-      tlapse: &avhrr3_n19_tlapse '{{cycle_dir}}/avhrr3_n19.{{background_time}}.tlapse.txt'
-    - name: lapse_rate
-      tlapse: *avhrr3_n19_tlapse
-    - name: emissivity
-    - name: scan_angle
-      order: 4
-    - name: scan_angle
-      order: 3
-    - name: scan_angle
-      order: 2
-    - name: scan_angle
-obs filters:
-#  Wavenumber Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: 3
-  where:
-  - variable:
-      name: MetaData/solarZenithAngle
-    maxvalue: 88.9999
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    minvalue: 1.0e-12
-  action:
-    name: reject
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n19_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorWavenumIR
+  obs operator:
+    name: CRTM
+    Absorbers: [H2O,O3,CO2]
+    linear obs operator:
+      Absorbers: [H2O,O3,CO2]
+    obs options:
+      Sensor_ID: &Sensor_ID avhrr3_n19
+      EndianType: little_endian
+      CoefficientPath: '{{crtm_coeff_dir}}'
+  obs space:
+    name: *Sensor_ID
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/avhrr3_n19.{{window_begin}}.nc4'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/{{experiment_id}}.avhrr3_n19.{{window_begin}}.nc4'
+    simulated variables: [brightnessTemperature]
+    channels: &avhrr3_n19_channels 3,4,5
+  obs bias:
+    input file: '{{cycle_dir}}/avhrr3_n19.{{background_time}}.satbias.nc4'
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &avhrr3_n19_tlapse '{{cycle_dir}}/avhrr3_n19.{{background_time}}.tlapse.txt'
+      - name: lapse_rate
+        tlapse: *avhrr3_n19_tlapse
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+  obs filters:
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
       channels: *avhrr3_n19_channels
-      options:
-        channels: *avhrr3_n19_channels
-#  Topography Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n19_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTopoRad
+    action:
+      name: assign error
+      error parameter vector: [ 0.6, 0.68, 0.72 ]
+# # assign ObsError <---- ObsErrorData (Assigned in Yaml)
+  - filter: Variable Assignment
+    assignments:
+    - name: ObsError/brightnessTemperature
       channels: *avhrr3_n19_channels
-      options:
-        channels: *avhrr3_n19_channels
-        sensor: avhrr3_n19
-#  Observation Range Sanity Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n19_channels
-  minvalue: 0.00001
-  maxvalue: 1000.0
-  action:
-    name: reject
-#  Transmittance Top Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n19_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTransmitTopRad
-      channels: *avhrr3_n19_channels
-      options:
-        channels: *avhrr3_n19_channels
-#  Cloud Detection Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n19_channels
-  test variables:
-  - name: ObsFunction/CloudDetectMinResidualAVHRR
-    channels: *avhrr3_n19_channels
-    options:
-      channels: *avhrr3_n19_channels
-      use_flag: [ 1,  1,  1 ]
-      use_flag_clddet: [ 1,  1,  1 ]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  NSST Retrieval Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n19_channels
-  test variables:
-  - name: ObsFunction/NearSSTRetCheckIR
-    channels: *avhrr3_n19_channels
-    options:
-      channels: *avhrr3_n19_channels
-      use_flag: [ 1,  1,  1 ]
-      obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  Surface Jacobians Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n19_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
-      channels: *avhrr3_n19_channels
-      options:
-        channels: *avhrr3_n19_channels
-        sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
-        obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
-#  Gross check
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n19_channels
-  function absolute threshold:
-  - name: ObsFunction/ObsErrorBoundIR
-    channels: *avhrr3_n19_channels
-    options:
-      channels: *avhrr3_n19_channels
-      obserr_bound_latitude:
-        name: ObsFunction/ObsErrorFactorLatRad
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
         options:
-          latitude_parameters: [25.0, 0.5, 0.04, 1.0]
-      obserr_bound_transmittop:
+          variables:
+          - name: ObsErrorData/brightnessTemperature
+            channels: *avhrr3_n19_channels
+#  Wavenumber Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: 3
+    where:
+    - variable:
+        name: MetaData/solarZenithAngle
+      maxvalue: 88.9999
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0e-12
+    action:
+      name: reject
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n19_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorWavenumIR
+        channels: *avhrr3_n19_channels
+        options:
+          channels: *avhrr3_n19_channels
+#  Observation Range Sanity Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n19_channels
+    minvalue: 0.00001
+    maxvalue: 1000.0
+    action:
+      name: reject
+#  Topography Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n19_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
+        channels: *avhrr3_n19_channels
+        options:
+          channels: *avhrr3_n19_channels
+          sensor: *Sensor_ID
+#  Transmittance Top Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n19_channels
+    action:
+      name: inflate error
+      inflation variable:
         name: ObsFunction/ObsErrorFactorTransmitTopRad
         channels: *avhrr3_n19_channels
         options:
           channels: *avhrr3_n19_channels
-      obserr_bound_max: [ 6.0, 6.0, 6.0 ]
-  action:
-    name: reject
-#  Useflag Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *avhrr3_n19_channels
-  test variables:
-  - name: ObsFunction/ChannelUseflagCheckRad
-    channels: *avhrr3_n19_channels
-    options:
+#  Cloud Detection Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *avhrr3_n19_channels
-      use_flag: [ 1,  1,  1 ]
-  minvalue: 1.0e-12
-  action:
-    name: reject
-
+    test variables:
+    - name: ObsFunction/CloudDetectMinResidualAVHRR
+      channels: *avhrr3_n19_channels
+      options:
+        channels: *avhrr3_n19_channels
+        use_flag: &useflag_avhrr3_n19 [ -1,  1,  1 ]
+        use_flag_clddet: [ 1,  1,  1 ]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  NSST Retrieval Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n19_channels
+    test variables:
+    - name: ObsFunction/NearSSTRetCheckIR
+      channels: *avhrr3_n19_channels
+      options:
+        channels: *avhrr3_n19_channels
+        use_flag: *useflag_avhrr3_n19
+        obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  Surface Jacobians Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n19_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
+        channels: *avhrr3_n19_channels
+        options:
+          channels: *avhrr3_n19_channels
+          sensor: *Sensor_ID
+          obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+          obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
+#  Gross check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n19_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundIR
+      channels: *avhrr3_n19_channels
+      options:
+        channels: *avhrr3_n19_channels
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [25.0, 0.5, 0.04, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *avhrr3_n19_channels
+          options:
+            channels: *avhrr3_n19_channels
+        obserr_bound_max: [ 3.0, 3.0, 3.0 ]
+    action:
+      name: reject
+#  Useflag Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *avhrr3_n19_channels
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *avhrr3_n19_channels
+      options:
+        channels: *avhrr3_n19_channels
+        use_flag: *useflag_avhrr3_n19
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
@@ -1,81 +1,83 @@
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3,CO2]
-  linear obs operator:
+  obs operator:
+    name: CRTM
+    Absorbers: [H2O,O3,CO2]
+    linear obs operator:
       Absorbers: [H2O,O3,CO2]
-  obs options:
-    Sensor_ID: &Sensor_ID cris-fsr_n20
-    EndianType: little_endian
-    CoefficientPath: '{{crtm_coeff_dir}}'
-obs space:
-  name: *Sensor_ID
-  obsdatain:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/cris-fsr_n20.{{window_begin}}.nc4'
-  obsdataout:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.cris-fsr_n20.{{window_begin}}.nc4'
-  simulated variables: [brightnessTemperature]
-  channels: &cris-fsr_n20_channels 19, 24, 26, 27, 28, 31, 32, 33, 37, 39, 42, 44, 47, 49, 50,
-            51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
-            69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
-            87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103,
-            104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
-            118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
-            132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145,
-            146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
-            160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173,
-            174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187,
-            188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 208,
-            211, 216, 224, 234, 236, 238, 239, 242, 246, 248, 255, 264, 266, 268,
-            275, 279, 283, 285, 291, 295, 301, 305, 311, 332, 342, 389, 400, 402,
-            404, 406, 410, 427, 439, 440, 441, 445, 449, 455, 458, 461, 464, 467,
-            470, 473, 475, 482, 486, 487, 490, 493, 496, 499, 501, 503, 505, 511,
-            513, 514, 518, 519, 520, 522, 529, 534, 563, 568, 575, 592, 594, 596,
-            598, 600, 602, 604, 611, 614, 616, 618, 620, 622, 626, 631, 638, 646,
-            648, 652, 659, 673, 675, 678, 684, 688, 694, 700, 707, 710, 713, 714,
-            718, 720, 722, 725, 728, 735, 742, 748, 753, 762, 780, 784, 798, 849,
-            860, 862, 866, 874, 882, 890, 898, 906, 907, 908, 914, 937, 972, 973,
-            978, 980, 981, 988, 995, 998, 1000, 1003, 1008, 1009, 1010, 1014, 1017,
-            1018, 1020, 1022, 1024, 1026, 1029, 1030, 1032, 1034, 1037, 1038, 1041,
-            1042, 1044, 1046, 1049, 1050, 1053, 1054, 1058, 1060, 1062, 1064, 1066,
-            1069, 1076, 1077, 1080, 1086, 1091, 1095, 1101, 1109, 1112, 1121, 1128,
-            1133, 1163, 1172, 1187, 1189, 1205, 1211, 1219, 1231, 1245, 1271, 1289,
-            1300, 1313, 1316, 1325, 1329, 1346, 1347, 1473, 1474, 1491, 1499, 1553,
-            1570, 1596, 1602, 1619, 1624, 1635, 1939, 1940, 1941, 1942, 1943, 1944,
-            1945, 1946, 1947, 1948, 1949, 1950, 1951, 1952, 1953, 1954, 1955, 1956,
-            1957, 1958, 1959, 1960, 1961, 1962, 1963, 1964, 1965, 1966, 1967, 1968,
-            1969, 1970, 1971, 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979, 1980,
-            1981, 1982, 1983, 1984, 1985, 1986, 1987, 2119, 2140, 2143, 2147, 2153,
-            2158, 2161, 2168, 2171, 2175, 2182
-obs bias:
-  input file: '{{cycle_dir}}/cris-fsr_n20.{{background_time}}.satbias.nc4'
-  variational bc:
-    predictors:
-    - name: constant
-    - name: lapse_rate
-      order: 2
-      tlapse: &cris-fsr_n20_tlapse '{{cycle_dir}}/cris-fsr_n20.{{background_time}}.tlapse.txt'
-    - name: lapse_rate
-      tlapse: *cris-fsr_n20_tlapse
-    - name: emissivity
-    - name: scan_angle
-      order: 4
-    - name: scan_angle
-      order: 3
-    - name: scan_angle
-      order: 2
-    - name: scan_angle
-obs filters:
-- filter: Perform Action
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  action:
-    name: assign error
-    error parameter vector: [ 0.8230, 0.7600, 0.7360, 0.7430, 0.8560, 1.0790, 0.8880, 0.7780, 0.6710, 0.6500,
+#    SurfaceWindGeoVars: uv
+    obs options:
+      Sensor_ID: &Sensor_ID cris-fsr_n20
+      EndianType: little_endian
+      CoefficientPath: '{{crtm_coeff_dir}}'
+  obs space:
+    name: *Sensor_ID
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/cris-fsr_n20.{{window_begin}}.nc4'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/{{experiment_id}}.cris-fsr_n20.{{window_begin}}.nc4'
+    simulated variables: [brightnessTemperature]
+    channels: &cris-fsr_n20_channels
+              19, 24, 26, 27, 28, 31, 32, 33, 37, 39, 42, 44, 47, 49, 50,
+              51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
+              69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
+              87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103,
+              104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+              118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
+              132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145,
+              146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
+              160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173,
+              174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187,
+              188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 208,
+              211, 216, 224, 234, 236, 238, 239, 242, 246, 248, 255, 264, 266, 268,
+              275, 279, 283, 285, 291, 295, 301, 305, 311, 332, 342, 389, 400, 402,
+              404, 406, 410, 427, 439, 440, 441, 445, 449, 455, 458, 461, 464, 467,
+              470, 473, 475, 482, 486, 487, 490, 493, 496, 499, 501, 503, 505, 511,
+              513, 514, 518, 519, 520, 522, 529, 534, 563, 568, 575, 592, 594, 596,
+              598, 600, 602, 604, 611, 614, 616, 618, 620, 622, 626, 631, 638, 646,
+              648, 652, 659, 673, 675, 678, 684, 688, 694, 700, 707, 710, 713, 714,
+              718, 720, 722, 725, 728, 735, 742, 748, 753, 762, 780, 784, 798, 849,
+              860, 862, 866, 874, 882, 890, 898, 906, 907, 908, 914, 937, 972, 973,
+              978, 980, 981, 988, 995, 998, 1000, 1003, 1008, 1009, 1010, 1014, 1017,
+              1018, 1020, 1022, 1024, 1026, 1029, 1030, 1032, 1034, 1037, 1038, 1041,
+              1042, 1044, 1046, 1049, 1050, 1053, 1054, 1058, 1060, 1062, 1064, 1066,
+              1069, 1076, 1077, 1080, 1086, 1091, 1095, 1101, 1109, 1112, 1121, 1128,
+              1133, 1163, 1172, 1187, 1189, 1205, 1211, 1219, 1231, 1245, 1271, 1289,
+              1300, 1313, 1316, 1325, 1329, 1346, 1347, 1473, 1474, 1491, 1499, 1553,
+              1570, 1596, 1602, 1619, 1624, 1635, 1939, 1940, 1941, 1942, 1943, 1944,
+              1945, 1946, 1947, 1948, 1949, 1950, 1951, 1952, 1953, 1954, 1955, 1956,
+              1957, 1958, 1959, 1960, 1961, 1962, 1963, 1964, 1965, 1966, 1967, 1968,
+              1969, 1970, 1971, 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979, 1980,
+              1981, 1982, 1983, 1984, 1985, 1986, 1987, 2119, 2140, 2143, 2147, 2153,
+              2158, 2161, 2168, 2171, 2175, 2182
+  obs bias:
+    input file: '{{cycle_dir}}/cris-fsr_n20.{{background_time}}.satbias.nc4'
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &cris-fsr_n20_tlapse '{{cycle_dir}}/cris-fsr_n20.{{background_time}}.tlapse.txt'
+      - name: lapse_rate
+        tlapse: *cris-fsr_n20_tlapse
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+  obs filters:
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_n20_channels
+    action:
+      name: assign error
+      error parameter vector: [ 0.8230, 0.7600, 0.7360, 0.7430, 0.8560, 1.0790, 0.8880, 0.7780, 0.6710, 0.6500,
                    0.6430, 0.6290, 0.6290, 0.6180, 0.6380, 0.6190, 0.6100, 0.6270, 0.6010, 0.6170,
                    0.6080, 0.4980, 0.5112, 0.4922, 0.4959, 0.4954, 0.4836, 0.5140, 0.5005, 0.4917,
                    0.4881, 0.4656, 0.4793, 0.4638, 0.4557, 0.4666, 0.4468, 0.4534, 0.4471, 0.4448,
@@ -119,306 +121,317 @@ obs filters:
                    0.7330, 0.7410, 0.7460, 0.7460, 0.7380, 0.7430, 0.7450, 0.7490, 0.7500, 0.7500,
                    0.8840, 0.9060, 0.9170, 0.9240, 0.9220, 0.9280, 0.9210, 0.9380, 0.9310, 0.9430,
                    0.9460 ]
-#  Wavenumber Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979, 1980, 1981,
-              1982, 1983, 1984, 1985, 1986, 1987, 2119, 2140, 2143, 2147,
-              2153, 2158, 2161, 2168, 2171, 2175, 2182
-  where:
-  - variable:
-      name: MetaData/solarZenithAngle
-    maxvalue: 88.9999
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    minvalue: 1.0e-12
-  action:
-    name: reject
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorWavenumIR
+  # # assign ObsError <---- ObsErrorData (Assigned in Yaml)
+  - filter: Variable Assignment
+    assignments:
+    - name: ObsError/brightnessTemperature
       channels: *cris-fsr_n20_channels
-      options:
-        channels: *cris-fsr_n20_channels
-#  Observation Range Sanity Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  minvalue: 50.00001
-  maxvalue: 549.99999
-  action:
-    name: reject
-#  Topography Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTopoRad
-      channels: *cris-fsr_n20_channels
-      options:
-        channels: *cris-fsr_n20_channels
-        sensor: *Sensor_ID
-#  Transmittance Top Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTransmitTopRad
-      channels: *cris-fsr_n20_channels
-      options:
-        channels: *cris-fsr_n20_channels
-#  Cloud Detection Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  test variables:
-  - name: ObsFunction/CloudDetectMinResidualIR
-    channels: *cris-fsr_n20_channels
-    options:
-      channels: *cris-fsr_n20_channels
-      use_flag: &useflag_cris-fsr_n20 [ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
-                            1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
-                            1, -1,  1,  1, -1,  1,  1, -1,  1, -1,
-                            1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
-                            1,  1, -1,  1,  1,  1,  1,  1,  1, -1,
-                            1,  1,  1,  1, -1,  1,  1,  1,  1, -1,
-                           -1, -1, -1, -1,  1,  1,  1,  1,  1, -1,
-                            1,  1,  1, -1,  1, -1, -1, -1, -1, -1,
-                            1, -1, -1, -1, -1,  1, -1, -1, -1, -1,
-                            1, -1, -1, -1, -1, -1,  1,  1, -1, -1,
-                           -1, -1,  1,  1, -1,  1, -1,  1,  1,  1,
-                            1,  1,  1,  1,  1,  1,  1,  1,  1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                            1,  1,  1,  1,  1,  1,  1,  1, -1,  1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1,  1,  1,  1, -1,  1,  1,  1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1,  1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1,  1, -1, -1,  1,
-                           -1, -1,  1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1,  1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1,  1,  1, -1, -1, -1, -1, -1, -1,  1,
-                           -1, -1, -1, -1, -1, -1,  1, -1, -1, -1,
-                            1, -1, -1, -1, -1, -1, -1,  1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1,  1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1]
-      use_flag_clddet: &clddet_cris-fsr_n20 [ 31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 30,
-                           30, 30, 31, 31, 30, 31, 30, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           31, 31, 31, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 31, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 31, 30, 30, 31,
-                           30, 30, 31, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 31, 30, 30, 30, 30, 30, 30, 31,
-                           30, 30, 30, 30, 30, 30, 31, 30, 30, 30,
-                           31, 30, 30, 30, 30, 30, 30, 31, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 31, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30 ]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-# Surface Temperature Jacobian Check over Land
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  where:
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    maxvalue: 0.99
-  test variables:
-  - name: ObsDiag/brightnessTemperature_jacobian_surface_temperature
-    channels: *cris-fsr_n20_channels
-  maxvalue: 0.2
-#  NSST Retrieval Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  test variables:
-  - name: ObsFunction/NearSSTRetCheckIR
-    channels: *cris-fsr_n20_channels
-    options:
-      channels: *cris-fsr_n20_channels
-      use_flag: *useflag_cris-fsr_n20
-      obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  Surface Jacobians Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
-      channels: *cris-fsr_n20_channels
-      options:
-        channels: *cris-fsr_n20_channels
-        sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
-        obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
-#  Gross check
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  function absolute threshold:
-  - name: ObsFunction/ObsErrorBoundIR
-    channels: *cris-fsr_n20_channels
-    options:
-      channels: *cris-fsr_n20_channels
-      obserr_bound_latitude:
-        name: ObsFunction/ObsErrorFactorLatRad
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
         options:
-          latitude_parameters: [25.0, 0.5, 0.04, 1.0]
-      obserr_bound_transmittop:
+          variables:
+          - name: ObsErrorData/brightnessTemperature
+            channels: *cris-fsr_n20_channels
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979, 1980, 1981,
+                1982, 1983, 1984, 1985, 1986, 1987, 2119, 2140, 2143, 2147,
+                2153, 2158, 2161, 2168, 2171, 2175, 2182
+    where:
+    - variable:
+        name: MetaData/solarZenithAngle
+      maxvalue: 88.9999
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0e-12
+    action:
+      name: reject
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_n20_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorWavenumIR
+        channels: *cris-fsr_n20_channels
+        options:
+          channels: *cris-fsr_n20_channels
+#  Observation Range Sanity Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_n20_channels
+    minvalue: 50.00001
+    maxvalue: 549.99999
+    action:
+      name: reject
+#  Topography Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_n20_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
+        channels: *cris-fsr_n20_channels
+        options:
+          channels: *cris-fsr_n20_channels
+          sensor: *Sensor_ID
+#  Transmittance Top Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_n20_channels
+    action:
+      name: inflate error
+      inflation variable:
         name: ObsFunction/ObsErrorFactorTransmitTopRad
         channels: *cris-fsr_n20_channels
         options:
           channels: *cris-fsr_n20_channels
-      obserr_bound_max: [ 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4,
-                          0.4, 2.0, 0.4, 0.4, 2.0, 0.4, 0.4, 2.0, 0.4, 2.0,
-                          0.4, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 0.4, 0.4, 0.4, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 2.0, 1.0,
-                          2.0, 2.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0 ]
-  action:
-    name: reject
+#  Cloud Detection Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_n20_channels
+    test variables:
+    - name: ObsFunction/CloudDetectMinResidualIR
+      channels: *cris-fsr_n20_channels
+      options:
+        channels: *cris-fsr_n20_channels
+        use_flag: &useflag_cris-fsr_n20 [ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+                              1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+                              1, -1,  1,  1, -1,  1,  1, -1,  1, -1,
+                              1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+                              1,  1, -1,  1,  1,  1,  1,  1,  1, -1,
+                              1,  1,  1,  1, -1,  1,  1,  1,  1, -1,
+                             -1, -1, -1, -1,  1,  1,  1,  1,  1, -1,
+                              1,  1,  1, -1,  1, -1, -1, -1, -1, -1,
+                              1, -1, -1, -1, -1,  1, -1, -1, -1, -1,
+                              1, -1, -1, -1, -1, -1,  1,  1, -1, -1,
+                             -1, -1,  1,  1, -1,  1, -1,  1,  1,  1,
+                              1,  1,  1,  1,  1,  1,  1,  1,  1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                              1,  1,  1,  1,  1,  1,  1,  1, -1,  1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1,  1,  1,  1, -1,  1,  1,  1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1,  1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1,  1, -1, -1,  1,
+                             -1, -1,  1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1,  1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1,  1,  1, -1, -1, -1, -1, -1, -1,  1,
+                             -1, -1, -1, -1, -1, -1,  1, -1, -1, -1,
+                              1, -1, -1, -1, -1, -1, -1,  1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1,  1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1]
+        use_flag_clddet: &clddet_cris-fsr_n20 [ 31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 30,
+                             30, 30, 31, 31, 30, 31, 30, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             31, 31, 31, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 31, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 31, 30, 30, 31,
+                             30, 30, 31, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 31, 30, 30, 30, 30, 30, 30, 31,
+                             30, 30, 30, 30, 30, 30, 31, 30, 30, 30,
+                             31, 30, 30, 30, 30, 30, 30, 31, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 31, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30 ]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+# Surface Temperature Jacobian Check over Land
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_n20_channels
+    where:
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      maxvalue: 0.99
+    test variables:
+    - name: ObsDiag/brightness_temperature_jacobian_surface_temperature
+      channels: *cris-fsr_n20_channels
+    maxvalue: 0.2
+#  NSST Retrieval Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_n20_channels
+    test variables:
+    - name: ObsFunction/NearSSTRetCheckIR
+      channels: *cris-fsr_n20_channels
+      options:
+        channels: *cris-fsr_n20_channels
+        use_flag: *useflag_cris-fsr_n20
+        obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  Surface Jacobians Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_n20_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
+        channels: *cris-fsr_n20_channels
+        options:
+          channels: *cris-fsr_n20_channels
+          sensor: *Sensor_ID
+          obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+          obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
+#  Gross check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_n20_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundIR
+      channels: *cris-fsr_n20_channels
+      options:
+        channels: *cris-fsr_n20_channels
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [25.0, 0.5, 0.04, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *cris-fsr_n20_channels
+          options:
+            channels: *cris-fsr_n20_channels
+        obserr_bound_max: [ 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4,
+                            0.4, 2.0, 0.4, 0.4, 2.0, 0.4, 0.4, 2.0, 0.4, 2.0,
+                            0.4, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 0.4, 0.4, 0.4, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 2.0, 1.0,
+                            2.0, 2.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0 ]
+    action:
+      name: reject
 #  Surface Type Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  test variables:
-  - name: SurfTypeCheckRad@ObsFunction
-    channels: *cris-fsr_n20_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *cris-fsr_n20_channels
-      use_flag: *useflag_cris-fsr_n20
-      use_flag_clddet: *clddet_cris-fsr_n20
-  maxvalue: 1.0e-12
-  defer to post: true
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/SurfTypeCheckRad
+      channels: *cris-fsr_n20_channels
+      options:
+        channels: *cris-fsr_n20_channels
+        use_flag: *useflag_cris-fsr_n20
+        use_flag_clddet: *clddet_cris-fsr_n20
+    maxvalue: 1.0e-12
+    defer to post: true
+    action:
+      name: reject
 #  Useflag Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_n20_channels
-  test variables:
-  - name: ObsFunction/ChannelUseflagCheckRad
-    channels: *cris-fsr_n20_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *cris-fsr_n20_channels
-      use passive_bc: true
-      use_flag: *useflag_cris-fsr_n20
-  minvalue: 1.0e-12
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *cris-fsr_n20_channels
+      options:
+        channels: *cris-fsr_n20_channels
+#        use passive_bc: true
+        use_flag: *useflag_cris-fsr_n20
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
@@ -1,81 +1,83 @@
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3,CO2]
-  linear obs operator:
+  obs operator:
+    name: CRTM
+    Absorbers: [H2O,O3,CO2]
+    linear obs operator:
       Absorbers: [H2O,O3,CO2]
-  obs options:
-    Sensor_ID: &Sensor_ID cris-fsr_npp
-    EndianType: little_endian
-    CoefficientPath: '{{crtm_coeff_dir}}'
-obs space:
-  name: *Sensor_ID
-  obsdatain:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/cris-fsr_npp.{{window_begin}}.nc4'
-  obsdataout:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.cris-fsr_npp.{{window_begin}}.nc4'
-  simulated variables: [brightnessTemperature]
-  channels: &cris-fsr_npp_channels 19, 24, 26, 27, 28, 31, 32, 33, 37, 39, 42, 44, 47, 49, 50,
-            51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
-            69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
-            87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103,
-            104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
-            118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
-            132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145,
-            146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
-            160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173,
-            174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187,
-            188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 208,
-            211, 216, 224, 234, 236, 238, 239, 242, 246, 248, 255, 264, 266, 268,
-            275, 279, 283, 285, 291, 295, 301, 305, 311, 332, 342, 389, 400, 402,
-            404, 406, 410, 427, 439, 440, 441, 445, 449, 455, 458, 461, 464, 467,
-            470, 473, 475, 482, 486, 487, 490, 493, 496, 499, 501, 503, 505, 511,
-            513, 514, 518, 519, 520, 522, 529, 534, 563, 568, 575, 592, 594, 596,
-            598, 600, 602, 604, 611, 614, 616, 618, 620, 622, 626, 631, 638, 646,
-            648, 652, 659, 673, 675, 678, 684, 688, 694, 700, 707, 710, 713, 714,
-            718, 720, 722, 725, 728, 735, 742, 748, 753, 762, 780, 784, 798, 849,
-            860, 862, 866, 874, 882, 890, 898, 906, 907, 908, 914, 937, 972, 973,
-            978, 980, 981, 988, 995, 998, 1000, 1003, 1008, 1009, 1010, 1014, 1017,
-            1018, 1020, 1022, 1024, 1026, 1029, 1030, 1032, 1034, 1037, 1038, 1041,
-            1042, 1044, 1046, 1049, 1050, 1053, 1054, 1058, 1060, 1062, 1064, 1066,
-            1069, 1076, 1077, 1080, 1086, 1091, 1095, 1101, 1109, 1112, 1121, 1128,
-            1133, 1163, 1172, 1187, 1189, 1205, 1211, 1219, 1231, 1245, 1271, 1289,
-            1300, 1313, 1316, 1325, 1329, 1346, 1347, 1473, 1474, 1491, 1499, 1553,
-            1570, 1596, 1602, 1619, 1624, 1635, 1939, 1940, 1941, 1942, 1943, 1944,
-            1945, 1946, 1947, 1948, 1949, 1950, 1951, 1952, 1953, 1954, 1955, 1956,
-            1957, 1958, 1959, 1960, 1961, 1962, 1963, 1964, 1965, 1966, 1967, 1968,
-            1969, 1970, 1971, 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979, 1980,
-            1981, 1982, 1983, 1984, 1985, 1986, 1987, 2119, 2140, 2143, 2147, 2153,
-            2158, 2161, 2168, 2171, 2175, 2182
-obs bias:
-  input file: '{{cycle_dir}}/cris-fsr_npp.{{background_time}}.satbias.nc4'
-  variational bc:
-    predictors:
-    - name: constant
-    - name: lapse_rate
-      order: 2
-      tlapse: &cris-fsr_npp_tlapse '{{cycle_dir}}/cris-fsr_npp.{{background_time}}.tlapse.txt'
-    - name: lapse_rate
-      tlapse: *cris-fsr_npp_tlapse
-    - name: emissivity
-    - name: scan_angle
-      order: 4
-    - name: scan_angle
-      order: 3
-    - name: scan_angle
-      order: 2
-    - name: scan_angle
-obs filters:
-- filter: Perform Action
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  action:
-    name: assign error
-    error parameter vector: [ 0.8230, 0.7600, 0.7360, 0.7430, 0.8560, 1.0790, 0.8880, 0.7780, 0.6710, 0.6500,
+#    SurfaceWindGeoVars: uv
+    obs options:
+      Sensor_ID: &Sensor_ID cris-fsr_npp
+      EndianType: little_endian
+      CoefficientPath: '{{crtm_coeff_dir}}'
+  obs space:
+    name: *Sensor_ID
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/cris-fsr_npp.{{window_begin}}.nc4'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/{{experiment_id}}.cris-fsr_npp.{{window_begin}}.nc4'
+    simulated variables: [brightnessTemperature]
+    channels: &cris-fsr_npp_channels
+              19, 24, 26, 27, 28, 31, 32, 33, 37, 39, 42, 44, 47, 49, 50,
+              51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
+              69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86,
+              87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103,
+              104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+              118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131,
+              132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145,
+              146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159,
+              160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173,
+              174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187,
+              188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 208,
+              211, 216, 224, 234, 236, 238, 239, 242, 246, 248, 255, 264, 266, 268,
+              275, 279, 283, 285, 291, 295, 301, 305, 311, 332, 342, 389, 400, 402,
+              404, 406, 410, 427, 439, 440, 441, 445, 449, 455, 458, 461, 464, 467,
+              470, 473, 475, 482, 486, 487, 490, 493, 496, 499, 501, 503, 505, 511,
+              513, 514, 518, 519, 520, 522, 529, 534, 563, 568, 575, 592, 594, 596,
+              598, 600, 602, 604, 611, 614, 616, 618, 620, 622, 626, 631, 638, 646,
+              648, 652, 659, 673, 675, 678, 684, 688, 694, 700, 707, 710, 713, 714,
+              718, 720, 722, 725, 728, 735, 742, 748, 753, 762, 780, 784, 798, 849,
+              860, 862, 866, 874, 882, 890, 898, 906, 907, 908, 914, 937, 972, 973,
+              978, 980, 981, 988, 995, 998, 1000, 1003, 1008, 1009, 1010, 1014, 1017,
+              1018, 1020, 1022, 1024, 1026, 1029, 1030, 1032, 1034, 1037, 1038, 1041,
+              1042, 1044, 1046, 1049, 1050, 1053, 1054, 1058, 1060, 1062, 1064, 1066,
+              1069, 1076, 1077, 1080, 1086, 1091, 1095, 1101, 1109, 1112, 1121, 1128,
+              1133, 1163, 1172, 1187, 1189, 1205, 1211, 1219, 1231, 1245, 1271, 1289,
+              1300, 1313, 1316, 1325, 1329, 1346, 1347, 1473, 1474, 1491, 1499, 1553,
+              1570, 1596, 1602, 1619, 1624, 1635, 1939, 1940, 1941, 1942, 1943, 1944,
+              1945, 1946, 1947, 1948, 1949, 1950, 1951, 1952, 1953, 1954, 1955, 1956,
+              1957, 1958, 1959, 1960, 1961, 1962, 1963, 1964, 1965, 1966, 1967, 1968,
+              1969, 1970, 1971, 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979, 1980,
+              1981, 1982, 1983, 1984, 1985, 1986, 1987, 2119, 2140, 2143, 2147, 2153,
+              2158, 2161, 2168, 2171, 2175, 2182
+  obs bias:
+    input file: '{{cycle_dir}}/cris-fsr_npp.{{background_time}}.satbias.nc4'
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &cris-fsr_npp_tlapse '{{cycle_dir}}/cris-fsr_npp.{{background_time}}.tlapse.txt'
+      - name: lapse_rate
+        tlapse: *cris-fsr_npp_tlapse
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+  obs filters:
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_npp_channels
+    action:
+      name: assign error
+      error parameter vector: [ 0.8230, 0.7600, 0.7360, 0.7430, 0.8560, 1.0790, 0.8880, 0.7780, 0.6710, 0.6500,
                    0.6430, 0.6290, 0.6290, 0.6180, 0.6380, 0.6190, 0.6100, 0.6270, 0.6010, 0.6170,
                    0.6080, 0.4980, 0.5112, 0.4922, 0.4959, 0.4954, 0.4836, 0.5140, 0.5005, 0.4917,
                    0.4881, 0.4656, 0.4793, 0.4638, 0.4557, 0.4666, 0.4468, 0.4534, 0.4471, 0.4448,
@@ -119,306 +121,317 @@ obs filters:
                    0.7330, 0.7410, 0.7460, 0.7460, 0.7380, 0.7430, 0.7450, 0.7490, 0.7500, 0.7500,
                    0.8840, 0.9060, 0.9170, 0.9240, 0.9220, 0.9280, 0.9210, 0.9380, 0.9310, 0.9430,
                    0.9460 ]
-#  Wavenumber Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979, 1980, 1981,
-              1982, 1983, 1984, 1985, 1986, 1987, 2119, 2140, 2143, 2147,
-              2153, 2158, 2161, 2168, 2171, 2175, 2182
-  where:
-  - variable:
-      name: MetaData/solarZenithAngle
-    maxvalue: 88.9999
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    minvalue: 1.0e-12
-  action:
-    name: reject
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorWavenumIR
+  # # assign ObsError <---- ObsErrorData (Assigned in Yaml)
+  - filter: Variable Assignment
+    assignments:
+    - name: ObsError/brightnessTemperature
       channels: *cris-fsr_npp_channels
-      options:
-        channels: *cris-fsr_npp_channels
-#  Observation Range Sanity Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  minvalue: 50.00001
-  maxvalue: 549.99999
-  action:
-    name: reject
-#  Topography Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTopoRad
-      channels: *cris-fsr_npp_channels
-      options:
-        channels: *cris-fsr_npp_channels
-        sensor: *Sensor_ID
-#  Transmittance Top Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTransmitTopRad
-      channels: *cris-fsr_npp_channels
-      options:
-        channels: *cris-fsr_npp_channels
-#  Cloud Detection Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  test variables:
-  - name: ObsFunction/CloudDetectMinResidualIR
-    channels: *cris-fsr_npp_channels
-    options:
-      channels: *cris-fsr_npp_channels
-      use_flag: &useflag_cris-fsr_npp [ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
-                            1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
-                            1, -1,  1,  1, -1,  1,  1, -1,  1, -1,
-                            1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
-                            1,  1, -1,  1,  1,  1,  1,  1,  1, -1,
-                            1,  1,  1,  1, -1,  1,  1,  1,  1, -1,
-                           -1, -1, -1, -1,  1,  1,  1,  1,  1, -1,
-                            1,  1,  1, -1,  1, -1, -1, -1, -1, -1,
-                            1, -1, -1, -1, -1,  1, -1, -1, -1, -1,
-                            1, -1, -1, -1, -1, -1,  1,  1, -1, -1,
-                           -1, -1,  1,  1, -1,  1, -1,  1,  1,  1,
-                            1,  1,  1,  1,  1,  1,  1,  1,  1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                            1,  1,  1,  1,  1,  1,  1,  1, -1,  1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1,  1,  1,  1, -1,  1,  1,  1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1,  1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1,  1, -1, -1,  1,
-                           -1, -1,  1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1,  1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1,  1,  1, -1, -1, -1, -1, -1, -1,  1,
-                           -1, -1, -1, -1, -1, -1,  1, -1, -1, -1,
-                            1, -1, -1, -1, -1, -1, -1,  1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1,  1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           -1]
-      use_flag_clddet: &clddet_cris-fsr_npp [ 31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 30,
-                           30, 30, 31, 31, 30, 31, 30, 31, 31, 31,
-                           31, 31, 31, 31, 31, 31, 31, 31, 31, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           31, 31, 31, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 31, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 31, 30, 30, 31,
-                           30, 30, 31, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 31, 30, 30, 30, 30, 30, 30, 31,
-                           30, 30, 30, 30, 30, 30, 31, 30, 30, 30,
-                           31, 30, 30, 30, 30, 30, 30, 31, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 31, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
-                           30 ]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-# Surface Temperature Jacobian Check over Land
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  where:
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    maxvalue: 0.99
-  test variables:
-  - name: ObsDiag/brightnessTemperature_jacobian_surface_temperature
-    channels: *cris-fsr_npp_channels
-  maxvalue: 0.2
-#  NSST Retrieval Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  test variables:
-  - name: ObsFunction/NearSSTRetCheckIR
-    channels: *cris-fsr_npp_channels
-    options:
-      channels: *cris-fsr_npp_channels
-      use_flag: *useflag_cris-fsr_npp
-      obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  Surface Jacobians Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
-      channels: *cris-fsr_npp_channels
-      options:
-        channels: *cris-fsr_npp_channels
-        sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
-        obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
-#  Gross check
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  function absolute threshold:
-  - name: ObsFunction/ObsErrorBoundIR
-    channels: *cris-fsr_npp_channels
-    options:
-      channels: *cris-fsr_npp_channels
-      obserr_bound_latitude:
-        name: ObsFunction/ObsErrorFactorLatRad
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
         options:
-          latitude_parameters: [25.0, 0.5, 0.04, 1.0]
-      obserr_bound_transmittop:
+          variables:
+          - name: ObsErrorData/brightnessTemperature
+            channels: *cris-fsr_npp_channels
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979, 1980, 1981,
+                1982, 1983, 1984, 1985, 1986, 1987, 2119, 2140, 2143, 2147,
+                2153, 2158, 2161, 2168, 2171, 2175, 2182
+    where:
+    - variable:
+        name: MetaData/solarZenithAngle
+      maxvalue: 88.9999
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0e-12
+    action:
+      name: reject
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_npp_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorWavenumIR
+        channels: *cris-fsr_npp_channels
+        options:
+          channels: *cris-fsr_npp_channels
+#  Observation Range Sanity Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_npp_channels
+    minvalue: 50.00001
+    maxvalue: 549.99999
+    action:
+      name: reject
+#  Topography Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_npp_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
+        channels: *cris-fsr_npp_channels
+        options:
+          channels: *cris-fsr_npp_channels
+          sensor: *Sensor_ID
+#  Transmittance Top Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_npp_channels
+    action:
+      name: inflate error
+      inflation variable:
         name: ObsFunction/ObsErrorFactorTransmitTopRad
         channels: *cris-fsr_npp_channels
         options:
           channels: *cris-fsr_npp_channels
-      obserr_bound_max: [ 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4,
-                          0.4, 2.0, 0.4, 0.4, 2.0, 0.4, 0.4, 2.0, 0.4, 2.0,
-                          0.4, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 0.4, 0.4, 0.4, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 2.0, 1.0,
-                          2.0, 2.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
-                          2.0 ]
-  action:
-    name: reject
+#  Cloud Detection Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_npp_channels
+    test variables:
+    - name: ObsFunction/CloudDetectMinResidualIR
+      channels: *cris-fsr_npp_channels
+      options:
+        channels: *cris-fsr_npp_channels
+        use_flag: &useflag_cris-fsr_npp [ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+                              1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+                              1, -1,  1,  1, -1,  1,  1, -1,  1, -1,
+                              1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+                              1,  1, -1,  1,  1,  1,  1,  1,  1, -1,
+                              1,  1,  1,  1, -1,  1,  1,  1,  1, -1,
+                             -1, -1, -1, -1,  1,  1,  1,  1,  1, -1,
+                              1,  1,  1, -1,  1, -1, -1, -1, -1, -1,
+                              1, -1, -1, -1, -1,  1, -1, -1, -1, -1,
+                              1, -1, -1, -1, -1, -1,  1,  1, -1, -1,
+                             -1, -1,  1,  1, -1,  1, -1,  1,  1,  1,
+                              1,  1,  1,  1,  1,  1,  1,  1,  1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                              1,  1,  1,  1,  1,  1,  1,  1, -1,  1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1,  1,  1,  1, -1,  1,  1,  1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1,  1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1,  1, -1, -1,  1,
+                             -1, -1,  1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1,  1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1,  1,  1, -1, -1, -1, -1, -1, -1,  1,
+                             -1, -1, -1, -1, -1, -1,  1, -1, -1, -1,
+                              1, -1, -1, -1, -1, -1, -1,  1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1,  1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                             -1]
+        use_flag_clddet: &clddet_cris-fsr_npp [ 31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 30,
+                             30, 30, 31, 31, 30, 31, 30, 31, 31, 31,
+                             31, 31, 31, 31, 31, 31, 31, 31, 31, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             31, 31, 31, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 31, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 31, 30, 30, 31,
+                             30, 30, 31, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 31, 30, 30, 30, 30, 30, 30, 31,
+                             30, 30, 30, 30, 30, 30, 31, 30, 30, 30,
+                             31, 30, 30, 30, 30, 30, 30, 31, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 31, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+                             30 ]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+# Surface Temperature Jacobian Check over Land
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_npp_channels
+    where:
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      maxvalue: 0.99
+    test variables:
+    - name: ObsDiag/brightness_temperature_jacobian_surface_temperature
+      channels: *cris-fsr_npp_channels
+    maxvalue: 0.2
+#  NSST Retrieval Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_npp_channels
+    test variables:
+    - name: ObsFunction/NearSSTRetCheckIR
+      channels: *cris-fsr_npp_channels
+      options:
+        channels: *cris-fsr_npp_channels
+        use_flag: *useflag_cris-fsr_npp
+        obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  Surface Jacobians Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_npp_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
+        channels: *cris-fsr_npp_channels
+        options:
+          channels: *cris-fsr_npp_channels
+          sensor: *Sensor_ID
+          obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+          obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
+#  Gross check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *cris-fsr_npp_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundIR
+      channels: *cris-fsr_npp_channels
+      options:
+        channels: *cris-fsr_npp_channels
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [25.0, 0.5, 0.04, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *cris-fsr_npp_channels
+          options:
+            channels: *cris-fsr_npp_channels
+        obserr_bound_max: [ 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4,
+                            0.4, 2.0, 0.4, 0.4, 2.0, 0.4, 0.4, 2.0, 0.4, 2.0,
+                            0.4, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 0.4, 0.4, 0.4, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 2.0, 2.0, 1.0,
+                            2.0, 2.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                            2.0 ]
+    action:
+      name: reject
 #  Surface Type Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  test variables:
-  - name: SurfTypeCheckRad@ObsFunction
-    channels: *cris-fsr_npp_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *cris-fsr_npp_channels
-      use_flag: *useflag_cris-fsr_npp
-      use_flag_clddet: *clddet_cris-fsr_npp
-  maxvalue: 1.0e-12
-  defer to post: true
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/SurfTypeCheckRad
+      channels: *cris-fsr_npp_channels
+      options:
+        channels: *cris-fsr_npp_channels
+        use_flag: *useflag_cris-fsr_npp
+        use_flag_clddet: *clddet_cris-fsr_npp
+    maxvalue: 1.0e-12
+    defer to post: true
+    action:
+      name: reject
 #  Useflag Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *cris-fsr_npp_channels
-  test variables:
-  - name: ObsFunction/ChannelUseflagCheckRad
-    channels: *cris-fsr_npp_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *cris-fsr_npp_channels
-      use passive_bc: true
-      use_flag: *useflag_cris-fsr_npp
-  minvalue: 1.0e-12
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *cris-fsr_npp_channels
+      options:
+        channels: *cris-fsr_npp_channels
+#        use passive_bc: true
+        use_flag: *useflag_cris-fsr_npp
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-a.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-a.yaml
@@ -1,98 +1,99 @@
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3,CO2]
-  linear obs operator:
+  obs operator:
+    name: CRTM
     Absorbers: [H2O,O3,CO2]
-  obs options:
-    Sensor_ID: &Sensor_ID iasi_metop-a
-    EndianType: little_endian
-    CoefficientPath: '{{crtm_coeff_dir}}'
-obs space:
-  name: *Sensor_ID
-  obsdatain:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/iasi_metop-a.{{window_begin}}.nc4'
-  obsdataout:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.iasi_metop-a.{{window_begin}}.nc4'
-  simulated variables: [brightnessTemperature]
-  channels: &iasi_metop-a_channels 16, 29, 32, 35, 38, 41, 44, 47, 49, 50, 51, 53,
-            55, 56, 57, 59, 61, 62, 63, 66, 68, 70, 72, 74, 76, 78, 79, 81, 82, 83,
-            84, 85, 86, 87, 89, 92, 93, 95, 97, 99, 101, 103, 104, 106, 109, 110,
-            111, 113, 116, 119, 122, 125, 128, 131, 133, 135, 138, 141, 144, 146,
-            148, 150, 151, 154, 157, 159, 160, 161, 163, 167, 170, 173, 176, 179,
-            180, 185, 187, 191, 193, 197, 199, 200, 202, 203, 205, 207, 210, 212,
-            213, 214, 217, 218, 219, 222, 224, 225, 226, 228, 230, 231, 232, 236,
-            237, 239, 243, 246, 249, 252, 254, 259, 260, 262, 265, 267, 269, 275,
-            279, 282, 285, 294, 296, 299, 300, 303, 306, 309, 313, 320, 323, 326,
-            327, 329, 332, 335, 345, 347, 350, 354, 356, 360, 363, 366, 371, 372,
-            373, 375, 377, 379, 381, 383, 386, 389, 398, 401, 404, 405, 407, 408,
-            410, 411, 414, 416, 418, 423, 426, 428, 432, 433, 434, 439, 442, 445,
-            450, 457, 459, 472, 477, 483, 509, 515, 546, 552, 559, 566, 571, 573,
-            578, 584, 594, 625, 646, 662, 668, 705, 739, 756, 797, 867, 906, 921,
-            1027, 1046, 1090, 1098, 1121, 1133, 1173, 1191, 1194, 1222, 1271, 1283,
-            1338, 1409, 1414, 1420, 1424, 1427, 1430, 1434, 1440, 1442, 1445, 1450,
-            1454, 1460, 1463, 1469, 1474, 1479, 1483, 1487, 1494, 1496, 1502, 1505,
-            1509, 1510, 1513, 1518, 1521, 1526, 1529, 1532, 1536, 1537, 1541, 1545,
-            1548, 1553, 1560, 1568, 1574, 1579, 1583, 1585, 1587, 1606, 1626, 1639,
-            1643, 1652, 1658, 1659, 1666, 1671, 1675, 1681, 1694, 1697, 1710, 1786,
-            1791, 1805, 1839, 1884, 1913, 1946, 1947, 1991, 2019, 2094, 2119, 2213,
-            2239, 2271, 2289, 2321, 2333, 2346, 2349, 2352, 2359, 2367, 2374, 2398,
-            2426, 2562, 2701, 2741, 2745, 2760, 2819, 2889, 2907, 2910, 2919, 2921,
-            2939, 2944, 2945, 2948, 2951, 2958, 2971, 2977, 2985, 2988, 2990, 2991,
-            2993, 3002, 3008, 3014, 3027, 3029, 3030, 3036, 3047, 3049, 3052, 3053,
-            3055, 3058, 3064, 3069, 3087, 3093, 3098, 3105, 3107, 3110, 3116, 3127,
-            3129, 3136, 3146, 3151, 3160, 3165, 3168, 3175, 3178, 3189, 3207, 3228,
-            3244, 3248, 3252, 3256, 3263, 3281, 3295, 3303, 3309, 3312, 3322, 3326,
-            3354, 3366, 3375, 3378, 3411, 3416, 3432, 3438, 3440, 3442, 3444, 3446,
-            3448, 3450, 3452, 3454, 3458, 3467, 3476, 3484, 3491, 3497, 3499, 3504,
-            3506, 3509, 3518, 3527, 3555, 3575, 3577, 3580, 3582, 3586, 3589, 3599,
-            3610, 3626, 3638, 3646, 3653, 3658, 3661, 3673, 3689, 3700, 3710, 3726,
-            3763, 3814, 3841, 3888, 4032, 4059, 4068, 4082, 4095, 4160, 4234, 4257,
-            4411, 4498, 4520, 4552, 4567, 4608, 4646, 4698, 4808, 4849, 4920, 4939,
-            4947, 4967, 4991, 4996, 5015, 5028, 5056, 5128, 5130, 5144, 5170, 5178,
-            5183, 5188, 5191, 5368, 5371, 5379, 5381, 5383, 5397, 5399, 5401, 5403,
-            5405, 5446, 5455, 5472, 5480, 5483, 5485, 5492, 5497, 5502, 5507, 5509,
-            5517, 5528, 5558, 5697, 5714, 5749, 5766, 5785, 5798, 5799, 5801, 5817,
-            5833, 5834, 5836, 5849, 5851, 5852, 5865, 5869, 5881, 5884, 5897, 5900,
-            5916, 5932, 5948, 5963, 5968, 5978, 5988, 5992, 5994, 5997, 6003, 6008,
-            6023, 6026, 6039, 6053, 6056, 6067, 6071, 6082, 6085, 6098, 6112, 6126,
-            6135, 6140, 6149, 6154, 6158, 6161, 6168, 6174, 6182, 6187, 6205, 6209,
-            6213, 6317, 6339, 6342, 6366, 6381, 6391, 6489, 6962, 6966, 6970, 6975,
-            6977, 6982, 6985, 6987, 6989, 6991, 6993, 6995, 6997, 6999, 7000, 7004,
-            7008, 7013, 7016, 7021, 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049,
-            7069, 7072, 7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
-            7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431, 7436, 7444,
-            7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853, 7865, 7885, 7888, 7912,
-            7950, 7972, 7980, 7995, 8007, 8015, 8055, 8078
-obs bias:
-  input file: '{{cycle_dir}}/iasi_metop-a.{{background_time}}.satbias.nc4'
-  variational bc:
-    predictors:
-    - name: constant
-    - name: lapse_rate
-      order: 2
-      tlapse: &iasi_metop-a_tlapse '{{cycle_dir}}/iasi_metop-a.{{background_time}}.tlapse.txt'
-    - name: lapse_rate
-      tlapse: *iasi_metop-a_tlapse
-    - name: emissivity
-    - name: scan_angle
-      order: 4
-    - name: scan_angle
-      order: 3
-    - name: scan_angle
-      order: 2
-    - name: scan_angle
-obs filters:
-- filter: Perform Action
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-a_channels
-  action:
-    name: assign error
-    error parameter vector: [ 0.7270, 0.8100, 0.7500, 0.7900, 0.7055, 0.7400, 0.6800, 0.7200, 0.6526, 0.6500,
+    linear obs operator:
+      Absorbers: [H2O,O3,CO2]
+#    SurfaceWindGeoVars: uv
+    obs options:
+      Sensor_ID: &Sensor_ID iasi_metop-a
+      EndianType: little_endian
+      CoefficientPath: '{{crtm_coeff_dir}}'
+  obs space:
+    name: *Sensor_ID
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/iasi_metop-a.{{window_begin}}.nc4'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/{{experiment_id}}.iasi_metop-a.{{window_begin}}.nc4'
+    simulated variables: [brightnessTemperature]
+    channels: &iasi_metop-a_channels 16, 29, 32, 35, 38, 41, 44, 47, 49, 50, 51, 53,
+                            55, 56, 57, 59, 61, 62, 63, 66, 68, 70, 72, 74, 76, 78, 79, 81, 82, 83,
+                            84, 85, 86, 87, 89, 92, 93, 95, 97, 99, 101, 103, 104, 106, 109, 110,
+                            111, 113, 116, 119, 122, 125, 128, 131, 133, 135, 138, 141, 144, 146,
+                            148, 150, 151, 154, 157, 159, 160, 161, 163, 167, 170, 173, 176, 179,
+                            180, 185, 187, 191, 193, 197, 199, 200, 202, 203, 205, 207, 210, 212,
+                            213, 214, 217, 218, 219, 222, 224, 225, 226, 228, 230, 231, 232, 236,
+                            237, 239, 243, 246, 249, 252, 254, 259, 260, 262, 265, 267, 269, 275,
+                            279, 282, 285, 294, 296, 299, 300, 303, 306, 309, 313, 320, 323, 326,
+                            327, 329, 332, 335, 345, 347, 350, 354, 356, 360, 363, 366, 371, 372,
+                            373, 375, 377, 379, 381, 383, 386, 389, 398, 401, 404, 405, 407, 408,
+                            410, 411, 414, 416, 418, 423, 426, 428, 432, 433, 434, 439, 442, 445,
+                            450, 457, 459, 472, 477, 483, 509, 515, 546, 552, 559, 566, 571, 573,
+                            578, 584, 594, 625, 646, 662, 668, 705, 739, 756, 797, 867, 906, 921,
+                            1027, 1046, 1090, 1098, 1121, 1133, 1173, 1191, 1194, 1222, 1271, 1283,
+                            1338, 1409, 1414, 1420, 1424, 1427, 1430, 1434, 1440, 1442, 1445, 1450,
+                            1454, 1460, 1463, 1469, 1474, 1479, 1483, 1487, 1494, 1496, 1502, 1505,
+                            1509, 1510, 1513, 1518, 1521, 1526, 1529, 1532, 1536, 1537, 1541, 1545,
+                            1548, 1553, 1560, 1568, 1574, 1579, 1583, 1585, 1587, 1606, 1626, 1639,
+                            1643, 1652, 1658, 1659, 1666, 1671, 1675, 1681, 1694, 1697, 1710, 1786,
+                            1791, 1805, 1839, 1884, 1913, 1946, 1947, 1991, 2019, 2094, 2119, 2213,
+                            2239, 2271, 2289, 2321, 2333, 2346, 2349, 2352, 2359, 2367, 2374, 2398,
+                            2426, 2562, 2701, 2741, 2745, 2760, 2819, 2889, 2907, 2910, 2919, 2921,
+                            2939, 2944, 2945, 2948, 2951, 2958, 2971, 2977, 2985, 2988, 2990, 2991,
+                            2993, 3002, 3008, 3014, 3027, 3029, 3030, 3036, 3047, 3049, 3052, 3053,
+                            3055, 3058, 3064, 3069, 3087, 3093, 3098, 3105, 3107, 3110, 3116, 3127,
+                            3129, 3136, 3146, 3151, 3160, 3165, 3168, 3175, 3178, 3189, 3207, 3228,
+                            3244, 3248, 3252, 3256, 3263, 3281, 3295, 3303, 3309, 3312, 3322, 3326,
+                            3354, 3366, 3375, 3378, 3411, 3416, 3432, 3438, 3440, 3442, 3444, 3446,
+                            3448, 3450, 3452, 3454, 3458, 3467, 3476, 3484, 3491, 3497, 3499, 3504,
+                            3506, 3509, 3518, 3527, 3555, 3575, 3577, 3580, 3582, 3586, 3589, 3599,
+                            3610, 3626, 3638, 3646, 3653, 3658, 3661, 3673, 3689, 3700, 3710, 3726,
+                            3763, 3814, 3841, 3888, 4032, 4059, 4068, 4082, 4095, 4160, 4234, 4257,
+                            4411, 4498, 4520, 4552, 4567, 4608, 4646, 4698, 4808, 4849, 4920, 4939,
+                            4947, 4967, 4991, 4996, 5015, 5028, 5056, 5128, 5130, 5144, 5170, 5178,
+                            5183, 5188, 5191, 5368, 5371, 5379, 5381, 5383, 5397, 5399, 5401, 5403,
+                            5405, 5446, 5455, 5472, 5480, 5483, 5485, 5492, 5497, 5502, 5507, 5509,
+                            5517, 5528, 5558, 5697, 5714, 5749, 5766, 5785, 5798, 5799, 5801, 5817,
+                            5833, 5834, 5836, 5849, 5851, 5852, 5865, 5869, 5881, 5884, 5897, 5900,
+                            5916, 5932, 5948, 5963, 5968, 5978, 5988, 5992, 5994, 5997, 6003, 6008,
+                            6023, 6026, 6039, 6053, 6056, 6067, 6071, 6082, 6085, 6098, 6112, 6126,
+                            6135, 6140, 6149, 6154, 6158, 6161, 6168, 6174, 6182, 6187, 6205, 6209,
+                            6213, 6317, 6339, 6342, 6366, 6381, 6391, 6489, 6962, 6966, 6970, 6975,
+                            6977, 6982, 6985, 6987, 6989, 6991, 6993, 6995, 6997, 6999, 7000, 7004,
+                            7008, 7013, 7016, 7021, 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049,
+                            7069, 7072, 7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
+                            7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431, 7436, 7444,
+                            7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853, 7865, 7885, 7888, 7912,
+                            7950, 7972, 7980, 7995, 8007, 8015, 8055, 8078
+  obs bias:
+    input file: '{{cycle_dir}}/iasi_metop-a.{{background_time}}.satbias.nc4'
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &iasi_metop-a_tlapse '{{cycle_dir}}/iasi_metop-a.{{background_time}}.tlapse.txt'
+      - name: lapse_rate
+        tlapse: *iasi_metop-a_tlapse
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+  obs filters:
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-a_channels
+    action:
+      name: assign error
+      error parameter vector: [ 0.7270, 0.8100, 0.7500, 0.7900, 0.7055, 0.7400, 0.6800, 0.7200, 0.6526, 0.6500,
                               0.6650, 0.6900, 0.6394, 0.6400, 0.6528, 0.6065, 0.6246, 0.6100, 0.6423, 0.5995,
                               0.5900, 0.6069, 0.6000, 0.5965, 0.6400, 0.6200, 0.5890, 0.5865, 0.6500, 0.5861,
                               0.6100, 0.5874, 0.6800, 0.6060, 0.6800, 4.3800, 3.0500, 2.3100, 1.5600, 1.3300,
@@ -154,81 +155,93 @@ obs filters:
                               2.5300, 2.4600, 2.4900, 2.5000, 2.5000, 2.5000, 2.5200, 2.5200, 2.5400, 2.5000,
                               2.4800, 2.5000, 2.5500, 2.5000, 2.4800, 2.5000, 2.5000, 2.5200, 2.5200, 2.4800,
                               2.5000, 2.5000, 2.5200, 2.4600, 2.5300, 9.0000 ]
+# assign ObsError <---- ObsErrorData (Assigned in Yaml)
+  - filter: Variable Assignment
+    assignments:
+    - name: ObsError/brightnessTemperature
+      channels: *iasi_metop-a_channels
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature
+            channels: *iasi_metop-a_channels
 #  Wavenumber Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049, 7069, 7072,
-              7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
-              7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431,
-              7436, 7444, 7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853,
-              7865, 7885, 7888, 7912, 7950, 7972, 7980, 7995, 8007, 8015,
-              8055, 8078
-  where:
-  - variable:
-      name: MetaData/solarZenithAngle
-    maxvalue: 88.9999
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    minvalue: 1.0e-12
-  action:
-    name: reject
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-a_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorWavenumIR
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049, 7069, 7072,
+                7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
+                7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431,
+                7436, 7444, 7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853,
+                7865, 7885, 7888, 7912, 7950, 7972, 7980, 7995, 8007, 8015,
+                8055, 8078
+    where:
+    - variable:
+        name: MetaData/solarZenithAngle
+      maxvalue: 88.9999
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0e-12
+    action:
+      name: reject
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-a_channels
-      options:
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorWavenumIR
         channels: *iasi_metop-a_channels
+        options:
+          channels: *iasi_metop-a_channels
 #  Observation Range Sanity Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-a_channels
-  minvalue: 50.00001
-  maxvalue: 549.99999
-  action:
-    name: reject
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-a_channels
+    minvalue: 50.00001
+    maxvalue: 549.99999
+    action:
+      name: reject
 #  Topography Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-a_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTopoRad
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-a_channels
-      options:
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
         channels: *iasi_metop-a_channels
-        sensor: *Sensor_ID
+        options:
+          channels: *iasi_metop-a_channels
+          sensor: *Sensor_ID
 #  Transmittance Top Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-a_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTransmitTopRad
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-a_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTransmitTopRad
+        channels: *iasi_metop-a_channels
+        options:
+          channels: *iasi_metop-a_channels
+#  Cloud Detection Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-a_channels
+    test variables:
+    - name: ObsFunction/CloudDetectMinResidualIR
       channels: *iasi_metop-a_channels
       options:
         channels: *iasi_metop-a_channels
-#  Cloud Detection Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-a_channels
-  test variables:
-  - name: ObsFunction/CloudDetectMinResidualIR
-    channels: *iasi_metop-a_channels
-    options:
-      channels: *iasi_metop-a_channels
-      use_flag: &useflag_iasi_metop-a [ 1, -1, -1, -1,  1, -1, -1, -1,  1, -1,
+        use_flag: &useflag_iasi_metop-a [ 1, -1, -1, -1,  1, -1, -1, -1,  1, -1,
                     1, -1,  1, -1,  1,  1,  1, -1,  1,  1,
                    -1,  1,  1,  1, -1, -1,  1,  1, -1,  1,
                    -1,  1, -1,  1, -1, -1, -1, -1, -1, -1,
@@ -290,7 +303,7 @@ obs filters:
                    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
                    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
                    -1, -1, -1, -1, -1, -1]
-      use_flag_clddet: &clddet_iasi_metop-a [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        use_flag_clddet: &clddet_iasi_metop-a [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -352,152 +365,152 @@ obs filters:
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
 #  NSST Retrieval Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-a_channels
-  test variables:
-  - name: ObsFunction/NearSSTRetCheckIR
-    channels: *iasi_metop-a_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-a_channels
-      use_flag: *useflag_iasi_metop-a
-      obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  Surface Jacobians Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-a_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+    test variables:
+    - name: ObsFunction/NearSSTRetCheckIR
       channels: *iasi_metop-a_channels
       options:
         channels: *iasi_metop-a_channels
-        sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
-        obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
-#  Gross check
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-a_channels
-  function absolute threshold:
-  - name: ObsFunction/ObsErrorBoundIR
-    channels: *iasi_metop-a_channels
-    options:
+        use_flag: *useflag_iasi_metop-a
+        obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  Surface Jacobians Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-a_channels
-      obserr_bound_latitude:
-        name: ObsFunction/ObsErrorFactorLatRad
-        options:
-          latitude_parameters: [25.0, 0.5, 0.04, 1.0]
-      obserr_bound_transmittop:
-        name: ObsFunction/ObsErrorFactorTransmitTopRad
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
         channels: *iasi_metop-a_channels
         options:
           channels: *iasi_metop-a_channels
-      obserr_bound_max: [ 3.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 4.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 4.00, 4.00,
-                          3.50, 2.50, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 0.75, 2.00,
-                          0.75, 2.00, 2.00, 2.00, 0.75, 0.75, 0.75, 0.75, 2.00, 0.75,
-                          0.75, 2.00, 0.75, 0.75, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.50, 2.00, 2.50, 2.50, 3.00, 2.50,
-                          2.50, 2.50, 2.50, 3.50, 2.50, 2.50, 3.00, 3.50, 3.00, 4.00,
-                          4.00, 0.75, 4.00, 4.00, 4.00, 4.50, 4.50, 4.50, 4.50, 4.50,
-                          4.00, 4.50, 4.00, 4.00, 4.50, 2.50, 3.00, 2.50, 3.00, 2.50,
-                          3.00, 2.00, 2.50, 2.50, 3.00, 3.00, 2.50, 3.00, 3.00, 3.00,
-                          2.50, 2.50, 4.00, 4.50, 4.50, 5.00, 4.00, 4.00, 5.00, 5.00,
-                          5.00, 5.00, 5.50, 5.50, 4.00, 5.00, 4.00, 4.50, 5.50, 5.50,
-                          6.00, 4.50, 4.50, 4.00, 5.00, 5.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 1.40, 6.00, 1.40, 6.00, 6.00, 1.40, 6.00,
-                          1.50, 6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.50, 4.50, 6.00,
-                          5.00, 5.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00,
-                          6.00, 6.00, 4.00, 6.00, 6.00, 6.00, 6.00, 4.50, 6.00, 6.00,
-                          4.50, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00, 6.00, 6.00,
-                          5.00, 6.00, 6.00, 5.00, 6.00, 5.00, 6.00, 6.00, 6.00, 5.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00 ]
-  action:
-    name: reject
+          sensor: *Sensor_ID
+          obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+          obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
+#  Gross check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-a_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundIR
+      channels: *iasi_metop-a_channels
+      options:
+        channels: *iasi_metop-a_channels
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [25.0, 0.5, 0.04, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *iasi_metop-a_channels
+          options:
+            channels: *iasi_metop-a_channels
+        obserr_bound_max: [ 3.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 4.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 4.00, 4.00,
+                            3.50, 2.50, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 0.75, 2.00,
+                            0.75, 2.00, 2.00, 2.00, 0.75, 0.75, 0.75, 0.75, 2.00, 0.75,
+                            0.75, 2.00, 0.75, 0.75, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.50, 2.00, 2.50, 2.50, 3.00, 2.50,
+                            2.50, 2.50, 2.50, 3.50, 2.50, 2.50, 3.00, 3.50, 3.00, 4.00,
+                            4.00, 0.75, 4.00, 4.00, 4.00, 4.50, 4.50, 4.50, 4.50, 4.50,
+                            4.00, 4.50, 4.00, 4.00, 4.50, 2.50, 3.00, 2.50, 3.00, 2.50,
+                            3.00, 2.00, 2.50, 2.50, 3.00, 3.00, 2.50, 3.00, 3.00, 3.00,
+                            2.50, 2.50, 4.00, 4.50, 4.50, 5.00, 4.00, 4.00, 5.00, 5.00,
+                            5.00, 5.00, 5.50, 5.50, 4.00, 5.00, 4.00, 4.50, 5.50, 5.50,
+                            6.00, 4.50, 4.50, 4.00, 5.00, 5.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 1.40, 6.00, 1.40, 6.00, 6.00, 1.40, 6.00,
+                            1.50, 6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.50, 4.50, 6.00,
+                            5.00, 5.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00,
+                            6.00, 6.00, 4.00, 6.00, 6.00, 6.00, 6.00, 4.50, 6.00, 6.00,
+                            4.50, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00, 6.00, 6.00,
+                            5.00, 6.00, 6.00, 5.00, 6.00, 5.00, 6.00, 6.00, 6.00, 5.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00 ]
+    action:
+      name: reject
 #  Surface Type Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-a_channels
-  test variables:
-  - name: SurfTypeCheckRad@ObsFunction
-    channels: *iasi_metop-a_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-a_channels
-      use_flag: *useflag_iasi_metop-a
-      use_flag_clddet: *clddet_iasi_metop-a
-  maxvalue: 1.0e-12
-  defer to post: true
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/SurfTypeCheckRad
+      channels: *iasi_metop-a_channels
+      options:
+        channels: *iasi_metop-a_channels
+        use_flag: *useflag_iasi_metop-a
+        use_flag_clddet: *clddet_iasi_metop-a
+    maxvalue: 1.0e-12
+    defer to post: true
+    action:
+      name: reject
 #  Useflag Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-a_channels
-  test variables:
-  - name: ObsFunction/ChannelUseflagCheckRad
-    channels: *iasi_metop-a_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-a_channels
-      use passive_bc: true
-      use_flag: *useflag_iasi_metop-a
-  minvalue: 1.0e-12
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *iasi_metop-a_channels
+      options:
+        channels: *iasi_metop-a_channels
+#        use passive_bc: true
+        use_flag: *useflag_iasi_metop-a
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
@@ -1,98 +1,99 @@
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3,CO2]
-  linear obs operator:
+  obs operator:
+    name: CRTM
     Absorbers: [H2O,O3,CO2]
-  obs options:
-    Sensor_ID: &Sensor_ID iasi_metop-b
-    EndianType: little_endian
-    CoefficientPath: '{{crtm_coeff_dir}}'
-obs space:
-  name: *Sensor_ID
-  obsdatain:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/iasi_metop-b.{{window_begin}}.nc4'
-  obsdataout:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.iasi_metop-b.{{window_begin}}.nc4'
-  simulated variables: [brightnessTemperature]
-  channels: &iasi_metop-b_channels 16, 29, 32, 35, 38, 41, 44, 47, 49, 50, 51, 53,
-            55, 56, 57, 59, 61, 62, 63, 66, 68, 70, 72, 74, 76, 78, 79, 81, 82, 83,
-            84, 85, 86, 87, 89, 92, 93, 95, 97, 99, 101, 103, 104, 106, 109, 110,
-            111, 113, 116, 119, 122, 125, 128, 131, 133, 135, 138, 141, 144, 146,
-            148, 150, 151, 154, 157, 159, 160, 161, 163, 167, 170, 173, 176, 179,
-            180, 185, 187, 191, 193, 197, 199, 200, 202, 203, 205, 207, 210, 212,
-            213, 214, 217, 218, 219, 222, 224, 225, 226, 228, 230, 231, 232, 236,
-            237, 239, 243, 246, 249, 252, 254, 259, 260, 262, 265, 267, 269, 275,
-            279, 282, 285, 294, 296, 299, 300, 303, 306, 309, 313, 320, 323, 326,
-            327, 329, 332, 335, 345, 347, 350, 354, 356, 360, 363, 366, 371, 372,
-            373, 375, 377, 379, 381, 383, 386, 389, 398, 401, 404, 405, 407, 408,
-            410, 411, 414, 416, 418, 423, 426, 428, 432, 433, 434, 439, 442, 445,
-            450, 457, 459, 472, 477, 483, 509, 515, 546, 552, 559, 566, 571, 573,
-            578, 584, 594, 625, 646, 662, 668, 705, 739, 756, 797, 867, 906, 921,
-            1027, 1046, 1090, 1098, 1121, 1133, 1173, 1191, 1194, 1222, 1271, 1283,
-            1338, 1409, 1414, 1420, 1424, 1427, 1430, 1434, 1440, 1442, 1445, 1450,
-            1454, 1460, 1463, 1469, 1474, 1479, 1483, 1487, 1494, 1496, 1502, 1505,
-            1509, 1510, 1513, 1518, 1521, 1526, 1529, 1532, 1536, 1537, 1541, 1545,
-            1548, 1553, 1560, 1568, 1574, 1579, 1583, 1585, 1587, 1606, 1626, 1639,
-            1643, 1652, 1658, 1659, 1666, 1671, 1675, 1681, 1694, 1697, 1710, 1786,
-            1791, 1805, 1839, 1884, 1913, 1946, 1947, 1991, 2019, 2094, 2119, 2213,
-            2239, 2271, 2289, 2321, 2333, 2346, 2349, 2352, 2359, 2367, 2374, 2398,
-            2426, 2562, 2701, 2741, 2745, 2760, 2819, 2889, 2907, 2910, 2919, 2921,
-            2939, 2944, 2945, 2948, 2951, 2958, 2971, 2977, 2985, 2988, 2990, 2991,
-            2993, 3002, 3008, 3014, 3027, 3029, 3030, 3036, 3047, 3049, 3052, 3053,
-            3055, 3058, 3064, 3069, 3087, 3093, 3098, 3105, 3107, 3110, 3116, 3127,
-            3129, 3136, 3146, 3151, 3160, 3165, 3168, 3175, 3178, 3189, 3207, 3228,
-            3244, 3248, 3252, 3256, 3263, 3281, 3295, 3303, 3309, 3312, 3322, 3326,
-            3354, 3366, 3375, 3378, 3411, 3416, 3432, 3438, 3440, 3442, 3444, 3446,
-            3448, 3450, 3452, 3454, 3458, 3467, 3476, 3484, 3491, 3497, 3499, 3504,
-            3506, 3509, 3518, 3527, 3555, 3575, 3577, 3580, 3582, 3586, 3589, 3599,
-            3610, 3626, 3638, 3646, 3653, 3658, 3661, 3673, 3689, 3700, 3710, 3726,
-            3763, 3814, 3841, 3888, 4032, 4059, 4068, 4082, 4095, 4160, 4234, 4257,
-            4411, 4498, 4520, 4552, 4567, 4608, 4646, 4698, 4808, 4849, 4920, 4939,
-            4947, 4967, 4991, 4996, 5015, 5028, 5056, 5128, 5130, 5144, 5170, 5178,
-            5183, 5188, 5191, 5368, 5371, 5379, 5381, 5383, 5397, 5399, 5401, 5403,
-            5405, 5446, 5455, 5472, 5480, 5483, 5485, 5492, 5497, 5502, 5507, 5509,
-            5517, 5528, 5558, 5697, 5714, 5749, 5766, 5785, 5798, 5799, 5801, 5817,
-            5833, 5834, 5836, 5849, 5851, 5852, 5865, 5869, 5881, 5884, 5897, 5900,
-            5916, 5932, 5948, 5963, 5968, 5978, 5988, 5992, 5994, 5997, 6003, 6008,
-            6023, 6026, 6039, 6053, 6056, 6067, 6071, 6082, 6085, 6098, 6112, 6126,
-            6135, 6140, 6149, 6154, 6158, 6161, 6168, 6174, 6182, 6187, 6205, 6209,
-            6213, 6317, 6339, 6342, 6366, 6381, 6391, 6489, 6962, 6966, 6970, 6975,
-            6977, 6982, 6985, 6987, 6989, 6991, 6993, 6995, 6997, 6999, 7000, 7004,
-            7008, 7013, 7016, 7021, 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049,
-            7069, 7072, 7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
-            7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431, 7436, 7444,
-            7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853, 7865, 7885, 7888, 7912,
-            7950, 7972, 7980, 7995, 8007, 8015, 8055, 8078
-obs bias:
-  input file: '{{cycle_dir}}/iasi_metop-b.{{background_time}}.satbias.nc4'
-  variational bc:
-    predictors:
-    - name: constant
-    - name: lapse_rate
-      order: 2
-      tlapse: &iasi_metop-b_tlapse '{{cycle_dir}}/iasi_metop-b.{{background_time}}.tlapse.txt'
-    - name: lapse_rate
-      tlapse: *iasi_metop-b_tlapse
-    - name: emissivity
-    - name: scan_angle
-      order: 4
-    - name: scan_angle
-      order: 3
-    - name: scan_angle
-      order: 2
-    - name: scan_angle
-obs filters:
-- filter: Perform Action
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-b_channels
-  action:
-    name: assign error
-    error parameter vector: [ 0.7270, 0.8100, 0.7500, 0.7900, 0.7055, 0.7400, 0.6800, 0.7200, 0.6526, 0.6500,
+    linear obs operator:
+      Absorbers: [H2O,O3,CO2]
+#    SurfaceWindGeoVars: uv
+    obs options:
+      Sensor_ID: &Sensor_ID iasi_metop-b
+      EndianType: little_endian
+      CoefficientPath: '{{crtm_coeff_dir}}'
+  obs space:
+    name: *Sensor_ID
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/iasi_metop-b.{{window_begin}}.nc4'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/{{experiment_id}}.iasi_metop-b.{{window_begin}}.nc4'
+    simulated variables: [brightnessTemperature]
+    channels: &iasi_metop-b_channels 16, 29, 32, 35, 38, 41, 44, 47, 49, 50, 51, 53,
+                            55, 56, 57, 59, 61, 62, 63, 66, 68, 70, 72, 74, 76, 78, 79, 81, 82, 83,
+                            84, 85, 86, 87, 89, 92, 93, 95, 97, 99, 101, 103, 104, 106, 109, 110,
+                            111, 113, 116, 119, 122, 125, 128, 131, 133, 135, 138, 141, 144, 146,
+                            148, 150, 151, 154, 157, 159, 160, 161, 163, 167, 170, 173, 176, 179,
+                            180, 185, 187, 191, 193, 197, 199, 200, 202, 203, 205, 207, 210, 212,
+                            213, 214, 217, 218, 219, 222, 224, 225, 226, 228, 230, 231, 232, 236,
+                            237, 239, 243, 246, 249, 252, 254, 259, 260, 262, 265, 267, 269, 275,
+                            279, 282, 285, 294, 296, 299, 300, 303, 306, 309, 313, 320, 323, 326,
+                            327, 329, 332, 335, 345, 347, 350, 354, 356, 360, 363, 366, 371, 372,
+                            373, 375, 377, 379, 381, 383, 386, 389, 398, 401, 404, 405, 407, 408,
+                            410, 411, 414, 416, 418, 423, 426, 428, 432, 433, 434, 439, 442, 445,
+                            450, 457, 459, 472, 477, 483, 509, 515, 546, 552, 559, 566, 571, 573,
+                            578, 584, 594, 625, 646, 662, 668, 705, 739, 756, 797, 867, 906, 921,
+                            1027, 1046, 1090, 1098, 1121, 1133, 1173, 1191, 1194, 1222, 1271, 1283,
+                            1338, 1409, 1414, 1420, 1424, 1427, 1430, 1434, 1440, 1442, 1445, 1450,
+                            1454, 1460, 1463, 1469, 1474, 1479, 1483, 1487, 1494, 1496, 1502, 1505,
+                            1509, 1510, 1513, 1518, 1521, 1526, 1529, 1532, 1536, 1537, 1541, 1545,
+                            1548, 1553, 1560, 1568, 1574, 1579, 1583, 1585, 1587, 1606, 1626, 1639,
+                            1643, 1652, 1658, 1659, 1666, 1671, 1675, 1681, 1694, 1697, 1710, 1786,
+                            1791, 1805, 1839, 1884, 1913, 1946, 1947, 1991, 2019, 2094, 2119, 2213,
+                            2239, 2271, 2289, 2321, 2333, 2346, 2349, 2352, 2359, 2367, 2374, 2398,
+                            2426, 2562, 2701, 2741, 2745, 2760, 2819, 2889, 2907, 2910, 2919, 2921,
+                            2939, 2944, 2945, 2948, 2951, 2958, 2971, 2977, 2985, 2988, 2990, 2991,
+                            2993, 3002, 3008, 3014, 3027, 3029, 3030, 3036, 3047, 3049, 3052, 3053,
+                            3055, 3058, 3064, 3069, 3087, 3093, 3098, 3105, 3107, 3110, 3116, 3127,
+                            3129, 3136, 3146, 3151, 3160, 3165, 3168, 3175, 3178, 3189, 3207, 3228,
+                            3244, 3248, 3252, 3256, 3263, 3281, 3295, 3303, 3309, 3312, 3322, 3326,
+                            3354, 3366, 3375, 3378, 3411, 3416, 3432, 3438, 3440, 3442, 3444, 3446,
+                            3448, 3450, 3452, 3454, 3458, 3467, 3476, 3484, 3491, 3497, 3499, 3504,
+                            3506, 3509, 3518, 3527, 3555, 3575, 3577, 3580, 3582, 3586, 3589, 3599,
+                            3610, 3626, 3638, 3646, 3653, 3658, 3661, 3673, 3689, 3700, 3710, 3726,
+                            3763, 3814, 3841, 3888, 4032, 4059, 4068, 4082, 4095, 4160, 4234, 4257,
+                            4411, 4498, 4520, 4552, 4567, 4608, 4646, 4698, 4808, 4849, 4920, 4939,
+                            4947, 4967, 4991, 4996, 5015, 5028, 5056, 5128, 5130, 5144, 5170, 5178,
+                            5183, 5188, 5191, 5368, 5371, 5379, 5381, 5383, 5397, 5399, 5401, 5403,
+                            5405, 5446, 5455, 5472, 5480, 5483, 5485, 5492, 5497, 5502, 5507, 5509,
+                            5517, 5528, 5558, 5697, 5714, 5749, 5766, 5785, 5798, 5799, 5801, 5817,
+                            5833, 5834, 5836, 5849, 5851, 5852, 5865, 5869, 5881, 5884, 5897, 5900,
+                            5916, 5932, 5948, 5963, 5968, 5978, 5988, 5992, 5994, 5997, 6003, 6008,
+                            6023, 6026, 6039, 6053, 6056, 6067, 6071, 6082, 6085, 6098, 6112, 6126,
+                            6135, 6140, 6149, 6154, 6158, 6161, 6168, 6174, 6182, 6187, 6205, 6209,
+                            6213, 6317, 6339, 6342, 6366, 6381, 6391, 6489, 6962, 6966, 6970, 6975,
+                            6977, 6982, 6985, 6987, 6989, 6991, 6993, 6995, 6997, 6999, 7000, 7004,
+                            7008, 7013, 7016, 7021, 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049,
+                            7069, 7072, 7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
+                            7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431, 7436, 7444,
+                            7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853, 7865, 7885, 7888, 7912,
+                            7950, 7972, 7980, 7995, 8007, 8015, 8055, 8078
+  obs bias:
+    input file: '{{cycle_dir}}/iasi_metop-b.{{background_time}}.satbias.nc4'
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &iasi_metop-b_tlapse '{{cycle_dir}}/iasi_metop-b.{{background_time}}.tlapse.txt'
+      - name: lapse_rate
+        tlapse: *iasi_metop-b_tlapse
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+  obs filters:
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-b_channels
+    action:
+      name: assign error
+      error parameter vector: [ 0.7270, 0.8100, 0.7500, 0.7900, 0.7055, 0.7400, 0.6800, 0.7200, 0.6526, 0.6500,
                               0.6650, 0.6900, 0.6394, 0.6400, 0.6528, 0.6065, 0.6246, 0.6100, 0.6423, 0.5995,
                               0.5900, 0.6069, 0.6000, 0.5965, 0.6400, 0.6200, 0.5890, 0.5865, 0.6500, 0.5861,
                               0.6100, 0.5874, 0.6800, 0.6060, 0.6800, 4.3800, 3.0500, 2.3100, 1.5600, 1.3300,
@@ -154,81 +155,93 @@ obs filters:
                               2.5300, 2.4600, 2.4900, 2.5000, 2.5000, 2.5000, 2.5200, 2.5200, 2.5400, 2.5000,
                               2.4800, 2.5000, 2.5500, 2.5000, 2.4800, 2.5000, 2.5000, 2.5200, 2.5200, 2.4800,
                               2.5000, 2.5000, 2.5200, 2.4600, 2.5300, 9.0000 ]
+# assign ObsError <---- ObsErrorData (Assigned in Yaml)
+  - filter: Variable Assignment
+    assignments:
+    - name: ObsError/brightnessTemperature
+      channels: *iasi_metop-b_channels
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature
+            channels: *iasi_metop-b_channels
 #  Wavenumber Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049, 7069, 7072,
-              7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
-              7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431,
-              7436, 7444, 7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853,
-              7865, 7885, 7888, 7912, 7950, 7972, 7980, 7995, 8007, 8015,
-              8055, 8078
-  where:
-  - variable:
-      name: MetaData/solarZenithAngle
-    maxvalue: 88.9999
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    minvalue: 1.0e-12
-  action:
-    name: reject
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-b_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorWavenumIR
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049, 7069, 7072,
+                7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
+                7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431,
+                7436, 7444, 7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853,
+                7865, 7885, 7888, 7912, 7950, 7972, 7980, 7995, 8007, 8015,
+                8055, 8078
+    where:
+    - variable:
+        name: MetaData/solarZenithAngle
+      maxvalue: 88.9999
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0e-12
+    action:
+      name: reject
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-b_channels
-      options:
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorWavenumIR
         channels: *iasi_metop-b_channels
+        options:
+          channels: *iasi_metop-b_channels
 #  Observation Range Sanity Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-b_channels
-  minvalue: 50.00001
-  maxvalue: 549.99999
-  action:
-    name: reject
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-b_channels
+    minvalue: 50.00001
+    maxvalue: 549.99999
+    action:
+      name: reject
 #  Topography Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-b_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTopoRad
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-b_channels
-      options:
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
         channels: *iasi_metop-b_channels
-        sensor: *Sensor_ID
+        options:
+          channels: *iasi_metop-b_channels
+          sensor: *Sensor_ID
 #  Transmittance Top Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-b_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTransmitTopRad
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-b_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTransmitTopRad
+        channels: *iasi_metop-b_channels
+        options:
+          channels: *iasi_metop-b_channels
+#  Cloud Detection Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-b_channels
+    test variables:
+    - name: ObsFunction/CloudDetectMinResidualIR
       channels: *iasi_metop-b_channels
       options:
         channels: *iasi_metop-b_channels
-#  Cloud Detection Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-b_channels
-  test variables:
-  - name: ObsFunction/CloudDetectMinResidualIR
-    channels: *iasi_metop-b_channels
-    options:
-      channels: *iasi_metop-b_channels
-      use_flag: &useflag_iasi_metop-b [ 1, -1, -1, -1,  1, -1, -1, -1,  1, -1,
+        use_flag: &useflag_iasi_metop-b [ 1, -1, -1, -1,  1, -1, -1, -1,  1, -1,
                     1, -1,  1, -1,  1,  1,  1, -1,  1,  1,
                    -1,  1,  1,  1, -1, -1,  1,  1, -1,  1,
                    -1,  1, -1,  1, -1, -1, -1, -1, -1, -1,
@@ -290,7 +303,7 @@ obs filters:
                    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
                    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
                    -1, -1, -1, -1, -1, -1]
-      use_flag_clddet: &clddet_iasi_metop-b [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        use_flag_clddet: &clddet_iasi_metop-b [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -352,152 +365,152 @@ obs filters:
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
 #  NSST Retrieval Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-b_channels
-  test variables:
-  - name: ObsFunction/NearSSTRetCheckIR
-    channels: *iasi_metop-b_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-b_channels
-      use_flag: *useflag_iasi_metop-b
-      obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  Surface Jacobians Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-b_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+    test variables:
+    - name: ObsFunction/NearSSTRetCheckIR
       channels: *iasi_metop-b_channels
       options:
         channels: *iasi_metop-b_channels
-        sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
-        obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
-#  Gross check
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-b_channels
-  function absolute threshold:
-  - name: ObsFunction/ObsErrorBoundIR
-    channels: *iasi_metop-b_channels
-    options:
+        use_flag: *useflag_iasi_metop-b
+        obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  Surface Jacobians Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-b_channels
-      obserr_bound_latitude:
-        name: ObsFunction/ObsErrorFactorLatRad
-        options:
-          latitude_parameters: [25.0, 0.5, 0.04, 1.0]
-      obserr_bound_transmittop:
-        name: ObsFunction/ObsErrorFactorTransmitTopRad
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
         channels: *iasi_metop-b_channels
         options:
           channels: *iasi_metop-b_channels
-      obserr_bound_max: [ 3.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 4.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 4.00, 4.00,
-                          3.50, 2.50, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 0.75, 2.00,
-                          0.75, 2.00, 2.00, 2.00, 0.75, 0.75, 0.75, 0.75, 2.00, 0.75,
-                          0.75, 2.00, 0.75, 0.75, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.50, 2.00, 2.50, 2.50, 3.00, 2.50,
-                          2.50, 2.50, 2.50, 3.50, 2.50, 2.50, 3.00, 3.50, 3.00, 4.00,
-                          4.00, 0.75, 4.00, 4.00, 4.00, 4.50, 4.50, 4.50, 4.50, 4.50,
-                          4.00, 4.50, 4.00, 4.00, 4.50, 2.50, 3.00, 2.50, 3.00, 2.50,
-                          3.00, 2.00, 2.50, 2.50, 3.00, 3.00, 2.50, 3.00, 3.00, 3.00,
-                          2.50, 2.50, 4.00, 4.50, 4.50, 5.00, 4.00, 4.00, 5.00, 5.00,
-                          5.00, 5.00, 5.50, 5.50, 4.00, 5.00, 4.00, 4.50, 5.50, 5.50,
-                          6.00, 4.50, 4.50, 4.00, 5.00, 5.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 1.40, 6.00, 1.40, 6.00, 6.00, 1.40, 6.00,
-                          1.50, 6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.50, 4.50, 6.00,
-                          5.00, 5.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00,
-                          6.00, 6.00, 4.00, 6.00, 6.00, 6.00, 6.00, 4.50, 6.00, 6.00,
-                          4.50, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00, 6.00, 6.00,
-                          5.00, 6.00, 6.00, 5.00, 6.00, 5.00, 6.00, 6.00, 6.00, 5.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00 ]
-  action:
-    name: reject
+          sensor: *Sensor_ID
+          obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+          obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
+#  Gross check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-b_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundIR
+      channels: *iasi_metop-b_channels
+      options:
+        channels: *iasi_metop-b_channels
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [25.0, 0.5, 0.04, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *iasi_metop-b_channels
+          options:
+            channels: *iasi_metop-b_channels
+        obserr_bound_max: [ 3.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 4.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 4.00, 4.00,
+                            3.50, 2.50, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 0.75, 2.00,
+                            0.75, 2.00, 2.00, 2.00, 0.75, 0.75, 0.75, 0.75, 2.00, 0.75,
+                            0.75, 2.00, 0.75, 0.75, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.50, 2.00, 2.50, 2.50, 3.00, 2.50,
+                            2.50, 2.50, 2.50, 3.50, 2.50, 2.50, 3.00, 3.50, 3.00, 4.00,
+                            4.00, 0.75, 4.00, 4.00, 4.00, 4.50, 4.50, 4.50, 4.50, 4.50,
+                            4.00, 4.50, 4.00, 4.00, 4.50, 2.50, 3.00, 2.50, 3.00, 2.50,
+                            3.00, 2.00, 2.50, 2.50, 3.00, 3.00, 2.50, 3.00, 3.00, 3.00,
+                            2.50, 2.50, 4.00, 4.50, 4.50, 5.00, 4.00, 4.00, 5.00, 5.00,
+                            5.00, 5.00, 5.50, 5.50, 4.00, 5.00, 4.00, 4.50, 5.50, 5.50,
+                            6.00, 4.50, 4.50, 4.00, 5.00, 5.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 1.40, 6.00, 1.40, 6.00, 6.00, 1.40, 6.00,
+                            1.50, 6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.50, 4.50, 6.00,
+                            5.00, 5.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00,
+                            6.00, 6.00, 4.00, 6.00, 6.00, 6.00, 6.00, 4.50, 6.00, 6.00,
+                            4.50, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00, 6.00, 6.00,
+                            5.00, 6.00, 6.00, 5.00, 6.00, 5.00, 6.00, 6.00, 6.00, 5.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00 ]
+    action:
+      name: reject
 #  Surface Type Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-b_channels
-  test variables:
-  - name: SurfTypeCheckRad@ObsFunction
-    channels: *iasi_metop-b_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-b_channels
-      use_flag: *useflag_iasi_metop-b
-      use_flag_clddet: *clddet_iasi_metop-b
-  maxvalue: 1.0e-12
-  defer to post: true
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/SurfTypeCheckRad
+      channels: *iasi_metop-b_channels
+      options:
+        channels: *iasi_metop-b_channels
+        use_flag: *useflag_iasi_metop-b
+        use_flag_clddet: *clddet_iasi_metop-b
+    maxvalue: 1.0e-12
+    defer to post: true
+    action:
+      name: reject
 #  Useflag Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-b_channels
-  test variables:
-  - name: ObsFunction/ChannelUseflagCheckRad
-    channels: *iasi_metop-b_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-b_channels
-      use passive_bc: true
-      use_flag: *useflag_iasi_metop-b
-  minvalue: 1.0e-12
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *iasi_metop-b_channels
+      options:
+        channels: *iasi_metop-b_channels
+#        use passive_bc: true
+        use_flag: *useflag_iasi_metop-b
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
@@ -1,98 +1,99 @@
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3,CO2]
-  linear obs operator:
+  obs operator:
+    name: CRTM
     Absorbers: [H2O,O3,CO2]
-  obs options:
-    Sensor_ID: &Sensor_ID iasi_metop-c
-    EndianType: little_endian
-    CoefficientPath: '{{crtm_coeff_dir}}'
-obs space:
-  name: *Sensor_ID
-  obsdatain:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/iasi_metop-c.{{window_begin}}.nc4'
-  obsdataout:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.iasi_metop-c.{{window_begin}}.nc4'
-  simulated variables: [brightnessTemperature]
-  channels: &iasi_metop-c_channels 16, 29, 32, 35, 38, 41, 44, 47, 49, 50, 51, 53,
-            55, 56, 57, 59, 61, 62, 63, 66, 68, 70, 72, 74, 76, 78, 79, 81, 82, 83,
-            84, 85, 86, 87, 89, 92, 93, 95, 97, 99, 101, 103, 104, 106, 109, 110,
-            111, 113, 116, 119, 122, 125, 128, 131, 133, 135, 138, 141, 144, 146,
-            148, 150, 151, 154, 157, 159, 160, 161, 163, 167, 170, 173, 176, 179,
-            180, 185, 187, 191, 193, 197, 199, 200, 202, 203, 205, 207, 210, 212,
-            213, 214, 217, 218, 219, 222, 224, 225, 226, 228, 230, 231, 232, 236,
-            237, 239, 243, 246, 249, 252, 254, 259, 260, 262, 265, 267, 269, 275,
-            279, 282, 285, 294, 296, 299, 300, 303, 306, 309, 313, 320, 323, 326,
-            327, 329, 332, 335, 345, 347, 350, 354, 356, 360, 363, 366, 371, 372,
-            373, 375, 377, 379, 381, 383, 386, 389, 398, 401, 404, 405, 407, 408,
-            410, 411, 414, 416, 418, 423, 426, 428, 432, 433, 434, 439, 442, 445,
-            450, 457, 459, 472, 477, 483, 509, 515, 546, 552, 559, 566, 571, 573,
-            578, 584, 594, 625, 646, 662, 668, 705, 739, 756, 797, 867, 906, 921,
-            1027, 1046, 1090, 1098, 1121, 1133, 1173, 1191, 1194, 1222, 1271, 1283,
-            1338, 1409, 1414, 1420, 1424, 1427, 1430, 1434, 1440, 1442, 1445, 1450,
-            1454, 1460, 1463, 1469, 1474, 1479, 1483, 1487, 1494, 1496, 1502, 1505,
-            1509, 1510, 1513, 1518, 1521, 1526, 1529, 1532, 1536, 1537, 1541, 1545,
-            1548, 1553, 1560, 1568, 1574, 1579, 1583, 1585, 1587, 1606, 1626, 1639,
-            1643, 1652, 1658, 1659, 1666, 1671, 1675, 1681, 1694, 1697, 1710, 1786,
-            1791, 1805, 1839, 1884, 1913, 1946, 1947, 1991, 2019, 2094, 2119, 2213,
-            2239, 2271, 2289, 2321, 2333, 2346, 2349, 2352, 2359, 2367, 2374, 2398,
-            2426, 2562, 2701, 2741, 2745, 2760, 2819, 2889, 2907, 2910, 2919, 2921,
-            2939, 2944, 2945, 2948, 2951, 2958, 2971, 2977, 2985, 2988, 2990, 2991,
-            2993, 3002, 3008, 3014, 3027, 3029, 3030, 3036, 3047, 3049, 3052, 3053,
-            3055, 3058, 3064, 3069, 3087, 3093, 3098, 3105, 3107, 3110, 3116, 3127,
-            3129, 3136, 3146, 3151, 3160, 3165, 3168, 3175, 3178, 3189, 3207, 3228,
-            3244, 3248, 3252, 3256, 3263, 3281, 3295, 3303, 3309, 3312, 3322, 3326,
-            3354, 3366, 3375, 3378, 3411, 3416, 3432, 3438, 3440, 3442, 3444, 3446,
-            3448, 3450, 3452, 3454, 3458, 3467, 3476, 3484, 3491, 3497, 3499, 3504,
-            3506, 3509, 3518, 3527, 3555, 3575, 3577, 3580, 3582, 3586, 3589, 3599,
-            3610, 3626, 3638, 3646, 3653, 3658, 3661, 3673, 3689, 3700, 3710, 3726,
-            3763, 3814, 3841, 3888, 4032, 4059, 4068, 4082, 4095, 4160, 4234, 4257,
-            4411, 4498, 4520, 4552, 4567, 4608, 4646, 4698, 4808, 4849, 4920, 4939,
-            4947, 4967, 4991, 4996, 5015, 5028, 5056, 5128, 5130, 5144, 5170, 5178,
-            5183, 5188, 5191, 5368, 5371, 5379, 5381, 5383, 5397, 5399, 5401, 5403,
-            5405, 5446, 5455, 5472, 5480, 5483, 5485, 5492, 5497, 5502, 5507, 5509,
-            5517, 5528, 5558, 5697, 5714, 5749, 5766, 5785, 5798, 5799, 5801, 5817,
-            5833, 5834, 5836, 5849, 5851, 5852, 5865, 5869, 5881, 5884, 5897, 5900,
-            5916, 5932, 5948, 5963, 5968, 5978, 5988, 5992, 5994, 5997, 6003, 6008,
-            6023, 6026, 6039, 6053, 6056, 6067, 6071, 6082, 6085, 6098, 6112, 6126,
-            6135, 6140, 6149, 6154, 6158, 6161, 6168, 6174, 6182, 6187, 6205, 6209,
-            6213, 6317, 6339, 6342, 6366, 6381, 6391, 6489, 6962, 6966, 6970, 6975,
-            6977, 6982, 6985, 6987, 6989, 6991, 6993, 6995, 6997, 6999, 7000, 7004,
-            7008, 7013, 7016, 7021, 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049,
-            7069, 7072, 7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
-            7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431, 7436, 7444,
-            7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853, 7865, 7885, 7888, 7912,
-            7950, 7972, 7980, 7995, 8007, 8015, 8055, 8078
-obs bias:
-  input file: '{{cycle_dir}}/iasi_metop-c.{{background_time}}.satbias.nc4'
-  variational bc:
-    predictors:
-    - name: constant
-    - name: lapse_rate
-      order: 2
-      tlapse: &iasi_metop-c_tlapse '{{cycle_dir}}/iasi_metop-c.{{background_time}}.tlapse.txt'
-    - name: lapse_rate
-      tlapse: *iasi_metop-c_tlapse
-    - name: emissivity
-    - name: scan_angle
-      order: 4
-    - name: scan_angle
-      order: 3
-    - name: scan_angle
-      order: 2
-    - name: scan_angle
-obs filters:
-- filter: Perform Action
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-c_channels
-  action:
-    name: assign error
-    error parameter vector: [ 0.7270, 0.8100, 0.7500, 0.7900, 0.7055, 0.7400, 0.6800, 0.7200, 0.6526, 0.6500,
+    linear obs operator:
+      Absorbers: [H2O,O3,CO2]
+#    SurfaceWindGeoVars: uv
+    obs options:
+      Sensor_ID: &Sensor_ID iasi_metop-c
+      EndianType: little_endian
+      CoefficientPath: '{{crtm_coeff_dir}}'
+  obs space:
+    name: *Sensor_ID
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/iasi_metop-c.{{window_begin}}.nc4'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/{{experiment_id}}.iasi_metop-c.{{window_begin}}.nc4'
+    simulated variables: [brightnessTemperature]
+    channels: &iasi_metop-c_channels 16, 29, 32, 35, 38, 41, 44, 47, 49, 50, 51, 53,
+                            55, 56, 57, 59, 61, 62, 63, 66, 68, 70, 72, 74, 76, 78, 79, 81, 82, 83,
+                            84, 85, 86, 87, 89, 92, 93, 95, 97, 99, 101, 103, 104, 106, 109, 110,
+                            111, 113, 116, 119, 122, 125, 128, 131, 133, 135, 138, 141, 144, 146,
+                            148, 150, 151, 154, 157, 159, 160, 161, 163, 167, 170, 173, 176, 179,
+                            180, 185, 187, 191, 193, 197, 199, 200, 202, 203, 205, 207, 210, 212,
+                            213, 214, 217, 218, 219, 222, 224, 225, 226, 228, 230, 231, 232, 236,
+                            237, 239, 243, 246, 249, 252, 254, 259, 260, 262, 265, 267, 269, 275,
+                            279, 282, 285, 294, 296, 299, 300, 303, 306, 309, 313, 320, 323, 326,
+                            327, 329, 332, 335, 345, 347, 350, 354, 356, 360, 363, 366, 371, 372,
+                            373, 375, 377, 379, 381, 383, 386, 389, 398, 401, 404, 405, 407, 408,
+                            410, 411, 414, 416, 418, 423, 426, 428, 432, 433, 434, 439, 442, 445,
+                            450, 457, 459, 472, 477, 483, 509, 515, 546, 552, 559, 566, 571, 573,
+                            578, 584, 594, 625, 646, 662, 668, 705, 739, 756, 797, 867, 906, 921,
+                            1027, 1046, 1090, 1098, 1121, 1133, 1173, 1191, 1194, 1222, 1271, 1283,
+                            1338, 1409, 1414, 1420, 1424, 1427, 1430, 1434, 1440, 1442, 1445, 1450,
+                            1454, 1460, 1463, 1469, 1474, 1479, 1483, 1487, 1494, 1496, 1502, 1505,
+                            1509, 1510, 1513, 1518, 1521, 1526, 1529, 1532, 1536, 1537, 1541, 1545,
+                            1548, 1553, 1560, 1568, 1574, 1579, 1583, 1585, 1587, 1606, 1626, 1639,
+                            1643, 1652, 1658, 1659, 1666, 1671, 1675, 1681, 1694, 1697, 1710, 1786,
+                            1791, 1805, 1839, 1884, 1913, 1946, 1947, 1991, 2019, 2094, 2119, 2213,
+                            2239, 2271, 2289, 2321, 2333, 2346, 2349, 2352, 2359, 2367, 2374, 2398,
+                            2426, 2562, 2701, 2741, 2745, 2760, 2819, 2889, 2907, 2910, 2919, 2921,
+                            2939, 2944, 2945, 2948, 2951, 2958, 2971, 2977, 2985, 2988, 2990, 2991,
+                            2993, 3002, 3008, 3014, 3027, 3029, 3030, 3036, 3047, 3049, 3052, 3053,
+                            3055, 3058, 3064, 3069, 3087, 3093, 3098, 3105, 3107, 3110, 3116, 3127,
+                            3129, 3136, 3146, 3151, 3160, 3165, 3168, 3175, 3178, 3189, 3207, 3228,
+                            3244, 3248, 3252, 3256, 3263, 3281, 3295, 3303, 3309, 3312, 3322, 3326,
+                            3354, 3366, 3375, 3378, 3411, 3416, 3432, 3438, 3440, 3442, 3444, 3446,
+                            3448, 3450, 3452, 3454, 3458, 3467, 3476, 3484, 3491, 3497, 3499, 3504,
+                            3506, 3509, 3518, 3527, 3555, 3575, 3577, 3580, 3582, 3586, 3589, 3599,
+                            3610, 3626, 3638, 3646, 3653, 3658, 3661, 3673, 3689, 3700, 3710, 3726,
+                            3763, 3814, 3841, 3888, 4032, 4059, 4068, 4082, 4095, 4160, 4234, 4257,
+                            4411, 4498, 4520, 4552, 4567, 4608, 4646, 4698, 4808, 4849, 4920, 4939,
+                            4947, 4967, 4991, 4996, 5015, 5028, 5056, 5128, 5130, 5144, 5170, 5178,
+                            5183, 5188, 5191, 5368, 5371, 5379, 5381, 5383, 5397, 5399, 5401, 5403,
+                            5405, 5446, 5455, 5472, 5480, 5483, 5485, 5492, 5497, 5502, 5507, 5509,
+                            5517, 5528, 5558, 5697, 5714, 5749, 5766, 5785, 5798, 5799, 5801, 5817,
+                            5833, 5834, 5836, 5849, 5851, 5852, 5865, 5869, 5881, 5884, 5897, 5900,
+                            5916, 5932, 5948, 5963, 5968, 5978, 5988, 5992, 5994, 5997, 6003, 6008,
+                            6023, 6026, 6039, 6053, 6056, 6067, 6071, 6082, 6085, 6098, 6112, 6126,
+                            6135, 6140, 6149, 6154, 6158, 6161, 6168, 6174, 6182, 6187, 6205, 6209,
+                            6213, 6317, 6339, 6342, 6366, 6381, 6391, 6489, 6962, 6966, 6970, 6975,
+                            6977, 6982, 6985, 6987, 6989, 6991, 6993, 6995, 6997, 6999, 7000, 7004,
+                            7008, 7013, 7016, 7021, 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049,
+                            7069, 7072, 7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
+                            7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431, 7436, 7444,
+                            7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853, 7865, 7885, 7888, 7912,
+                            7950, 7972, 7980, 7995, 8007, 8015, 8055, 8078
+  obs bias:
+    input file: '{{cycle_dir}}/iasi_metop-c.{{background_time}}.satbias.nc4'
+    variational bc:
+      predictors:
+      - name: constant
+      - name: lapse_rate
+        order: 2
+        tlapse: &iasi_metop-c_tlapse '{{cycle_dir}}/iasi_metop-c.{{background_time}}.tlapse.txt'
+      - name: lapse_rate
+        tlapse: *iasi_metop-c_tlapse
+      - name: emissivity
+      - name: scan_angle
+        order: 4
+      - name: scan_angle
+        order: 3
+      - name: scan_angle
+        order: 2
+      - name: scan_angle
+  obs filters:
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-c_channels
+    action:
+      name: assign error
+      error parameter vector: [ 0.7270, 0.8100, 0.7500, 0.7900, 0.7055, 0.7400, 0.6800, 0.7200, 0.6526, 0.6500,
                               0.6650, 0.6900, 0.6394, 0.6400, 0.6528, 0.6065, 0.6246, 0.6100, 0.6423, 0.5995,
                               0.5900, 0.6069, 0.6000, 0.5965, 0.6400, 0.6200, 0.5890, 0.5865, 0.6500, 0.5861,
                               0.6100, 0.5874, 0.6800, 0.6060, 0.6800, 4.3800, 3.0500, 2.3100, 1.5600, 1.3300,
@@ -154,81 +155,93 @@ obs filters:
                               2.5300, 2.4600, 2.4900, 2.5000, 2.5000, 2.5000, 2.5200, 2.5200, 2.5400, 2.5000,
                               2.4800, 2.5000, 2.5500, 2.5000, 2.4800, 2.5000, 2.5000, 2.5200, 2.5200, 2.4800,
                               2.5000, 2.5000, 2.5200, 2.4600, 2.5300, 9.0000 ]
+# assign ObsError <---- ObsErrorData (Assigned in Yaml)
+  - filter: Variable Assignment
+    assignments:
+    - name: ObsError/brightnessTemperature
+      channels: *iasi_metop-c_channels
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature
+            channels: *iasi_metop-c_channels
 #  Wavenumber Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049, 7069, 7072,
-              7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
-              7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431,
-              7436, 7444, 7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853,
-              7865, 7885, 7888, 7912, 7950, 7972, 7980, 7995, 8007, 8015,
-              8055, 8078
-  where:
-  - variable:
-      name: MetaData/solarZenithAngle
-    maxvalue: 88.9999
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    minvalue: 1.0e-12
-  action:
-    name: reject
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-c_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorWavenumIR
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: 7024, 7027, 7029, 7032, 7038, 7043, 7046, 7049, 7069, 7072,
+                7076, 7081, 7084, 7089, 7099, 7209, 7222, 7231, 7235, 7247,
+                7267, 7269, 7284, 7389, 7419, 7423, 7424, 7426, 7428, 7431,
+                7436, 7444, 7475, 7549, 7584, 7665, 7666, 7831, 7836, 7853,
+                7865, 7885, 7888, 7912, 7950, 7972, 7980, 7995, 8007, 8015,
+                8055, 8078
+    where:
+    - variable:
+        name: MetaData/solarZenithAngle
+      maxvalue: 88.9999
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      minvalue: 1.0e-12
+    action:
+      name: reject
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-c_channels
-      options:
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorWavenumIR
         channels: *iasi_metop-c_channels
+        options:
+          channels: *iasi_metop-c_channels
 #  Observation Range Sanity Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-c_channels
-  minvalue: 50.00001
-  maxvalue: 549.99999
-  action:
-    name: reject
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-c_channels
+    minvalue: 50.00001
+    maxvalue: 549.99999
+    action:
+      name: reject
 #  Topography Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-c_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTopoRad
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-c_channels
-      options:
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTopoRad
         channels: *iasi_metop-c_channels
-        sensor: *Sensor_ID
+        options:
+          channels: *iasi_metop-c_channels
+          sensor: *Sensor_ID
 #  Transmittance Top Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-c_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorTransmitTopRad
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-c_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorTransmitTopRad
+        channels: *iasi_metop-c_channels
+        options:
+          channels: *iasi_metop-c_channels
+#  Cloud Detection Check
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-c_channels
+    test variables:
+    - name: ObsFunction/CloudDetectMinResidualIR
       channels: *iasi_metop-c_channels
       options:
         channels: *iasi_metop-c_channels
-#  Cloud Detection Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-c_channels
-  test variables:
-  - name: ObsFunction/CloudDetectMinResidualIR
-    channels: *iasi_metop-c_channels
-    options:
-      channels: *iasi_metop-c_channels
-      use_flag: &useflag_iasi_metop-c [ 1, -1, -1, -1,  1, -1, -1, -1,  1, -1,
+        use_flag: &useflag_iasi_metop-c [ 1, -1, -1, -1,  1, -1, -1, -1,  1, -1,
                     1, -1,  1, -1,  1,  1,  1, -1,  1,  1,
                    -1,  1,  1,  1, -1, -1,  1,  1, -1,  1,
                    -1,  1, -1,  1, -1, -1, -1, -1, -1, -1,
@@ -290,7 +303,7 @@ obs filters:
                    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
                    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
                    -1, -1, -1, -1, -1, -1]
-      use_flag_clddet: &clddet_iasi_metop-c [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        use_flag_clddet: &clddet_iasi_metop-c [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -352,152 +365,152 @@ obs filters:
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                            1, 1, 1, 1, 1, 1]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
 #  NSST Retrieval Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-c_channels
-  test variables:
-  - name: ObsFunction/NearSSTRetCheckIR
-    channels: *iasi_metop-c_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-c_channels
-      use_flag: *useflag_iasi_metop-c
-      obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
-      obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-#  Surface Jacobians Check
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-c_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+    test variables:
+    - name: ObsFunction/NearSSTRetCheckIR
       channels: *iasi_metop-c_channels
       options:
         channels: *iasi_metop-c_channels
-        sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
-        obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
-#  Gross check
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-c_channels
-  function absolute threshold:
-  - name: ObsFunction/ObsErrorBoundIR
-    channels: *iasi_metop-c_channels
-    options:
+        use_flag: *useflag_iasi_metop-c
+        obserr_demisf: [0.01,0.02,0.03,0.02,0.03]
+        obserr_dtempf: [0.50,2.00,4.00,2.00,4.00]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+#  Surface Jacobians Check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-c_channels
-      obserr_bound_latitude:
-        name: ObsFunction/ObsErrorFactorLatRad
-        options:
-          latitude_parameters: [25.0, 0.5, 0.04, 1.0]
-      obserr_bound_transmittop:
-        name: ObsFunction/ObsErrorFactorTransmitTopRad
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
         channels: *iasi_metop-c_channels
         options:
           channels: *iasi_metop-c_channels
-      obserr_bound_max: [ 3.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 4.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 4.00, 4.00,
-                          3.50, 2.50, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 0.75, 2.00,
-                          0.75, 2.00, 2.00, 2.00, 0.75, 0.75, 0.75, 0.75, 2.00, 0.75,
-                          0.75, 2.00, 0.75, 0.75, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
-                          2.00, 2.00, 2.00, 2.00, 2.50, 2.00, 2.50, 2.50, 3.00, 2.50,
-                          2.50, 2.50, 2.50, 3.50, 2.50, 2.50, 3.00, 3.50, 3.00, 4.00,
-                          4.00, 0.75, 4.00, 4.00, 4.00, 4.50, 4.50, 4.50, 4.50, 4.50,
-                          4.00, 4.50, 4.00, 4.00, 4.50, 2.50, 3.00, 2.50, 3.00, 2.50,
-                          3.00, 2.00, 2.50, 2.50, 3.00, 3.00, 2.50, 3.00, 3.00, 3.00,
-                          2.50, 2.50, 4.00, 4.50, 4.50, 5.00, 4.00, 4.00, 5.00, 5.00,
-                          5.00, 5.00, 5.50, 5.50, 4.00, 5.00, 4.00, 4.50, 5.50, 5.50,
-                          6.00, 4.50, 4.50, 4.00, 5.00, 5.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 1.40, 6.00, 1.40, 6.00, 6.00, 1.40, 6.00,
-                          1.50, 6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.50, 4.50, 6.00,
-                          5.00, 5.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00,
-                          6.00, 6.00, 4.00, 6.00, 6.00, 6.00, 6.00, 4.50, 6.00, 6.00,
-                          4.50, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00, 6.00, 6.00,
-                          5.00, 6.00, 6.00, 5.00, 6.00, 5.00, 6.00, 6.00, 6.00, 5.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
-                          6.00, 6.00, 6.00, 6.00, 6.00, 6.00 ]
-  action:
-    name: reject
+          sensor: *Sensor_ID
+          obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+          obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
+#  Gross check
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *iasi_metop-c_channels
+    function absolute threshold:
+    - name: ObsFunction/ObsErrorBoundIR
+      channels: *iasi_metop-c_channels
+      options:
+        channels: *iasi_metop-c_channels
+        obserr_bound_latitude:
+          name: ObsFunction/ObsErrorFactorLatRad
+          options:
+            latitude_parameters: [25.0, 0.5, 0.04, 1.0]
+        obserr_bound_transmittop:
+          name: ObsFunction/ObsErrorFactorTransmitTopRad
+          channels: *iasi_metop-c_channels
+          options:
+            channels: *iasi_metop-c_channels
+        obserr_bound_max: [ 3.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 4.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 4.00, 4.00,
+                            3.50, 2.50, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00, 0.75, 2.00,
+                            0.75, 2.00, 2.00, 2.00, 0.75, 0.75, 0.75, 0.75, 2.00, 0.75,
+                            0.75, 2.00, 0.75, 0.75, 2.00, 2.00, 2.00, 2.00, 2.00, 2.00,
+                            2.00, 2.00, 2.00, 2.00, 2.50, 2.00, 2.50, 2.50, 3.00, 2.50,
+                            2.50, 2.50, 2.50, 3.50, 2.50, 2.50, 3.00, 3.50, 3.00, 4.00,
+                            4.00, 0.75, 4.00, 4.00, 4.00, 4.50, 4.50, 4.50, 4.50, 4.50,
+                            4.00, 4.50, 4.00, 4.00, 4.50, 2.50, 3.00, 2.50, 3.00, 2.50,
+                            3.00, 2.00, 2.50, 2.50, 3.00, 3.00, 2.50, 3.00, 3.00, 3.00,
+                            2.50, 2.50, 4.00, 4.50, 4.50, 5.00, 4.00, 4.00, 5.00, 5.00,
+                            5.00, 5.00, 5.50, 5.50, 4.00, 5.00, 4.00, 4.50, 5.50, 5.50,
+                            6.00, 4.50, 4.50, 4.00, 5.00, 5.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 1.25,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 1.40, 6.00, 1.40, 6.00, 6.00, 1.40, 6.00,
+                            1.50, 6.00, 6.00, 6.00, 6.00, 1.50, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.50, 4.50, 6.00,
+                            5.00, 5.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00,
+                            6.00, 6.00, 4.00, 6.00, 6.00, 6.00, 6.00, 4.50, 6.00, 6.00,
+                            4.50, 6.00, 6.00, 6.00, 6.00, 6.00, 5.00, 6.00, 6.00, 6.00,
+                            5.00, 6.00, 6.00, 5.00, 6.00, 5.00, 6.00, 6.00, 6.00, 5.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00, 6.00,
+                            6.00, 6.00, 6.00, 6.00, 6.00, 6.00 ]
+    action:
+      name: reject
 #  Surface Type Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-c_channels
-  test variables:
-  - name: SurfTypeCheckRad@ObsFunction
-    channels: *iasi_metop-c_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-c_channels
-      use_flag: *useflag_iasi_metop-c
-      use_flag_clddet: *clddet_iasi_metop-c
-  maxvalue: 1.0e-12
-  defer to post: true
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/SurfTypeCheckRad
+      channels: *iasi_metop-c_channels
+      options:
+        channels: *iasi_metop-c_channels
+        use_flag: *useflag_iasi_metop-c
+        use_flag_clddet: *clddet_iasi_metop-c
+    maxvalue: 1.0e-12
+    defer to post: true
+    action:
+      name: reject
 #  Useflag Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *iasi_metop-c_channels
-  test variables:
-  - name: ObsFunction/ChannelUseflagCheckRad
-    channels: *iasi_metop-c_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *iasi_metop-c_channels
-      use passive_bc: true
-      use_flag: *useflag_iasi_metop-c
-  minvalue: 1.0e-12
-  action:
-    name: reject
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *iasi_metop-c_channels
+      options:
+        channels: *iasi_metop-c_channels
+#        use passive_bc: true
+        use_flag: *useflag_iasi_metop-c
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ssmis_f17.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ssmis_f17.yaml
@@ -1,753 +1,753 @@
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3,CO2]
-  linear obs operator:
+  obs operator:
+    name: CRTM
     Absorbers: [H2O,O3,CO2]
-  obs options:
-    Sensor_ID: &Sensor_ID ssmis_f17
-    EndianType: little_endian
-    CoefficientPath: '{{crtm_coeff_dir}}'
-obs space:
-  name: *Sensor_ID
-  obsdatain:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/ssmis_f17.{{window_begin}}.nc4'
-  obsdataout:
-    engine:
-      type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.ssmis_f17.{{window_begin}}.nc4'
-  simulated variables: [brightnessTemperature]
-  channels: &ssmis_f17_channels 1-24
-obs bias:
-  input file: '{{cycle_dir}}/ssmis_f17.{{background_time}}.satbias.nc4'
-  variational bc:
-    predictors:
-    - name: constant
-    - name: cloud_liquid_water
-      satellite: SSMIS
-      ch19h: 12
-      ch19v: 13
-      ch22v: 14
-      ch37h: 15
-      ch37v: 16
-      ch91v: 17
-      ch91h: 18
-    - name: cosine_of_latitude_times_orbit_node
-    - name: sine_of_latitude
-    - name: lapse_rate
-      order: 2
-      tlapse: &ssmis_f17_tlapse '{{cycle_dir}}/ssmis_f17.{{background_time}}.tlapse.txt'
-    - name: lapse_rate
-      tlapse: *ssmis_f17_tlapse
-    - name: emissivity
-    - name: scan_angle
-      var_name: sensorScanPosition
-      order: 4
-    - name: scan_angle
-      var_name: sensorScanPosition
-      order: 3
-    - name: scan_angle
-      var_name: sensorScanPosition
-      order: 2
-    - name: scan_angle
-      var_name: sensorScanPosition
-obs prior filters:
+    linear obs operator:
+      Absorbers: [H2O,O3,CO2]
+    obs options:
+      Sensor_ID: &Sensor_ID ssmis_f17
+      EndianType: little_endian
+      CoefficientPath: '{{crtm_coeff_dir}}'
+  obs space:
+    name: *Sensor_ID
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/ssmis_f17.{{window_begin}}.nc4'
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/{{experiment_id}}.ssmis_f17.{{window_begin}}.nc4'
+    simulated variables: [brightnessTemperature]
+    channels: &ssmis_f17_channels 1-24
+  obs bias:
+    input file: '{{cycle_dir}}/ssmis_f17.{{background_time}}.satbias.nc4'
+    variational bc:
+      predictors:
+      - name: constant
+      - name: cloud_liquid_water
+        sensor: SSMIS
+        ch19h: 12
+        ch19v: 13
+        ch22v: 14
+        ch37h: 15
+        ch37v: 16
+        ch91v: 17
+        ch91h: 18
+      - name: lapse_rate
+        order: 2
+        tlapse: &ssmis_f17_tlapse '{{cycle_dir}}/ssmis_f17.{{background_time}}.tlapse.txt'
+      - name: lapse_rate
+        tlapse: *ssmis_f17_tlapse
+      - name: cosine_of_latitude_times_orbit_node
+      - name: sine_of_latitude
+      - name: emissivity
+      - name: scan_angle
+        var_name: sensorScanPosition
+        order: 4
+      - name: scan_angle
+        var_name: sensorScanPosition
+        order: 3
+      - name: scan_angle
+        var_name: sensorScanPosition
+        order: 2
+      - name: scan_angle
+        var_name: sensorScanPosition
+
+  obs prior filters:
 # Step 1: Initial Observation Error Assignment
-- filter: Perform Action
-  filter variables:
-  - name: brightnessTemperature
-    channels: *ssmis_f17_channels
-  action:
-    name: assign error
-    error parameter vector: [ 1.50, 0.50, 0.50, 0.50, 0.50, 1.00, 1.00, 3.00, 3.00, 3.00,
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *ssmis_f17_channels
+    action:
+      name: assign error
+      error parameter vector: [ 1.50, 0.50, 0.50, 0.50, 0.50, 1.00, 1.00, 3.00, 3.00, 3.00,
                               3.00, 2.40, 1.27, 1.44, 3.00, 1.34, 1.74, 3.75, 3.00, 3.00,
                               2.00, 6.40, 1.00, 1.00]
-obs post filters:
+  obs post filters:
 # step 2: Gross check(qcmod)
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *ssmis_f17_channels
-  absolute threshold: 3.5
-  remove bias correction: true
-  where:
-    - variable:
-        name: GeoVaLs/water_area_fraction
-      minvalue: 0.99
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *ssmis_f17_channels
+    absolute threshold: 3.5
+    remove bias correction: true
+    where:
+      - variable:
+          name: GeoVaLs/water_area_fraction
+        minvalue: 0.99
+    action:
+      name: reject
 
 # Step 3: Reject all channels if surface height is greater than 2km
-- filter: RejectList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *ssmis_f17_channels
-  where:
-  - variable:
-      name: GeoVaLs/surface_geopotential_height
-    minvalue: 2000.0
-    min_exclusive: true
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    maxvalue: 0.99
-    max_exclusive: true
-
-# Step 4: Reject data over mixed surface type
-- filter: RejectList
-  filter variables:
-  - name: brightnessTemperature
-    channels: 1-3,8-18
-  where:
-  - variable:
-      name: GeoVaLs/land_area_fraction
-    maxvalue: 0.99
-    max_exclusive: true
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    maxvalue: 0.99
-    max_exclusive: true
-  - variable:
-      name: GeoVaLs/ice_area_fraction
-    maxvalue: 0.99
-    max_exclusive: true
-  - variable:
-      name: GeoVaLs/surface_snow_area_fraction
-    maxvalue: 0.99
-    max_exclusive: true
-
-# Step 5: Channel 2 O-F check over non-water dominant area
-- filter: Difference Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: 1-2, 12-16
-  reference: ObsValue/brightnessTemperature_2
-  value: HofX/brightnessTemperature_2
-  minvalue: -1.5
-  maxvalue: 1.5
-  where:
-  - variable:
-      name: GeoVaLs/water_area_fraction
-    maxvalue: 0.99
-    max_exclusive: true
-
-# Step 6: Gross check over non-water dominant area
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *ssmis_f17_channels
-  absolute threshold: 3.5
-  remove bias correction: true
-  where:
+  - filter: RejectList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *ssmis_f17_channels
+    where:
+    - variable:
+        name: GeoVaLs/surface_geopotential_height
+      minvalue: 2000.0
+      min_exclusive: true
     - variable:
         name: GeoVaLs/water_area_fraction
       maxvalue: 0.99
       max_exclusive: true
-  action:
-    name: reject
+
+# Step 4: Reject data over mixed surface type
+  - filter: RejectList
+    filter variables:
+    - name: brightnessTemperature
+      channels: 1-3,8-18
+    where:
+    - variable:
+        name: GeoVaLs/land_area_fraction
+      maxvalue: 0.99
+      max_exclusive: true
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      maxvalue: 0.99
+      max_exclusive: true
+    - variable:
+        name: GeoVaLs/ice_area_fraction
+      maxvalue: 0.99
+      max_exclusive: true
+    - variable:
+        name: GeoVaLs/surface_snow_area_fraction
+      maxvalue: 0.99
+      max_exclusive: true
+
+# Step 5: Channel 2 O-F check over non-water dominant area
+  - filter: Difference Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: 1-2, 12-16
+    reference: ObsValue/brightnessTemperature_2
+    value: HofX/brightnessTemperature_2
+    minvalue: -1.5
+    maxvalue: 1.5
+    where:
+    - variable:
+        name: GeoVaLs/water_area_fraction
+      maxvalue: 0.99
+      max_exclusive: true
+
+# Step 6: Gross check over non-water dominant area
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: *ssmis_f17_channels
+    absolute threshold: 3.5
+    remove bias correction: true
+    where:
+      - variable:
+          name: GeoVaLs/water_area_fraction
+        maxvalue: 0.99
+        max_exclusive: true
+    action:
+      name: reject
 
 # Step 7: Scattering check for channels 9-11 using channels 8 and 17
-- filter: Difference Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: 9
-  reference: ObsValue/brightnessTemperature_9
-  value:
-    name: ObsFunction/Arithmetic
-    options:
-      variables:
-      - name: HofX/brightnessTemperature_17
-      - name: ObsBiasData/brightnessTemperature_17
-      - name: HofX/brightnessTemperature_8
-      - name: ObsBiasData/brightnessTemperature_8
-      coefs: [-0.485934, 0.485934, 0.473806, -0.473806]
-      intercept: 271.252327
-  maxvalue: 2
+  - filter: Difference Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: 9
+    reference: ObsValue/brightnessTemperature_9
+    value:
+      name: ObsFunction/Arithmetic
+      options:
+        variables:
+        - name: HofX/brightnessTemperature_17
+        - name: ObsBiasData/brightnessTemperature_17
+        - name: HofX/brightnessTemperature_8
+        - name: ObsBiasData/brightnessTemperature_8
+        coefs: [-0.485934, 0.485934, 0.473806, -0.473806]
+        intercept: 271.252327
+    maxvalue: 2
 
-- filter: Difference Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: 10
-  reference: ObsValue/brightnessTemperature_10
-  value:
-    name: ObsFunction/Arithmetic
-    options:
-      variables:
-      - name: HofX/brightnessTemperature_17
-      - name: ObsBiasData/brightnessTemperature_17
-      - name: HofX/brightnessTemperature_8
-      - name: ObsBiasData/brightnessTemperature_8
-      coefs: [-0.413688, 0.413688, 0.361549, -0.361549]
-      intercept: 272.280341
-  maxvalue: 2
+  - filter: Difference Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: 10
+    reference: ObsValue/brightnessTemperature_10
+    value:
+      name: ObsFunction/Arithmetic
+      options:
+        variables:
+        - name: HofX/brightnessTemperature_17
+        - name: ObsBiasData/brightnessTemperature_17
+        - name: HofX/brightnessTemperature_8
+        - name: ObsBiasData/brightnessTemperature_8
+        coefs: [-0.413688, 0.413688, 0.361549, -0.361549]
+        intercept: 272.280341
+    maxvalue: 2
 
-- filter: Difference Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: 11
-  reference: ObsValue/brightnessTemperature_11
-  value:
-    name: ObsFunction/Arithmetic
-    options:
-      variables:
-      - name: HofX/brightnessTemperature_17
-      - name: ObsBiasData/brightnessTemperature_17
-      - name: HofX/brightnessTemperature_8
-      - name: ObsBiasData/brightnessTemperature_8
-      coefs: [-0.400882, 0.400882, 0.270510, -0.270510]
-      intercept: 278.824902
-  maxvalue: 2
+  - filter: Difference Check
+    filter variables:
+    - name: brightnessTemperature
+      channels: 11
+    reference: ObsValue/brightnessTemperature_11
+    value:
+      name: ObsFunction/Arithmetic
+      options:
+        variables:
+        - name: HofX/brightnessTemperature_17
+        - name: ObsBiasData/brightnessTemperature_17
+        - name: HofX/brightnessTemperature_8
+        - name: ObsBiasData/brightnessTemperature_8
+        coefs: [-0.400882, 0.400882, 0.270510, -0.270510]
+        intercept: 278.824902
+    maxvalue: 2
 
 # Step 8: NSST retrieval check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *ssmis_f17_channels
-  test variables:
-  - name: ObsFunction/NearSSTRetCheckIR
-    channels: *ssmis_f17_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *ssmis_f17_channels
-      use_flag: &useflag_ssmis_f17 [ -1,  -1, -1, -1,  1,  1,  1, -1, -1, -1,
-                  -1,  -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                  -1,  -1,  1,  1]
-  maxvalue: 1.0e-12
-  action:
-    name: reject
-
-# Step 9: Error inflation based on surface jacobian
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *ssmis_f17_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+    test variables:
+    - name: ObsFunction/NearSSTRetCheckIR
       channels: *ssmis_f17_channels
       options:
         channels: *ssmis_f17_channels
-        sensor: *Sensor_ID
-        obserr_demisf: [0.010, 0.010, 0.010, 0.010, 0.010]
-        obserr_dtempf: [0.500, 0.500, 0.500, 0.500, 0.500]
+        use_flag: &useflag_ssmis_f17 [ -1,  -1, -1, -1,  1,  1,  1, -1, -1, -1,
+                    -1,  -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                    -1,  -1,  1,  1]
+    maxvalue: 1.0e-12
+    action:
+      name: reject
+
+# Step 9: Error inflation based on surface jacobian
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *ssmis_f17_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
+        channels: *ssmis_f17_channels
+        options:
+          channels: *ssmis_f17_channels
+          sensor: *Sensor_ID
+          obserr_demisf: [0.010, 0.010, 0.010, 0.010, 0.010]
+          obserr_dtempf: [0.500, 0.500, 0.500, 0.500, 0.500]
 
 # Step 10: Final gross check
 # Channel 1
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor1
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_1
-        coefs: [ 2.25 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor1
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_1
+          coefs: [ 2.25 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_1
-  threshold: DerivedMetaData/errorInflationFactor1
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_1
+    threshold: DerivedMetaData/errorInflationFactor1
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 2
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor2
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_2
-        coefs: [ 0.75 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor2
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_2
+          coefs: [ 0.75 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_2
-  threshold: DerivedMetaData/errorInflationFactor2
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_2
+    threshold: DerivedMetaData/errorInflationFactor2
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 3
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor3
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_3
-        coefs: [ 0.75 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor3
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_3
+          coefs: [ 0.75 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_3
-  threshold: DerivedMetaData/errorInflationFactor3
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_3
+    threshold: DerivedMetaData/errorInflationFactor3
+    absolute threshold: 6.0
+    action:
+      name: reject
 
-# Channel 4
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor4
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_4
-        coefs: [ 0.75 ]
-        exponents: [ -1 ]
+  # Channel 4
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor4
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_4
+          coefs: [ 0.75 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_4
-  threshold: DerivedMetaData/errorInflationFactor4
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_4
+    threshold: DerivedMetaData/errorInflationFactor4
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 5
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor5
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_5
-        coefs: [ 0.75 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor5
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_5
+          coefs: [ 0.75 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_5
-  threshold: DerivedMetaData/errorInflationFactor5
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_5
+    threshold: DerivedMetaData/errorInflationFactor5
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 6
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor6
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_6
-        coefs: [ 1.50 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor6
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_6
+          coefs: [ 1.50 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_6
-  threshold: DerivedMetaData/errorInflationFactor6
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_6
+    threshold: DerivedMetaData/errorInflationFactor6
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 7
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor7
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_7
-        coefs: [ 1.50 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor7
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_7
+          coefs: [ 1.50 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_7
-  threshold: DerivedMetaData/errorInflationFactor7
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_7
+    threshold: DerivedMetaData/errorInflationFactor7
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 8
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor8
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_8
-        coefs: [ 4.50 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor8
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_8
+          coefs: [ 4.50 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_8
-  threshold: DerivedMetaData/errorInflationFactor8
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_8
+    threshold: DerivedMetaData/errorInflationFactor8
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 9
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor9
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_9
-        coefs: [ 4.50 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor9
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_9
+          coefs: [ 4.50 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_9
-  threshold: DerivedMetaData/errorInflationFactor9
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_9
+    threshold: DerivedMetaData/errorInflationFactor9
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 10
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor10
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_10
-        coefs: [ 4.50 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor10
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_10
+          coefs: [ 4.50 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_10
-  threshold: DerivedMetaData/errorInflationFactor10
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_10
+    threshold: DerivedMetaData/errorInflationFactor10
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 11
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor11
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_11
-        coefs: [ 4.50 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor11
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_11
+          coefs: [ 4.50 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_11
-  threshold: DerivedMetaData/errorInflationFactor11
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_11
+    threshold: DerivedMetaData/errorInflationFactor11
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 12
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor12
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_12
-        coefs: [ 3.60 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor12
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_12
+          coefs: [ 3.60 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_12
-  threshold: DerivedMetaData/errorInflationFactor12
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_12
+    threshold: DerivedMetaData/errorInflationFactor12
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 13
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor13
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_13
-        coefs: [ 1.905 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor13
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_13
+          coefs: [ 1.905 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_13
-  threshold: DerivedMetaData/errorInflationFactor13
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_13
+    threshold: DerivedMetaData/errorInflationFactor13
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 14
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor14
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_14
-        coefs: [ 2.16 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor14
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_14
+          coefs: [ 2.16 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_14
-  threshold: DerivedMetaData/errorInflationFactor14
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_14
+    threshold: DerivedMetaData/errorInflationFactor14
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 15
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor15
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_15
-        coefs: [ 4.50 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor15
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_15
+          coefs: [ 4.50 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_15
-  threshold: DerivedMetaData/errorInflationFactor15
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_15
+    threshold: DerivedMetaData/errorInflationFactor15
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 16
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor16
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_16
-        coefs: [ 2.01 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor16
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_16
+          coefs: [ 2.01 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_16
-  threshold: DerivedMetaData/errorInflationFactor16
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_16
+    threshold: DerivedMetaData/errorInflationFactor16
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 17
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor17
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_17
-        coefs: [ 2.61 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor17
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_17
+          coefs: [ 2.61 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_17
-  threshold: DerivedMetaData/errorInflationFactor17
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_17
+    threshold: DerivedMetaData/errorInflationFactor17
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 18
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor18
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_18
-        coefs: [ 5.625 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor18
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_18
+          coefs: [ 5.625 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_18
-  threshold: DerivedMetaData/errorInflationFactor18
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_18
+    threshold: DerivedMetaData/errorInflationFactor18
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 19
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor19
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_19
-        coefs: [ 4.50 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor19
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_19
+          coefs: [ 4.50 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_19
-  threshold: DerivedMetaData/errorInflationFactor19
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_19
+    threshold: DerivedMetaData/errorInflationFactor19
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 20
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor20
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_20
-        coefs: [ 4.50 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor20
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_20
+          coefs: [ 4.50 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_20
-  threshold: DerivedMetaData/errorInflationFactor20
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_20
+    threshold: DerivedMetaData/errorInflationFactor20
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 21
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor21
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_21
-        coefs: [ 3.00 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor21
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_21
+          coefs: [ 3.00 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_21
-  threshold: DerivedMetaData/errorInflationFactor21
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_21
+    threshold: DerivedMetaData/errorInflationFactor21
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 22
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor22
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_22
-        coefs: [ 9.60 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor22
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_22
+          coefs: [ 9.60 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_22
-  threshold: DerivedMetaData/errorInflationFactor22
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_22
+    threshold: DerivedMetaData/errorInflationFactor22
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 23
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor23
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_23
-        coefs: [ 1.50 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor23
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_23
+          coefs: [ 1.50 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_23
-  threshold: DerivedMetaData/errorInflationFactor23
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_23
+    threshold: DerivedMetaData/errorInflationFactor23
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 # Channel 24
-- filter: Variable Assignment
-  assignments:
-  - name: DerivedMetaData/errorInflationFactor24
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/brightnessTemperature_24
-        coefs: [ 1.50 ]
-        exponents: [ -1 ]
+  - filter: Variable Assignment
+    assignments:
+    - name: DerivedMetaData/errorInflationFactor24
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/brightnessTemperature_24
+          coefs: [ 1.50 ]
+          exponents: [ -1 ]
 
-- filter: Background Check
-  filter variables:
-  - name: brightnessTemperature_24
-  threshold: DerivedMetaData/errorInflationFactor24
-  absolute threshold: 6.0
-  action:
-    name: reject
+  - filter: Background Check
+    filter variables:
+    - name: brightnessTemperature_24
+    threshold: DerivedMetaData/errorInflationFactor24
+    absolute threshold: 6.0
+    action:
+      name: reject
 
 #  Useflag Check
-- filter: Bounds Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: *ssmis_f17_channels
-  test variables:
-  - name: ObsFunction/ChannelUseflagCheckRad
-    channels: *ssmis_f17_channels
-    options:
+  - filter: Bounds Check
+    filter variables:
+    - name: brightnessTemperature
       channels: *ssmis_f17_channels
-      use_flag: *useflag_ssmis_f17
-  minvalue: 1.0e-12
-  action:
-    name: reject
-
+    test variables:
+    - name: ObsFunction/ChannelUseflagCheckRad
+      channels: *ssmis_f17_channels
+      options:
+        channels: *ssmis_f17_channels
+        use_flag: *useflag_ssmis_f17
+    minvalue: 1.0e-12
+    action:
+      name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ufo_tests.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ufo_tests.yaml
@@ -25,7 +25,7 @@ airs_aqua:
   operator_test:
     rms ref: 1.0e-1
   filter_test:
-    passedBenchmark: 1
+    passedBenchmark: 360232
 
 amsr2_gcom-w1:
   operator_test:
@@ -87,29 +87,35 @@ atms_npp:
   filter_test:
     passedBenchmark: 158687
 
-avhrr3_metop-a:
+avhrr3_metop-b:
   operator_test:
     rms ref: 1.0e-1
   filter_test:
-    passedBenchmark: 1
+    passedBenchmark: 4940
 
 avhrr3_n18:
   operator_test:
     rms ref: 1.0e-1
   filter_test:
-    passedBenchmark: 1
+    passedBenchmark: 5455
+
+avhrr3_n19:
+  operator_test:
+    rms ref: 1.0e-1
+  filter_test:
+    passedBenchmark: 4948
 
 cris-fsr_n20:
   operator_test:
     rms ref: 1.0e-1
   filter_test:
-    passedBenchmark: 1
+    passedBenchmark: 220381
 
 cris-fsr_npp:
   operator_test:
     rms ref: 1.0e-1
   filter_test:
-    passedBenchmark: 1
+    passedBenchmark: 210942
 
 gmi_gpm:
   operator_test:
@@ -123,17 +129,17 @@ gnssrobndnbam:
   filter_test:
     passedBenchmark: 1
 
-iasi_metop-a:
-  operator_test:
-    rms ref: 1.0e-1
-  filter_test:
-    passedBenchmark: 1
-
 iasi_metop-b:
   operator_test:
     rms ref: 1.0e-1
   filter_test:
-    passedBenchmark: 1
+    passedBenchmark: 561875
+
+iasi_metop-c:
+  operator_test:
+    rms ref: 1.0e-1
+  filter_test:
+    passedBenchmark: 558904
 
 mhs_metop-b:
   operator_test:
@@ -211,7 +217,7 @@ ssmis_f17:
   operator_test:
     rms ref: 1.0e-1
   filter_test:
-    passedBenchmark: 1
+    passedBenchmark: 48462
 
 vadwind:
   operator_test:


### PR DESCRIPTION
## Description

The initial observations errors are defined for all IR sensors and "use passive_bc" is removed in the yaml to have the correct benchmark numbers for observations that pass QC.

## Dependencies

- [ ] NA

## Impact

- [ ] benchmark numbers for observations that pass QC
