### PR TITLE
Add observation version controlling

### DIFF
--- a/src/swell/test/suite_tests/hofx-stable_build.yaml
+++ b/src/swell/test/suite_tests/hofx-stable_build.yaml
@@ -32,10 +32,12 @@ models:
     - mls55_aura
     - omi_aura
     - ompsnm_npp
-    #- pibal
+    - pibal
     - satwind
     - scatwind
-    #- sfcship
-    #- sfc
-    #- sondes
+    - sfcship
+    - sfc
+    - sondes
     - ssmis_f17
+    obs_experiment: x0048v1
+    geovals_experiment: x0048v1-geovals

--- a/src/swell/test/suite_tests/ufo_testing-stable_build.yaml
+++ b/src/swell/test/suite_tests/ufo_testing-stable_build.yaml
@@ -57,3 +57,6 @@ models:
     - gsi_ncdiags/aircraft/*.nc4
     - gsi_ncdiags/aircraft
     - gsi_ncdiags
+    path_to_gsi_nc_diags: /discover/nobackup/drholdaw/SwellTestData/ufo_testing/ncdiagv1/%Y%m%d%H
+    obs_experiment: x0048v1
+    geovals_experiment: x0048v1-geovals


### PR DESCRIPTION
## Description

Turn on remaining observations for h(x) and add version controlling of the observations ahead of updating them with the new wind scaling factors.