### PR TITLE
Configurations for sfc data.

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
@@ -1,6 +1,3 @@
-obs operator:
-  name: SfcPCorrected
-  da_psfc_scheme: UKMO
 # geovar_geomz: geopotential_height
 # geovar_sfc_geomz: surface_geopotential_height
 obs space:
@@ -14,31 +11,75 @@ obs space:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.sfc.{{window_begin}}.nc4'
   simulated variables: [stationPressure] #, airTemperature]
+obs operator:
+  name: Composite
+  components:
+
+   # Wind fields are handled using wind reduction factor applied to the lowest level.
+   - name: Product
+     geovals to scale hofx by: wind_reduction_factor_at_10m
+     variables:
+     - name: windEastward
+     - name: windNorthward
+
+   # Temperatures use vertical interpolation
+   - name: VertInterp
+     observation alias file: /discover/nobackup/jjin3/jedi/JediUfoTests_iodav3/Config/obsop_name_map.yaml
+     apply near surface wind scaling: true
+     variables:
+     - name: airTemperature
+     - name: virtualTemperature
+
+   # Surface pressure is handled using the correction scheme
+   - name: SfcPCorrected
+     variables:
+     - name: stationPressure
+     da_psfc_scheme: GSI
+     geovar_geomz: geopotential_height
+     geovar_sfc_geomz: surface_geometric_height
+     station_altitude: height
+
+   # Specific humidity is using the lowest model level (identity)
+   - name: Identity
+     observation alias file: /discover/nobackup/jjin3/jedi/JediUfoTests_iodav3/Config/obsop_name_map.yaml
+     variables:
+     - name: specificHumidity
+
 obs filters:
+
+# ------------------
+# stationPressure (surface pressure)
 # Observation Range Sanity Check
 - filter: Bounds Check
   filter variables:
   - name: stationPressure
-  minvalue: 37499
-  maxvalue: 106999
+  minvalue: 49999
   action:
     name: reject
-# Reject all obs with PreQC mark already set above 3
-- filter: PreQC
-  maxvalue: 3
+# PreUseFlag is assigned in reading programs in GSI.
+- filter: Perform Action
+  filter variables:
+  - name: stationPressure
+  where:
+  - variable: PreUseFlag/stationPressure
+    # PreUseFlag should =< ijter ( # of outloop(0,1,2) + 1) in GSI
+    minvalue: 1
   action:
     name: reject
-# Assign obsError.
-- filter: BlackList
+# PrepBUFR check to be supplemented later
+- filter: RejectList
+  where:
+  - variable:
+      name: PreQC/stationPressure
+    is_in: 4-15
+# error assignments
+# Original error interpolated from the error table
+- filter: Perform Action
   filter variables:
   - name: stationPressure
-  action:
-    name: assign error
-    error parameter: 120             # 120 Pa (1.2mb)
-#
-- filter: BlackList
-  filter variables:
-  - name: stationPressure
+  where:
+  - variable: ObsType/stationPressure
+    is_in: [181]
   action:
     name: assign error
     error function:
@@ -46,16 +87,14 @@ obs filters:
       options:
         xvar:
           name: ObsValue/stationPressure
-        xvals: [80000, 75000]
-        errors: [110, 120]
-  where:
-  - variable:
-      name: ObsType/stationPressure
-    is_in: 181          # Type is SYNOP
-#
-- filter: BlackList
+        xvals: [70000, 65000, 60000, 55000]
+        errors: [100,    120,   120, 1.0e+11]
+- filter: Perform Action
   filter variables:
   - name: stationPressure
+  where:
+  - variable: ObsType/stationPressure
+    is_in: [187]
   action:
     name: assign error
     error function:
@@ -63,15 +102,18 @@ obs filters:
       options:
         xvar:
           name: ObsValue/stationPressure
-        xvals: [85000, 80000]
-        errors: [120, 140]
+        xvals: [80000, 75000, 70000, 65000]
+        errors: [100,    130,   160, 1.0e+11]
+# Ajusted error after reading prep_bufr
+- filter: Perform Action
+  action:
+    name: inflate error
+    inflation factor: 1.2
   where:
-  - variable:
-      name: ObsType/stationPressure
-    is_in: 187          # Type is METAR
-#
-# Inflate ObsError as it is done with GSI
-- filter: BlackList
+  - variable: PreQC/stationPressure
+    is_in: [3]
+# error inflation based on Ps correction
+- filter: Perform Action
   filter variables:
   - name: stationPressure
   action:
@@ -79,46 +121,176 @@ obs filters:
     inflation variable:
       name: ObsFunction/ObsErrorFactorSfcPressure
       options:
-#       original_obserr: ObsError
-        error_min: 100         # 1 mb
-        error_max: 300         # 3 mb
-        geovar_sfc_geomz: surface_geopotential_height
-#
-# If the ObsError is inflated too much, reject the obs
-- filter: Bounds Check
+        geovar_geomz: geopotential_height
+        geovar_sfc_geomz: surface_geometric_height
+        station_altitude: height
+# assign TempObsErrorData/stationPressure <--- ObsErrorData before changing its Min and Max
+- filter: Variable Assignment
+  assignments:
+  - name: TempObsErrorData/stationPressure
+    type: float
+    function:
+      name: ObsFunction/Arithmetic
+      options:
+        variables:
+        - name: ObsErrorData/stationPressure
+  defer to post: true
+# set ObsErrorData 100 Pa if it < 100 Pa.
+- filter: Perform Action
   filter variables:
   - name: stationPressure
   action:
-    name: reject
-  maxvalue: 3.6
-  test variables:
-  - name: ObsFunction/ObsErrorFactorQuotient
-    options:
-      numerator:
-        name: ObsErrorData/stationPressure   # After inflation step
-      denominator:
-        name: ObsError/stationPressure
-  defer to post: true
+    name: assign error
+    error parameter: 100
   where:
   - variable:
-      name: ObsType/stationPressure
-    is_in: 181          # Type is SYNOP
-#
-- filter: Bounds Check
+      name: TempObsErrorData/stationPressure
+    maxvalue: 100
+  - variable:
+      name: TempObsErrorData/stationPressure
+    is_defined:
+  defer to post: true
+# set ObsErrorData 300 Pa if it > 300 Pa.
+- filter: Perform Action
   filter variables:
   - name: stationPressure
   action:
-    name: reject
-  maxvalue: 4.0
-  test variables:
-  - name: ObsFunction/ObsErrorFactorQuotient
-    options:
-      numerator:
-        name: ObsErrorData/stationPressure   # After inflation step
-      denominator:
-        name: ObsError/stationPressure
-  defer to post: true
+    name: assign error
+    error parameter: 300
   where:
   - variable:
-      name: ObsType/stationPressure
-    is_in: 187          # Type is METAR
+      name: TempObsErrorData/stationPressure
+    minvalue: 300
+  - variable:
+      name: TempObsErrorData/stationPressure
+    is_defined:
+  defer to post: true
+
+# Background check 
+# background check for obstype 187:
+- filter: Background Check
+  filter variables:
+  - name: stationPressure
+  threshold: 4.0
+  action:
+    name: reject
+  where:
+  - variable: PreQC/stationPressure
+    is_not_in: [3]
+  - variable: ObsType/stationPressure
+    is_in: 187
+  defer to post: true
+# threshold 4.0 * 0.7 = 2.8 if PreQC=3
+- filter: Background Check
+  filter variables:
+  - name: stationPressure
+  threshold: 2.8
+  action:
+    name: reject
+  where:
+  - variable: PreQC/stationPressure
+    is_in: [3]
+  - variable: ObsType/stationPressure
+    is_in: 187
+  defer to post: true
+# background check for obstype 181:
+# threshold 3.6 if PreQC /= 3
+- filter: Background Check
+  filter variables:
+  - name: stationPressure
+  threshold: 3.6
+  action:
+    name: reject
+  where:
+  - variable: PreQC/stationPressure
+    is_not_in: [3]
+  - variable: ObsType/stationPressure
+    is_in: [181]
+  defer to post: true
+# threshold 3.6 * 0.7 = 2.52 if PreQC=3
+- filter: Background Check
+  filter variables:
+  - name: stationPressure
+  threshold: 2.52
+  action:
+    name: reject
+  where:
+  - variable: PreQC/stationPressure
+    is_in: [3]
+  - variable: ObsType/stationPressure
+    is_in: [181]
+  defer to post: true
+# Re-assign error ObsErrorData/stationPressure <--- TempObsErrorData/stationPressure
+- filter: Perform Action
+  filter variables:
+  - name: stationPressure
+  action:
+    name: assign error
+    error function: TempObsErrorData/stationPressure
+  where:
+  - variable:
+      name: TempObsErrorData/stationPressure
+    is_defined:
+  defer to post: true
+# Duplicate factor
+- filter: Perform Action
+  filter variables:
+  - name: stationPressure
+  action:
+    name: inflate error
+    inflation variable:
+      name: ObsFunction/ObsErrorFactorDuplicateCheck
+      options:
+        use_air_pressure: false
+        variable: stationPressure
+  defer to post: true
+
+## specificHumidity. Both types 181 & 187 are rejected.
+- filter: Perform Action
+  filter variables:
+  - name: specificHumidity
+  where:
+  - variable: ObsType/specificHumidity
+    is_in: 181,187
+  action:
+    name: reject
+
+## airTemperature. Both types 181 & 187 are rejected.
+- filter: Perform Action
+  filter variables:
+  - name: airTemperature
+  where:
+  - variable: ObsType/airTemperature
+    is_in: 181,187
+  action:
+    name: reject
+
+## virtualTemperature. Both types 181 & 187 are rejected.
+- filter: Perform Action
+  filter variables:
+  - name: virtualTemperature
+  where:
+  - variable: ObsType/virtualTemperature
+    is_in: 181,187
+  action:
+    name: reject
+
+## windEastward. Both types 281 & 287 are rejected.
+- filter: Perform Action
+  filter variables:
+  - name: windEastward
+  where:
+  - variable: ObsType/windEastward
+    is_in: 281,287
+  action:
+    name: reject
+
+## windNorthward. Both types 281 & 287 are rejected.
+- filter: Perform Action
+  filter variables:
+  - name: windNorthward
+  where:
+  - variable: ObsType/windNorthward
+    is_in: 281,287
+  action:
+    name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
@@ -166,7 +166,7 @@ obs filters:
     is_defined:
   defer to post: true
 
-# Background check 
+# Background check
 # background check for obstype 187:
 - filter: Background Check
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
@@ -167,7 +167,7 @@ obs space:
       is_defined:
     defer to post: true
 
-# Background check 
+# Background check
   # background check for obstype 187:
   - filter: Background Check
     filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
@@ -1,5 +1,3 @@
-# geovar_geomz: geopotential_height
-# geovar_sfc_geomz: surface_geopotential_height
 obs space:
   name: sfc
     obsdatain:
@@ -12,286 +10,286 @@ obs space:
       obsfile: '{{cycle_dir}}/{{experiment_id}}.sfc.{{window_begin}}.nc4'
     simulated variables: [windEastward, windNorthward, virtualTemperature, airTemperature,
                           specificHumidity, stationPressure]
-  obs operator:
-    name: Composite
-    components:
+obs operator:
+  name: Composite
+  components:
 
-     # Wind fields are handled using wind reduction factor applied to the lowest level.
-     - name: Product
-       geovals to scale hofx by: wind_reduction_factor_at_10m
-       variables:
-       - name: windEastward
-       - name: windNorthward
+   # Wind fields are handled using wind reduction factor applied to the lowest level.
+   - name: Product
+     geovals to scale hofx by: wind_reduction_factor_at_10m
+     variables:
+     - name: windEastward
+     - name: windNorthward
 
-     # Temperatures use vertical interpolation
-     - name: VertInterp
-       observation alias file: /discover/nobackup/jjin3/jedi/JediUfoTests_iodav3/Config/obsop_name_map.yaml
-       apply near surface wind scaling: true
-       variables:
-       - name: airTemperature
-       - name: virtualTemperature
+   # Temperatures use vertical interpolation
+   - name: VertInterp
+     observation alias file: /discover/nobackup/jjin3/jedi/JediUfoTests_iodav3/Config/obsop_name_map.yaml
+     apply near surface wind scaling: true
+     variables:
+     - name: airTemperature
+     - name: virtualTemperature
 
-     # Surface pressure is handled using the correction scheme
-     - name: SfcPCorrected
-       variables:
-       - name: stationPressure
-       da_psfc_scheme: GSI
-       geovar_geomz: geopotential_height
-       geovar_sfc_geomz: surface_geometric_height
-       station_altitude: height
+   # Surface pressure is handled using the correction scheme
+   - name: SfcPCorrected
+     variables:
+     - name: stationPressure
+     da_psfc_scheme: GSI
+     geovar_geomz: geopotential_height
+     geovar_sfc_geomz: surface_geometric_height
+     station_altitude: height
 
-     # Specific humidity is using the lowest model level (identity)
-     - name: Identity
-       observation alias file: /discover/nobackup/jjin3/jedi/JediUfoTests_iodav3/Config/obsop_name_map.yaml
-       variables:
-       - name: specificHumidity
+   # Specific humidity is using the lowest model level (identity)
+   - name: Identity
+     observation alias file: /discover/nobackup/jjin3/jedi/JediUfoTests_iodav3/Config/obsop_name_map.yaml
+     variables:
+     - name: specificHumidity
 
-  obs filters:
+obs filters:
 
 # ------------------
 # stationPressure (surface pressure)
 # Observation Range Sanity Check
-  - filter: Bounds Check
-    filter variables:
-    - name: stationPressure
-    minvalue: 49999
-    action:
-      name: reject
-  # PreUseFlag is assigned in reading programs in GSI.
-  - filter: Perform Action
-    filter variables:
-    - name: stationPressure
-    where:
-    - variable: PreUseFlag/stationPressure
-      # PreUseFlag should =< ijter ( # of outloop(0,1,2) + 1) in GSI
-      minvalue: 1
-    action:
-      name: reject
-  # PrepBUFR check to be supplemented later
-  - filter: RejectList
-    where:
-    - variable:
-        name: PreQC/stationPressure
-      is_in: 4-15
-  # error assignments
-  # Original error interpolated from the error table
-  - filter: Perform Action
-    filter variables:
-    - name: stationPressure
-    where:
-    - variable: ObsType/stationPressure
-      is_in: [181]
-    action:
-      name: assign error
-      error function:
-        name: ObsFunction/ObsErrorModelStepwiseLinear
-        options:
-          xvar:
-            name: ObsValue/stationPressure
-          xvals: [70000, 65000, 60000, 55000]
-          errors: [100,    120,   120, 1.0e+11]
-  - filter: Perform Action
-    filter variables:
-    - name: stationPressure
-    where:
-    - variable: ObsType/stationPressure
-      is_in: [187]
-    action:
-      name: assign error
-      error function:
-        name: ObsFunction/ObsErrorModelStepwiseLinear
-        options:
-          xvar:
-            name: ObsValue/stationPressure
-          xvals: [80000, 75000, 70000, 65000]
-          errors: [100,    130,   160, 1.0e+11]
-  # Ajusted error after reading prep_bufr
-  - filter: Perform Action
-    action:
-      name: inflate error
-      inflation factor: 1.2
-    where:
-    - variable: PreQC/stationPressure
-      is_in: [3]
-  # error inflation based on Ps correction
-  - filter: Perform Action
-    filter variables:
-    - name: stationPressure
-    action:
-      name: inflate error
-      inflation variable:
-        name: ObsFunction/ObsErrorFactorSfcPressure
-        options:
-          geovar_geomz: geopotential_height
-          geovar_sfc_geomz: surface_geometric_height
-          station_altitude: height
-  # assign TempObsErrorData/stationPressure <--- ObsErrorData before changing its Min and Max
-  - filter: Variable Assignment
-    assignments:
-    - name: TempObsErrorData/stationPressure
-      type: float
-      function:
-        name: ObsFunction/Arithmetic
-        options:
-          variables:
-          - name: ObsErrorData/stationPressure
-    defer to post: true
-  # set ObsErrorData 100 Pa if it < 100 Pa.
-  - filter: Perform Action
-    filter variables:
-    - name: stationPressure
-    action:
-      name: assign error
-      error parameter: 100
-    where:
-    - variable:
-        name: TempObsErrorData/stationPressure
-      maxvalue: 100
-    - variable:
-        name: TempObsErrorData/stationPressure
-      is_defined:
-    defer to post: true
-  # set ObsErrorData 300 Pa if it > 300 Pa.
-  - filter: Perform Action
-    filter variables:
-    - name: stationPressure
-    action:
-      name: assign error
-      error parameter: 300
-    where:
-    - variable:
-        name: TempObsErrorData/stationPressure
-      minvalue: 300
-    - variable:
-        name: TempObsErrorData/stationPressure
-      is_defined:
-    defer to post: true
+- filter: Bounds Check
+  filter variables:
+  - name: stationPressure
+  minvalue: 49999
+  action:
+    name: reject
+# PreUseFlag is assigned in reading programs in GSI.
+- filter: Perform Action
+  filter variables:
+  - name: stationPressure
+  where:
+  - variable: PreUseFlag/stationPressure
+    # PreUseFlag should =< ijter ( # of outloop(0,1,2) + 1) in GSI
+    minvalue: 1
+  action:
+    name: reject
+# PrepBUFR check to be supplemented later
+- filter: RejectList
+  where:
+  - variable:
+      name: PreQC/stationPressure
+    is_in: 4-15
+# error assignments
+# Original error interpolated from the error table
+- filter: Perform Action
+  filter variables:
+  - name: stationPressure
+  where:
+  - variable: ObsType/stationPressure
+    is_in: [181]
+  action:
+    name: assign error
+    error function:
+      name: ObsFunction/ObsErrorModelStepwiseLinear
+      options:
+        xvar:
+          name: ObsValue/stationPressure
+        xvals: [70000, 65000, 60000, 55000]
+        errors: [100,    120,   120, 1.0e+11]
+- filter: Perform Action
+  filter variables:
+  - name: stationPressure
+  where:
+  - variable: ObsType/stationPressure
+    is_in: [187]
+  action:
+    name: assign error
+    error function:
+      name: ObsFunction/ObsErrorModelStepwiseLinear
+      options:
+        xvar:
+          name: ObsValue/stationPressure
+        xvals: [80000, 75000, 70000, 65000]
+        errors: [100,    130,   160, 1.0e+11]
+# Ajusted error after reading prep_bufr
+- filter: Perform Action
+  action:
+    name: inflate error
+    inflation factor: 1.2
+  where:
+  - variable: PreQC/stationPressure
+    is_in: [3]
+# error inflation based on Ps correction
+- filter: Perform Action
+  filter variables:
+  - name: stationPressure
+  action:
+    name: inflate error
+    inflation variable:
+      name: ObsFunction/ObsErrorFactorSfcPressure
+      options:
+        geovar_geomz: geopotential_height
+        geovar_sfc_geomz: surface_geometric_height
+        station_altitude: height
+# assign TempObsErrorData/stationPressure <--- ObsErrorData before changing its Min and Max
+- filter: Variable Assignment
+  assignments:
+  - name: TempObsErrorData/stationPressure
+    type: float
+    function:
+      name: ObsFunction/Arithmetic
+      options:
+        variables:
+        - name: ObsErrorData/stationPressure
+  defer to post: true
+# set ObsErrorData 100 Pa if it < 100 Pa.
+- filter: Perform Action
+  filter variables:
+  - name: stationPressure
+  action:
+    name: assign error
+    error parameter: 100
+  where:
+  - variable:
+      name: TempObsErrorData/stationPressure
+    maxvalue: 100
+  - variable:
+      name: TempObsErrorData/stationPressure
+    is_defined:
+  defer to post: true
+# set ObsErrorData 300 Pa if it > 300 Pa.
+- filter: Perform Action
+  filter variables:
+  - name: stationPressure
+  action:
+    name: assign error
+    error parameter: 300
+  where:
+  - variable:
+      name: TempObsErrorData/stationPressure
+    minvalue: 300
+  - variable:
+      name: TempObsErrorData/stationPressure
+    is_defined:
+  defer to post: true
 
 # Background check
-  # background check for obstype 187:
-  - filter: Background Check
-    filter variables:
-    - name: stationPressure
-    threshold: 4.0
-    action:
-      name: reject
-    where:
-    - variable: PreQC/stationPressure
-      is_not_in: [3]
-    - variable: ObsType/stationPressure
-      is_in: 187
-    defer to post: true
-  # threshold 4.0 * 0.7 = 2.8 if PreQC=3
-  - filter: Background Check
-    filter variables:
-    - name: stationPressure
-    threshold: 2.8
-    action:
-      name: reject
-    where:
-    - variable: PreQC/stationPressure
-      is_in: [3]
-    - variable: ObsType/stationPressure
-      is_in: 187
-    defer to post: true
-  # background check for obstype 181:
-  # threshold 3.6 if PreQC /= 3
-  - filter: Background Check
-    filter variables:
-    - name: stationPressure
-    threshold: 3.6
-    action:
-      name: reject
-    where:
-    - variable: PreQC/stationPressure
-      is_not_in: [3]
-    - variable: ObsType/stationPressure
-      is_in: [181]
-    defer to post: true
-  # threshold 3.6 * 0.7 = 2.52 if PreQC=3
-  - filter: Background Check
-    filter variables:
-    - name: stationPressure
-    threshold: 2.52
-    action:
-      name: reject
-    where:
-    - variable: PreQC/stationPressure
-      is_in: [3]
-    - variable: ObsType/stationPressure
-      is_in: [181]
-    defer to post: true
-  # Re-assign error ObsErrorData/stationPressure <--- TempObsErrorData/stationPressure
-  - filter: Perform Action
-    filter variables:
-    - name: stationPressure
-    action:
-      name: assign error
-      error function: TempObsErrorData/stationPressure
-    where:
-    - variable:
-        name: TempObsErrorData/stationPressure
-      is_defined:
-    defer to post: true
+# background check for obstype 187:
+- filter: Background Check
+  filter variables:
+  - name: stationPressure
+  threshold: 4.0
+  action:
+    name: reject
+  where:
+  - variable: PreQC/stationPressure
+    is_not_in: [3]
+  - variable: ObsType/stationPressure
+    is_in: 187
+  defer to post: true
+# threshold 4.0 * 0.7 = 2.8 if PreQC=3
+- filter: Background Check
+  filter variables:
+  - name: stationPressure
+  threshold: 2.8
+  action:
+    name: reject
+  where:
+  - variable: PreQC/stationPressure
+    is_in: [3]
+  - variable: ObsType/stationPressure
+    is_in: 187
+  defer to post: true
+# background check for obstype 181:
+# threshold 3.6 if PreQC /= 3
+- filter: Background Check
+  filter variables:
+  - name: stationPressure
+  threshold: 3.6
+  action:
+    name: reject
+  where:
+  - variable: PreQC/stationPressure
+    is_not_in: [3]
+  - variable: ObsType/stationPressure
+    is_in: [181]
+  defer to post: true
+# threshold 3.6 * 0.7 = 2.52 if PreQC=3
+- filter: Background Check
+  filter variables:
+  - name: stationPressure
+  threshold: 2.52
+  action:
+    name: reject
+  where:
+  - variable: PreQC/stationPressure
+    is_in: [3]
+  - variable: ObsType/stationPressure
+    is_in: [181]
+  defer to post: true
+# Re-assign error ObsErrorData/stationPressure <--- TempObsErrorData/stationPressure
+- filter: Perform Action
+  filter variables:
+  - name: stationPressure
+  action:
+    name: assign error
+    error function: TempObsErrorData/stationPressure
+  where:
+  - variable:
+      name: TempObsErrorData/stationPressure
+    is_defined:
+  defer to post: true
 # Duplicate factor
-  - filter: Perform Action
-    filter variables:
-    - name: stationPressure
-    action:
-      name: inflate error
-      inflation variable:
-        name: ObsFunction/ObsErrorFactorDuplicateCheck
-        options:
-          use_air_pressure: false
-          variable: stationPressure
-    defer to post: true
+- filter: Perform Action
+  filter variables:
+  - name: stationPressure
+  action:
+    name: inflate error
+    inflation variable:
+      name: ObsFunction/ObsErrorFactorDuplicateCheck
+      options:
+        use_air_pressure: false
+        variable: stationPressure
+  defer to post: true
 
 ## specificHumidity. Both types 181 & 187 are rejected.
-  - filter: Perform Action
-    filter variables:
-    - name: specificHumidity
-    where:
-    - variable: ObsType/specificHumidity
-      is_in: 181,187
-    action:
-      name: reject
+- filter: Perform Action
+  filter variables:
+  - name: specificHumidity
+  where:
+  - variable: ObsType/specificHumidity
+    is_in: 181,187
+  action:
+    name: reject
 
 ## airTemperature. Both types 181 & 187 are rejected.
-  - filter: Perform Action
-    filter variables:
-    - name: airTemperature
-    where:
-    - variable: ObsType/airTemperature
-      is_in: 181,187
-    action:
-      name: reject
+- filter: Perform Action
+  filter variables:
+  - name: airTemperature
+  where:
+  - variable: ObsType/airTemperature
+    is_in: 181,187
+  action:
+    name: reject
 
 ## virtualTemperature. Both types 181 & 187 are rejected.
-  - filter: Perform Action
-    filter variables:
-    - name: virtualTemperature
-    where:
-    - variable: ObsType/virtualTemperature
-      is_in: 181,187
-    action:
-      name: reject
+- filter: Perform Action
+  filter variables:
+  - name: virtualTemperature
+  where:
+  - variable: ObsType/virtualTemperature
+    is_in: 181,187
+  action:
+    name: reject
 
 ## windEastward. Both types 281 & 287 are rejected.
-  - filter: Perform Action
-    filter variables:
-    - name: windEastward
-    where:
-    - variable: ObsType/windEastward
-      is_in: 281,287
-    action:
-      name: reject
+- filter: Perform Action
+  filter variables:
+  - name: windEastward
+  where:
+  - variable: ObsType/windEastward
+    is_in: 281,287
+  action:
+    name: reject
 
 ## windNorthward. Both types 281 & 287 are rejected.
-  - filter: Perform Action
-    filter variables:
-    - name: windNorthward
-    where:
-    - variable: ObsType/windNorthward
-      is_in: 281,287
-    action:
-      name: reject
+- filter: Perform Action
+  filter variables:
+  - name: windNorthward
+  where:
+  - variable: ObsType/windNorthward
+    is_in: 281,287
+  action:
+    name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
@@ -1,15 +1,15 @@
 obs space:
   name: sfc
-    obsdatain:
-      engine:
-        type: H5File
+  obsdatain:
+    engine:
+      type: H5File
       obsfile: '{{cycle_dir}}/sfc.{{window_begin}}.nc4'
-    obsdataout:
-      engine:
-        type: H5File
+  obsdataout:
+    engine:
+      type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.sfc.{{window_begin}}.nc4'
-    simulated variables: [windEastward, windNorthward, virtualTemperature, airTemperature,
-                          specificHumidity, stationPressure]
+  simulated variables: [windEastward, windNorthward, virtualTemperature, airTemperature,
+                        specificHumidity, stationPressure]
 obs operator:
   name: Composite
   components:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
@@ -2,295 +2,296 @@
 # geovar_sfc_geomz: surface_geopotential_height
 obs space:
   name: sfc
-  obsdatain:
-    engine:
-      type: H5File
+    obsdatain:
+      engine:
+        type: H5File
       obsfile: '{{cycle_dir}}/sfc.{{window_begin}}.nc4'
-  obsdataout:
-    engine:
-      type: H5File
+    obsdataout:
+      engine:
+        type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.sfc.{{window_begin}}.nc4'
-  simulated variables: [stationPressure] #, airTemperature]
-obs operator:
-  name: Composite
-  components:
+    simulated variables: [windEastward, windNorthward, virtualTemperature, airTemperature,
+                          specificHumidity, stationPressure]
+  obs operator:
+    name: Composite
+    components:
 
-   # Wind fields are handled using wind reduction factor applied to the lowest level.
-   - name: Product
-     geovals to scale hofx by: wind_reduction_factor_at_10m
-     variables:
-     - name: windEastward
-     - name: windNorthward
+     # Wind fields are handled using wind reduction factor applied to the lowest level.
+     - name: Product
+       geovals to scale hofx by: wind_reduction_factor_at_10m
+       variables:
+       - name: windEastward
+       - name: windNorthward
 
-   # Temperatures use vertical interpolation
-   - name: VertInterp
-     observation alias file: /discover/nobackup/jjin3/jedi/JediUfoTests_iodav3/Config/obsop_name_map.yaml
-     apply near surface wind scaling: true
-     variables:
-     - name: airTemperature
-     - name: virtualTemperature
+     # Temperatures use vertical interpolation
+     - name: VertInterp
+       observation alias file: /discover/nobackup/jjin3/jedi/JediUfoTests_iodav3/Config/obsop_name_map.yaml
+       apply near surface wind scaling: true
+       variables:
+       - name: airTemperature
+       - name: virtualTemperature
 
-   # Surface pressure is handled using the correction scheme
-   - name: SfcPCorrected
-     variables:
-     - name: stationPressure
-     da_psfc_scheme: GSI
-     geovar_geomz: geopotential_height
-     geovar_sfc_geomz: surface_geometric_height
-     station_altitude: height
+     # Surface pressure is handled using the correction scheme
+     - name: SfcPCorrected
+       variables:
+       - name: stationPressure
+       da_psfc_scheme: GSI
+       geovar_geomz: geopotential_height
+       geovar_sfc_geomz: surface_geometric_height
+       station_altitude: height
 
-   # Specific humidity is using the lowest model level (identity)
-   - name: Identity
-     observation alias file: /discover/nobackup/jjin3/jedi/JediUfoTests_iodav3/Config/obsop_name_map.yaml
-     variables:
-     - name: specificHumidity
+     # Specific humidity is using the lowest model level (identity)
+     - name: Identity
+       observation alias file: /discover/nobackup/jjin3/jedi/JediUfoTests_iodav3/Config/obsop_name_map.yaml
+       variables:
+       - name: specificHumidity
 
-obs filters:
+  obs filters:
 
 # ------------------
 # stationPressure (surface pressure)
 # Observation Range Sanity Check
-- filter: Bounds Check
-  filter variables:
-  - name: stationPressure
-  minvalue: 49999
-  action:
-    name: reject
-# PreUseFlag is assigned in reading programs in GSI.
-- filter: Perform Action
-  filter variables:
-  - name: stationPressure
-  where:
-  - variable: PreUseFlag/stationPressure
-    # PreUseFlag should =< ijter ( # of outloop(0,1,2) + 1) in GSI
-    minvalue: 1
-  action:
-    name: reject
-# PrepBUFR check to be supplemented later
-- filter: RejectList
-  where:
-  - variable:
-      name: PreQC/stationPressure
-    is_in: 4-15
-# error assignments
-# Original error interpolated from the error table
-- filter: Perform Action
-  filter variables:
-  - name: stationPressure
-  where:
-  - variable: ObsType/stationPressure
-    is_in: [181]
-  action:
-    name: assign error
-    error function:
-      name: ObsFunction/ObsErrorModelStepwiseLinear
-      options:
-        xvar:
-          name: ObsValue/stationPressure
-        xvals: [70000, 65000, 60000, 55000]
-        errors: [100,    120,   120, 1.0e+11]
-- filter: Perform Action
-  filter variables:
-  - name: stationPressure
-  where:
-  - variable: ObsType/stationPressure
-    is_in: [187]
-  action:
-    name: assign error
-    error function:
-      name: ObsFunction/ObsErrorModelStepwiseLinear
-      options:
-        xvar:
-          name: ObsValue/stationPressure
-        xvals: [80000, 75000, 70000, 65000]
-        errors: [100,    130,   160, 1.0e+11]
-# Ajusted error after reading prep_bufr
-- filter: Perform Action
-  action:
-    name: inflate error
-    inflation factor: 1.2
-  where:
-  - variable: PreQC/stationPressure
-    is_in: [3]
-# error inflation based on Ps correction
-- filter: Perform Action
-  filter variables:
-  - name: stationPressure
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSfcPressure
-      options:
-        geovar_geomz: geopotential_height
-        geovar_sfc_geomz: surface_geometric_height
-        station_altitude: height
-# assign TempObsErrorData/stationPressure <--- ObsErrorData before changing its Min and Max
-- filter: Variable Assignment
-  assignments:
-  - name: TempObsErrorData/stationPressure
-    type: float
-    function:
-      name: ObsFunction/Arithmetic
-      options:
-        variables:
-        - name: ObsErrorData/stationPressure
-  defer to post: true
-# set ObsErrorData 100 Pa if it < 100 Pa.
-- filter: Perform Action
-  filter variables:
-  - name: stationPressure
-  action:
-    name: assign error
-    error parameter: 100
-  where:
-  - variable:
-      name: TempObsErrorData/stationPressure
-    maxvalue: 100
-  - variable:
-      name: TempObsErrorData/stationPressure
-    is_defined:
-  defer to post: true
-# set ObsErrorData 300 Pa if it > 300 Pa.
-- filter: Perform Action
-  filter variables:
-  - name: stationPressure
-  action:
-    name: assign error
-    error parameter: 300
-  where:
-  - variable:
-      name: TempObsErrorData/stationPressure
-    minvalue: 300
-  - variable:
-      name: TempObsErrorData/stationPressure
-    is_defined:
-  defer to post: true
+  - filter: Bounds Check
+    filter variables:
+    - name: stationPressure
+    minvalue: 49999
+    action:
+      name: reject
+  # PreUseFlag is assigned in reading programs in GSI.
+  - filter: Perform Action
+    filter variables:
+    - name: stationPressure
+    where:
+    - variable: PreUseFlag/stationPressure
+      # PreUseFlag should =< ijter ( # of outloop(0,1,2) + 1) in GSI
+      minvalue: 1
+    action:
+      name: reject
+  # PrepBUFR check to be supplemented later
+  - filter: RejectList
+    where:
+    - variable:
+        name: PreQC/stationPressure
+      is_in: 4-15
+  # error assignments
+  # Original error interpolated from the error table
+  - filter: Perform Action
+    filter variables:
+    - name: stationPressure
+    where:
+    - variable: ObsType/stationPressure
+      is_in: [181]
+    action:
+      name: assign error
+      error function:
+        name: ObsFunction/ObsErrorModelStepwiseLinear
+        options:
+          xvar:
+            name: ObsValue/stationPressure
+          xvals: [70000, 65000, 60000, 55000]
+          errors: [100,    120,   120, 1.0e+11]
+  - filter: Perform Action
+    filter variables:
+    - name: stationPressure
+    where:
+    - variable: ObsType/stationPressure
+      is_in: [187]
+    action:
+      name: assign error
+      error function:
+        name: ObsFunction/ObsErrorModelStepwiseLinear
+        options:
+          xvar:
+            name: ObsValue/stationPressure
+          xvals: [80000, 75000, 70000, 65000]
+          errors: [100,    130,   160, 1.0e+11]
+  # Ajusted error after reading prep_bufr
+  - filter: Perform Action
+    action:
+      name: inflate error
+      inflation factor: 1.2
+    where:
+    - variable: PreQC/stationPressure
+      is_in: [3]
+  # error inflation based on Ps correction
+  - filter: Perform Action
+    filter variables:
+    - name: stationPressure
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSfcPressure
+        options:
+          geovar_geomz: geopotential_height
+          geovar_sfc_geomz: surface_geometric_height
+          station_altitude: height
+  # assign TempObsErrorData/stationPressure <--- ObsErrorData before changing its Min and Max
+  - filter: Variable Assignment
+    assignments:
+    - name: TempObsErrorData/stationPressure
+      type: float
+      function:
+        name: ObsFunction/Arithmetic
+        options:
+          variables:
+          - name: ObsErrorData/stationPressure
+    defer to post: true
+  # set ObsErrorData 100 Pa if it < 100 Pa.
+  - filter: Perform Action
+    filter variables:
+    - name: stationPressure
+    action:
+      name: assign error
+      error parameter: 100
+    where:
+    - variable:
+        name: TempObsErrorData/stationPressure
+      maxvalue: 100
+    - variable:
+        name: TempObsErrorData/stationPressure
+      is_defined:
+    defer to post: true
+  # set ObsErrorData 300 Pa if it > 300 Pa.
+  - filter: Perform Action
+    filter variables:
+    - name: stationPressure
+    action:
+      name: assign error
+      error parameter: 300
+    where:
+    - variable:
+        name: TempObsErrorData/stationPressure
+      minvalue: 300
+    - variable:
+        name: TempObsErrorData/stationPressure
+      is_defined:
+    defer to post: true
 
-# Background check
-# background check for obstype 187:
-- filter: Background Check
-  filter variables:
-  - name: stationPressure
-  threshold: 4.0
-  action:
-    name: reject
-  where:
-  - variable: PreQC/stationPressure
-    is_not_in: [3]
-  - variable: ObsType/stationPressure
-    is_in: 187
-  defer to post: true
-# threshold 4.0 * 0.7 = 2.8 if PreQC=3
-- filter: Background Check
-  filter variables:
-  - name: stationPressure
-  threshold: 2.8
-  action:
-    name: reject
-  where:
-  - variable: PreQC/stationPressure
-    is_in: [3]
-  - variable: ObsType/stationPressure
-    is_in: 187
-  defer to post: true
-# background check for obstype 181:
-# threshold 3.6 if PreQC /= 3
-- filter: Background Check
-  filter variables:
-  - name: stationPressure
-  threshold: 3.6
-  action:
-    name: reject
-  where:
-  - variable: PreQC/stationPressure
-    is_not_in: [3]
-  - variable: ObsType/stationPressure
-    is_in: [181]
-  defer to post: true
-# threshold 3.6 * 0.7 = 2.52 if PreQC=3
-- filter: Background Check
-  filter variables:
-  - name: stationPressure
-  threshold: 2.52
-  action:
-    name: reject
-  where:
-  - variable: PreQC/stationPressure
-    is_in: [3]
-  - variable: ObsType/stationPressure
-    is_in: [181]
-  defer to post: true
-# Re-assign error ObsErrorData/stationPressure <--- TempObsErrorData/stationPressure
-- filter: Perform Action
-  filter variables:
-  - name: stationPressure
-  action:
-    name: assign error
-    error function: TempObsErrorData/stationPressure
-  where:
-  - variable:
-      name: TempObsErrorData/stationPressure
-    is_defined:
-  defer to post: true
+# Background check 
+  # background check for obstype 187:
+  - filter: Background Check
+    filter variables:
+    - name: stationPressure
+    threshold: 4.0
+    action:
+      name: reject
+    where:
+    - variable: PreQC/stationPressure
+      is_not_in: [3]
+    - variable: ObsType/stationPressure
+      is_in: 187
+    defer to post: true
+  # threshold 4.0 * 0.7 = 2.8 if PreQC=3
+  - filter: Background Check
+    filter variables:
+    - name: stationPressure
+    threshold: 2.8
+    action:
+      name: reject
+    where:
+    - variable: PreQC/stationPressure
+      is_in: [3]
+    - variable: ObsType/stationPressure
+      is_in: 187
+    defer to post: true
+  # background check for obstype 181:
+  # threshold 3.6 if PreQC /= 3
+  - filter: Background Check
+    filter variables:
+    - name: stationPressure
+    threshold: 3.6
+    action:
+      name: reject
+    where:
+    - variable: PreQC/stationPressure
+      is_not_in: [3]
+    - variable: ObsType/stationPressure
+      is_in: [181]
+    defer to post: true
+  # threshold 3.6 * 0.7 = 2.52 if PreQC=3
+  - filter: Background Check
+    filter variables:
+    - name: stationPressure
+    threshold: 2.52
+    action:
+      name: reject
+    where:
+    - variable: PreQC/stationPressure
+      is_in: [3]
+    - variable: ObsType/stationPressure
+      is_in: [181]
+    defer to post: true
+  # Re-assign error ObsErrorData/stationPressure <--- TempObsErrorData/stationPressure
+  - filter: Perform Action
+    filter variables:
+    - name: stationPressure
+    action:
+      name: assign error
+      error function: TempObsErrorData/stationPressure
+    where:
+    - variable:
+        name: TempObsErrorData/stationPressure
+      is_defined:
+    defer to post: true
 # Duplicate factor
-- filter: Perform Action
-  filter variables:
-  - name: stationPressure
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorDuplicateCheck
-      options:
-        use_air_pressure: false
-        variable: stationPressure
-  defer to post: true
+  - filter: Perform Action
+    filter variables:
+    - name: stationPressure
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorDuplicateCheck
+        options:
+          use_air_pressure: false
+          variable: stationPressure
+    defer to post: true
 
 ## specificHumidity. Both types 181 & 187 are rejected.
-- filter: Perform Action
-  filter variables:
-  - name: specificHumidity
-  where:
-  - variable: ObsType/specificHumidity
-    is_in: 181,187
-  action:
-    name: reject
+  - filter: Perform Action
+    filter variables:
+    - name: specificHumidity
+    where:
+    - variable: ObsType/specificHumidity
+      is_in: 181,187
+    action:
+      name: reject
 
 ## airTemperature. Both types 181 & 187 are rejected.
-- filter: Perform Action
-  filter variables:
-  - name: airTemperature
-  where:
-  - variable: ObsType/airTemperature
-    is_in: 181,187
-  action:
-    name: reject
+  - filter: Perform Action
+    filter variables:
+    - name: airTemperature
+    where:
+    - variable: ObsType/airTemperature
+      is_in: 181,187
+    action:
+      name: reject
 
 ## virtualTemperature. Both types 181 & 187 are rejected.
-- filter: Perform Action
-  filter variables:
-  - name: virtualTemperature
-  where:
-  - variable: ObsType/virtualTemperature
-    is_in: 181,187
-  action:
-    name: reject
+  - filter: Perform Action
+    filter variables:
+    - name: virtualTemperature
+    where:
+    - variable: ObsType/virtualTemperature
+      is_in: 181,187
+    action:
+      name: reject
 
 ## windEastward. Both types 281 & 287 are rejected.
-- filter: Perform Action
-  filter variables:
-  - name: windEastward
-  where:
-  - variable: ObsType/windEastward
-    is_in: 281,287
-  action:
-    name: reject
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    where:
+    - variable: ObsType/windEastward
+      is_in: 281,287
+    action:
+      name: reject
 
 ## windNorthward. Both types 281 & 287 are rejected.
-- filter: Perform Action
-  filter variables:
-  - name: windNorthward
-  where:
-  - variable: ObsType/windNorthward
-    is_in: 281,287
-  action:
-    name: reject
+  - filter: Perform Action
+    filter variables:
+    - name: windNorthward
+    where:
+    - variable: ObsType/windNorthward
+      is_in: 281,287
+    action:
+      name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ufo_tests.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ufo_tests.yaml
@@ -193,7 +193,7 @@ sfc:
   operator_test:
     rms ref: 1.0e-1
   filter_test:
-    passedBenchmark: 1
+    passedBenchmark: 71960
 
 sondes:
   operator_test:

--- a/src/swell/test/suite_tests/ufo_testing-stable_build.yaml
+++ b/src/swell/test/suite_tests/ufo_testing-stable_build.yaml
@@ -33,13 +33,12 @@ models:
     - mhs_metop-c
     - mhs_n19
     #- mls55_aura
-    #- obsop_name_map
     #- omi_aura
     #- ompsnm_npp
     - satwind
     - scatwind
     #- sfcship
-    #- sfc
+    - sfc
     #- sondes
     - ssmis_f17
     produce_geovals: false


### PR DESCRIPTION
Add configuration for sfc (marine surface) observations.
Note: The benchmark number is made with Obs and GeoVal files:
/discover/nobackup/jjin3/jedi/For_others/x0048.jj_20230818/conv/combine_conv/obs/sfc_obs_2021121200.nc4
/discover/nobackup/jjin3/jedi/For_others/x0048.jj_20230818/conv/combine_conv/geoval/sfc_geoval_2021121200.nc4
These files are created from GSI output in /discover/nobackup/projects/gmao/obsdev/jjin3/archive/x0048.jj_20230818/obs/.