### PR TITLE
Bring YAMLs up to date with new eva and parallelize the EvaObservation task

### DIFF
--- a/src/swell/deployment/platforms/nccs_discover/modules
+++ b/src/swell/deployment/platforms/nccs_discover/modules
@@ -43,7 +43,7 @@ module load other/mepo
 module use -a /discover/nobackup/drholdaw/JediOpt/modulefiles/core
 module load solo/swell-1.0.0
 module load r2d2/swell-1.0.5
-module load eva/1.3.5
+module load eva/1.6.0-spackstack1.4
 module load jedi_bundle/1.0.14-swell
 
 # Set the swell paths

--- a/src/swell/deployment/prep_suite.py
+++ b/src/swell/deployment/prep_suite.py
@@ -121,6 +121,7 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
     slurm_tasks = [
         'BuildJedi',
         'BuildGeos',
+        'EvaObservations',
         'GenerateBClimatology',
         'RunJediHofxExecutable',
         'RunJediLetkfExecutable',
@@ -138,7 +139,7 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
         render_dictionary['scheduling'][slurm_task]['account'] = account
         render_dictionary['scheduling'][slurm_task]['qos'] = qos
         render_dictionary['scheduling'][slurm_task]['nodes'] = 1
-        render_dictionary['scheduling'][slurm_task]['ntasks_per_node'] = 24
+        render_dictionary['scheduling'][slurm_task]['ntasks_per_node'] = 40
         render_dictionary['scheduling'][slurm_task]['constraint'] = constraint
         render_dictionary['scheduling'][slurm_task]['partition'] = partition
 
@@ -147,7 +148,6 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
 
     # run time
     render_dictionary['scheduling']['BuildJedi']['execution_time_limit'] = 'PT3H'
-    render_dictionary['scheduling']['RunJediHofxExecutable']['execution_time_limit'] = 'PT2H'
 
     # Render the template
     # -------------------

--- a/src/swell/deployment/prep_suite.py
+++ b/src/swell/deployment/prep_suite.py
@@ -148,6 +148,7 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
 
     # run time
     render_dictionary['scheduling']['BuildJedi']['execution_time_limit'] = 'PT3H'
+    render_dictionary['scheduling']['EvaObservations']['execution_time_limit'] = 'PT30M'
 
     # Render the template
     # -------------------

--- a/src/swell/suites/3dvar/eva/jedi_log-geos_ocean.yaml
+++ b/src/swell/suites/3dvar/eva/jedi_log-geos_ocean.yaml
@@ -1,56 +1,57 @@
-diagnostics:
+datasets:
 
-  # Data read
-  # ---------
-- data:
-    type: JediLog
-    collection_name: jedi_log_test
-    jedi_log_to_parse: '{{cycle_dir}}/jedi_variational_log.log'
-    data_to_parse:
-      convergence: true
+- type: JediLog
+  collection_name: jedi_log_test
+  jedi_log_to_parse: '{{cycle_dir}}/jedi_variational_log.log'
+  data_to_parse:
+    convergence: true
 
-  graphics:
-      - figure:
-          layout: [3,1]
-          figure size: [12,10]
-          title: 'Gradient and Norm Reduction Plots RPCG'
-          output name: '{{cycle_dir}}/eva/jedi_log/convergence/norm_gradient_reduction.png'
-        plots:
-          - add_xlabel: 'Total inner iteration number'
-            add_ylabel: 'Gradient reduction'
-            layers:
-            - type: LinePlot
-              x:
-                variable: jedi_log_test::convergence::total_iteration
-              y:
-                variable: jedi_log_test::convergence::gradient_reduction
-              color: 'black'
+graphics:
 
-          - add_xlabel: 'Total inner iteration number'
-            add_ylabel: 'Norm reduction'
-            layers:
-            - type: LinePlot
-              x:
-                variable: jedi_log_test::convergence::total_iteration
-              y:
-                variable: jedi_log_test::convergence::norm_reduction
-              color: 'black'
+  plotting_backend: Emcpy
+  figure_list:
 
-          - add_xlabel: 'Total inner iteration number'
-            add_ylabel: 'Normalized Value'
-            add_legend:
-            layers:
-            - type: LinePlot
-              x:
-                variable: jedi_log_test::convergence::total_iteration
-              y:
-                variable: jedi_log_test::convergence::gradient_reduction_normalized
-              color: 'red'
-              label: 'Normalized gradient reduction'
-            - type: LinePlot
-              x:
-                variable: jedi_log_test::convergence::total_iteration
-              y:
-                variable: jedi_log_test::convergence::norm_reduction_normalized
-              color: 'blue'
-              label: 'Normalized norm reduction'
+  - figure:
+      layout: [3,1]
+      figure size: [12,10]
+      title: 'Gradient and Norm Reduction Plots RPCG'
+      output name: '{{cycle_dir}}/eva/jedi_log/convergence/norm_gradient_reduction.png'
+    plots:
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Gradient reduction'
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::gradient_reduction
+          color: 'black'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Norm reduction'
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::norm_reduction
+          color: 'black'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Normalized Value'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::gradient_reduction_normalized
+          color: 'red'
+          label: 'Normalized gradient reduction'
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::norm_reduction_normalized
+          color: 'blue'
+          label: 'Normalized norm reduction'

--- a/src/swell/suites/3dvar/eva/observations-geos_ocean.yaml
+++ b/src/swell/suites/3dvar/eva/observations-geos_ocean.yaml
@@ -1,293 +1,293 @@
-diagnostics:
+datasets:
 
-- data:
-    type: IodaObsSpace
-    datasets:
+- name: experiment
+  type: IodaObsSpace
+  filenames:
+    - {{obs_path_file}}
+  groups:
+    - name: ObsValue
+      variables: &variables {{simulated_variables}}
+    - name: hofx0
+    - name: hofx1
+    - name: ombg
+    - name: oman
+    - name: MetaData
+    - name: EffectiveQC0
+    - name: EffectiveQC1
 
-      - name: experiment
-        filenames:
-          - {{obs_path_file}}
-        groups:
-          - name: ObsValue
-            variables: &variables {{simulated_variables}}
-          - name: hofx0
-          - name: hofx1
-          - name: ombg
-          - name: oman
-          - name: MetaData
-          - name: EffectiveQC0
-          - name: EffectiveQC1
+transforms:
 
-  transforms:
+# Generate Increment for JEDI
+- transform: arithmetic
+  new name: experiment::increment::${variable}
+  equals: experiment::ombg::${variable}-experiment::oman::${variable}
+  for:
+    variable: *variables
 
-    # Generate Increment for JEDI
-    - transform: arithmetic
-      new name: experiment::increment::${variable}
-      equals: experiment::ombg::${variable}-experiment::oman::${variable}
-      for:
-        variable: *variables
+# Generate hofx0 that passed QC for JEDI
+- transform: accept where
+  new name: experiment::hofx0PassedQc::${variable}
+  starting field: experiment::hofx0::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate hofx0 that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::hofx0PassedQc::${variable}
-      starting field: experiment::hofx0::${variable}
-      where:
-        - experiment::EffectiveQC0::${variable} == 0
-      for:
-        variable: *variables
+# Generate hofx1 that passed QC for JEDI
+- transform: accept where
+  new name: experiment::hofx1PassedQc::${variable}
+  starting field: experiment::hofx1::${variable}
+  where:
+    - experiment::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate hofx1 that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::hofx1PassedQc::${variable}
-      starting field: experiment::hofx1::${variable}
-      where:
-        - experiment::EffectiveQC1::${variable} == 0
-      for:
-        variable: *variables
+# Generate ombg that passed QC for JEDI
+- transform: accept where
+  new name: experiment::ombgPassedQc::${variable}
+  starting field: experiment::ombg::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate ombg that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::ombgPassedQc::${variable}
-      starting field: experiment::ombg::${variable}
-      where:
-        - experiment::EffectiveQC0::${variable} == 0
-      for:
-        variable: *variables
+# Generate oman that passed QC for JEDI
+- transform: accept where
+  new name: experiment::omanPassedQc::${variable}
+  starting field: experiment::oman::${variable}
+  where:
+    - experiment::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate oman that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::omanPassedQc::${variable}
-      starting field: experiment::oman::${variable}
-      where:
-        - experiment::EffectiveQC1::${variable} == 0
-      for:
-        variable: *variables
+# Generate obs that passed QC for JEDI
+- transform: accept where
+  new name: experiment::ObsValuePassedQc::${variable}
+  starting field: experiment::ObsValue::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate obs that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::ObsValuePassedQc::${variable}
-      starting field: experiment::ObsValue::${variable}
-      where:
-        - experiment::EffectiveQC0::${variable} == 0
-      for:
-        variable: *variables
+graphics:
 
-  graphics:
+  plotting_backend: Emcpy
+  figure_list:
 
-    # Correlation scatter plots
-    # -------------------------
+  # Correlation scatter plots
+  # -------------------------
 
-    # JEDI h(x) vs Observations
-    - batch figure:
-        variables: *variables
-      figure:
-        layout: [1,1]
-        title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}/jedi_hofx_vs_obs_{{instrument}}_${variable}.png'
-      plots:
-        - add_xlabel: 'Observation Value'
-          add_ylabel: 'JEDI h(x)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            x:
-              variable: experiment::ObsValue::${variable}
-            y:
-              variable: experiment::hofx0PassedQc::${variable}
-            markersize: 5
-            color: 'black'
-            label: 'JEDI h(x) versus obs (all obs)'
-          - type: Scatter
-            x:
-              variable: experiment::ObsValue::${variable}
-            y:
-              variable: experiment::hofx1::${variable}
-            markersize: 5
-            color: 'red'
-            label: 'JEDI h(x) versus obs (passed QC in JEDI)'
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}/jedi_hofx_vs_obs_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Observation Value'
+        add_ylabel: 'JEDI h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofx0PassedQc::${variable}
+          markersize: 5
+          color: 'black'
+          label: 'JEDI h(x) versus obs (all obs)'
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofx1::${variable}
+          markersize: 5
+          color: 'red'
+          label: 'JEDI h(x) versus obs (passed QC in JEDI)'
 
-    # Histogram plots
-    # ---------------
+  # Histogram plots
+  # ---------------
 
-    # JEDI h(x) vs Observations
-    - batch figure:
-        variables: *variables
-      dynamic options:
-        - type: histogram_bins
-          data variable: experiment::omanPassedQc::${variable}
-          number of bins rule: 'rice'
-      figure:
-        layout: [1,1]
-        title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/histogram/${variable}/ombg_oman_{{instrument}}_${variable}.png'
-      plots:
-        - add_xlabel: 'Difference'
-          add_ylabel: 'Count'
-          set_xlim: [-3, 3]
-          add_legend:
-            loc: 'upper left'
-          statistics:
-            fields:
-              - field_name: experiment::ombgPassedQc::${variable}
-                xloc: 0.5
-                yloc: -0.10
-                kwargs:
-                  color: 'black'
-                  fontsize: 8
-                  fontfamily: monospace
-              - field_name: experiment::omanPassedQc::${variable}
-                xloc: 0.5
-                yloc: -0.13
-                kwargs:
-                  color: 'red'
-                  fontsize: 8
-                  fontfamily: monospace
-            statistics_variables:
-            - n
-            - min
-            - mean
-            - max
-            - std
-          layers:
-          - type: Histogram
-            data:
-              variable: experiment::ombgPassedQc::${variable}
-            color: 'red'
-            label: 'observations minus background '
-            bins: ${dynamic_bins}
-            alpha: 0.5
-            density: true
-          - type: Histogram
-            data:
-              variable: experiment::omanPassedQc::${variable}
-            color: 'blue'
-            label: 'observations minus analysis'
-            bins: ${dynamic_bins}
-            alpha: 0.5
-            density: true
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: histogram_bins
+        data variable: experiment::omanPassedQc::${variable}
+        number of bins rule: 'rice'
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/histogram/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Difference'
+        add_ylabel: 'Count'
+        set_xlim: [-3, 3]
+        add_legend:
+          loc: 'upper left'
+        statistics:
+          fields:
+            - field_name: experiment::ombgPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.10
+              kwargs:
+                color: 'black'
+                fontsize: 8
+                fontfamily: monospace
+            - field_name: experiment::omanPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.13
+              kwargs:
+                color: 'red'
+                fontsize: 8
+                fontfamily: monospace
+          statistics_variables:
+          - n
+          - min
+          - mean
+          - max
+          - std
+        layers:
+        - type: Histogram
+          data:
+            variable: experiment::ombgPassedQc::${variable}
+          color: 'red'
+          label: 'observations minus background '
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+        - type: Histogram
+          data:
+            variable: experiment::omanPassedQc::${variable}
+          color: 'blue'
+          label: 'observations minus analysis'
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
 
-    # Map plots
-    # ---------
-    # Increment
-    - batch figure:
-        variables: *variables
-      dynamic options:
-        - type: vminvmaxcmap
-          data variable: experiment::ombgPassedQc::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [2,1]
-        title: '{{instrument_title}} | Passed QC'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/ombg_oman_{{instrument}}_${variable}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: ObsValue
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::ombgPassedQc::${variable}
-            markersize: 2
-            label: OmAn
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+  # Map plots
+  # ---------
+  # Increment
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::ombgPassedQc::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [2,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::ombgPassedQc::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
 
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: ObsValue
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::omanPassedQc::${variable}
-            markersize: 2
-            label: OmBg
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::omanPassedQc::${variable}
+          markersize: 2
+          label: OmBg
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
 
-    - batch figure:
-        variables: *variables
-      dynamic options:
-        - type: vminvmaxcmap
-          data variable: experiment::EffectiveQC1::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [1,1]
-        title: '{{instrument_title}} | Passed QC'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/effectiveQC_{{instrument}}_${variable}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: EffectiveQC1
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::EffectiveQC1::${variable}
-            markersize: 2
-            label: OmAn
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::EffectiveQC1::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/effectiveQC_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: EffectiveQC1
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::EffectiveQC1::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
 
-    - batch figure:
-        variables: *variables
-      dynamic options:
-        - type: vminvmaxcmap
-          data variable: experiment::increment::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [1,1]
-        title: '{{instrument_title}} | Passed QC'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/increment_{{instrument}}_${variable}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: Increment (OmBg - OmAn)
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::increment::${variable}
-            markersize: 2
-            label: OmAn
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::increment::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/increment_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Increment (OmBg - OmAn)
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::increment::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}

--- a/src/swell/suites/3dvar/flow.cylc
+++ b/src/swell/suites/3dvar/flow.cylc
@@ -157,6 +157,18 @@
 
     [[EvaObservations-{{model_component}}]]
         script = "swell_task EvaObservations $config -d $datetime -m {{model_component}}"
+        platform = {{platform}}
+        execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
+        [[[directives]]]
+            --account = {{scheduling["EvaObservations"]["account"]}}
+            --qos = {{scheduling["EvaObservations"]["qos"]}}
+            --job-name = EvaObservations
+            --nodes={{scheduling["EvaObservations"]["nodes"]}}
+            --ntasks-per-node={{scheduling["EvaObservations"]["ntasks_per_node"]}}
+            --constraint={{scheduling["EvaObservations"]["constraint"]}}
+            {% if scheduling["EvaObservations"]["partition"] %}
+            --partition={{scheduling["EvaObservations"]["partition"]}}
+            {% endif %}
 
     [[SaveObsDiags-{{model_component}}]]
         script = "swell_task SaveObsDiags $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/3dvar_cycle/eva/jedi_log-geos_ocean.yaml
+++ b/src/swell/suites/3dvar_cycle/eva/jedi_log-geos_ocean.yaml
@@ -1,56 +1,57 @@
-diagnostics:
+datasets:
 
-  # Data read
-  # ---------
-- data:
-    type: JediLog
-    collection_name: jedi_log_test
-    jedi_log_to_parse: '{{cycle_dir}}/jedi_variational_log.log'
-    data_to_parse:
-      convergence: true
+- type: JediLog
+  collection_name: jedi_log_test
+  jedi_log_to_parse: '{{cycle_dir}}/jedi_variational_log.log'
+  data_to_parse:
+    convergence: true
 
-  graphics:
-      - figure:
-          layout: [3,1]
-          figure size: [12,10]
-          title: 'Gradient and Norm Reduction Plots RPCG'
-          output name: '{{cycle_dir}}/eva/jedi_log/convergence/norm_gradient_reduction.png'
-        plots:
-          - add_xlabel: 'Total inner iteration number'
-            add_ylabel: 'Gradient reduction'
-            layers:
-            - type: LinePlot
-              x:
-                variable: jedi_log_test::convergence::total_iteration
-              y:
-                variable: jedi_log_test::convergence::gradient_reduction
-              color: 'black'
+graphics:
 
-          - add_xlabel: 'Total inner iteration number'
-            add_ylabel: 'Norm reduction'
-            layers:
-            - type: LinePlot
-              x:
-                variable: jedi_log_test::convergence::total_iteration
-              y:
-                variable: jedi_log_test::convergence::norm_reduction
-              color: 'black'
+  plotting_backend: Emcpy
+  figure_list:
 
-          - add_xlabel: 'Total inner iteration number'
-            add_ylabel: 'Normalized Value'
-            add_legend:
-            layers:
-            - type: LinePlot
-              x:
-                variable: jedi_log_test::convergence::total_iteration
-              y:
-                variable: jedi_log_test::convergence::gradient_reduction_normalized
-              color: 'red'
-              label: 'Normalized gradient reduction'
-            - type: LinePlot
-              x:
-                variable: jedi_log_test::convergence::total_iteration
-              y:
-                variable: jedi_log_test::convergence::norm_reduction_normalized
-              color: 'blue'
-              label: 'Normalized norm reduction'
+  - figure:
+      layout: [3,1]
+      figure size: [12,10]
+      title: 'Gradient and Norm Reduction Plots RPCG'
+      output name: '{{cycle_dir}}/eva/jedi_log/convergence/norm_gradient_reduction.png'
+    plots:
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Gradient reduction'
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::gradient_reduction
+          color: 'black'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Norm reduction'
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::norm_reduction
+          color: 'black'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Normalized Value'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::gradient_reduction_normalized
+          color: 'red'
+          label: 'Normalized gradient reduction'
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::norm_reduction_normalized
+          color: 'blue'
+          label: 'Normalized norm reduction'

--- a/src/swell/suites/3dvar_cycle/eva/observations-geos_ocean.yaml
+++ b/src/swell/suites/3dvar_cycle/eva/observations-geos_ocean.yaml
@@ -1,294 +1,294 @@
-diagnostics:
+datasets:
 
-- data:
-    type: IodaObsSpace
-    datasets:
+- name: experiment
+  type: IodaObsSpace
+  filenames:
+    - {{obs_path_file}}
+  groups:
+    - name: ObsValue
+      variables: &variables {{simulated_variables}}
+    - name: hofx0
+    - name: hofx1
+    - name: ombg
+    - name: oman
+    - name: MetaData
+    - name: EffectiveQC0
+    - name: EffectiveQC1
 
-      - name: experiment
-        filenames:
-          - {{obs_path_file}}
-        groups:
-          - name: ObsValue
-            variables: &variables {{simulated_variables}}
-          - name: hofx0
-          - name: hofx1
-          - name: ombg
-          - name: oman
-          - name: MetaData
-          - name: EffectiveQC0
-          - name: EffectiveQC1
+transforms:
 
-  transforms:
+# Generate Increment for JEDI
+- transform: arithmetic
+  new name: experiment::increment::${variable}
+  equals: experiment::ombg::${variable}-experiment::oman::${variable}
+  for:
+    variable: *variables
 
-    # Generate Increment for JEDI
-    - transform: arithmetic
-      new name: experiment::increment::${variable}
-      equals: experiment::ombg::${variable}-experiment::oman::${variable}
-      for:
-        variable: *variables
+# Generate hofx0 that passed QC for JEDI
+- transform: accept where
+  new name: experiment::hofx0PassedQc::${variable}
+  starting field: experiment::hofx0::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate hofx0 that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::hofx0PassedQc::${variable}
-      starting field: experiment::hofx0::${variable}
-      where:
-        - experiment::EffectiveQC0::${variable} == 0
-      for:
-        variable: *variables
+# Generate hofx1 that passed QC for JEDI
+- transform: accept where
+  new name: experiment::hofx1PassedQc::${variable}
+  starting field: experiment::hofx1::${variable}
+  where:
+    - experiment::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate hofx1 that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::hofx1PassedQc::${variable}
-      starting field: experiment::hofx1::${variable}
-      where:
-        - experiment::EffectiveQC1::${variable} == 0
-      for:
-        variable: *variables
+# Generate ombg that passed QC for JEDI
+- transform: accept where
+  new name: experiment::ombgPassedQc::${variable}
+  starting field: experiment::ombg::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate ombg that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::ombgPassedQc::${variable}
-      starting field: experiment::ombg::${variable}
-      where:
-        - experiment::EffectiveQC0::${variable} == 0
-      for:
-        variable: *variables
+# Generate oman that passed QC for JEDI
+- transform: accept where
+  new name: experiment::omanPassedQc::${variable}
+  starting field: experiment::oman::${variable}
+  where:
+    - experiment::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate oman that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::omanPassedQc::${variable}
-      starting field: experiment::oman::${variable}
-      where:
-        - experiment::EffectiveQC1::${variable} == 0
-      for:
-        variable: *variables
+# Generate obs that passed QC for JEDI
+- transform: accept where
+  new name: experiment::ObsValuePassedQc::${variable}
+  starting field: experiment::ObsValue::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate obs that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::ObsValuePassedQc::${variable}
-      starting field: experiment::ObsValue::${variable}
-      where:
-        - experiment::EffectiveQC0::${variable} == 0
-      for:
-        variable: *variables
+graphics:
 
-  graphics:
+  plotting_backend: Emcpy
+  figure_list:
 
-    # Correlation scatter plots
-    # -------------------------
+  # Correlation scatter plots
+  # -------------------------
 
-    # JEDI h(x) vs Observations
-    - batch figure:
-        variables: *variables
-      figure:
-        layout: [1,1]
-        title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}/jedi_hofx_vs_obs_{{instrument}}_${variable}.png'
-      plots:
-        - add_xlabel: 'Observation Value'
-          add_ylabel: 'JEDI h(x)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            x:
-              variable: experiment::ObsValue::${variable}
-            y:
-              variable: experiment::hofx0PassedQc::${variable}
-            markersize: 5
-            color: 'black'
-            label: 'JEDI h(x) versus obs (all obs)'
-          - type: Scatter
-            x:
-              variable: experiment::ObsValue::${variable}
-            y:
-              variable: experiment::hofx1::${variable}
-            markersize: 5
-            color: 'red'
-            label: 'JEDI h(x) versus obs (passed QC in JEDI)'
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}/jedi_hofx_vs_obs_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Observation Value'
+        add_ylabel: 'JEDI h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofx0PassedQc::${variable}
+          markersize: 5
+          color: 'black'
+          label: 'JEDI h(x) versus obs (all obs)'
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofx1::${variable}
+          markersize: 5
+          color: 'red'
+          label: 'JEDI h(x) versus obs (passed QC in JEDI)'
 
-    # Histogram plots
-    # ---------------
+  # Histogram plots
+  # ---------------
 
-    # JEDI h(x) vs Observations
-    - batch figure:
-        variables: *variables
-      dynamic options:
-        - type: histogram_bins
-          data variable: experiment::omanPassedQc::${variable}
-          number of bins rule: 'rice'
-      figure:
-        layout: [1,1]
-        title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/histogram/${variable}/ombg_oman_{{instrument}}_${variable}.png'
-      plots:
-        - add_xlabel: 'Difference'
-          add_ylabel: 'Count'
-          set_xlim: [-3, 3]
-          add_legend:
-            loc: 'upper left'
-          statistics:
-            fields:
-              - field_name: experiment::omanPassedQc::${variable}
-                xloc: 0.5
-                yloc: -0.10
-                kwargs:
-                  color: 'blue'
-                  fontsize: 8
-                  fontfamily: monospace
-              - field_name: experiment::ombgPassedQc::${variable}
-                xloc: 0.5
-                yloc: -0.13
-                kwargs:
-                  color: 'red'
-                  fontsize: 8
-                  fontfamily: monospace
-            statistics_variables:
-            - n
-            - min
-            - mean
-            - max
-            - std
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: histogram_bins
+        data variable: experiment::omanPassedQc::${variable}
+        number of bins rule: 'rice'
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/histogram/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Difference'
+        add_ylabel: 'Count'
+        set_xlim: [-3, 3]
+        add_legend:
+          loc: 'upper left'
+        statistics:
+          fields:
+            - field_name: experiment::omanPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.10
+              kwargs:
+                color: 'blue'
+                fontsize: 8
+                fontfamily: monospace
+            - field_name: experiment::ombgPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.13
+              kwargs:
+                color: 'red'
+                fontsize: 8
+                fontfamily: monospace
+          statistics_variables:
+          - n
+          - min
+          - mean
+          - max
+          - std
 
-          layers:
-          - type: Histogram
-            data:
-              variable: experiment::ombgPassedQc::${variable}
-            color: 'red'
-            label: 'observations minus background '
-            bins: ${dynamic_bins}
-            alpha: 0.5
-            density: true
-          - type: Histogram
-            data:
-              variable: experiment::omanPassedQc::${variable}
-            color: 'blue'
-            label: 'observations minus analysis'
-            bins: ${dynamic_bins}
-            alpha: 0.5
-            density: true
+        layers:
+        - type: Histogram
+          data:
+            variable: experiment::ombgPassedQc::${variable}
+          color: 'red'
+          label: 'observations minus background '
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+        - type: Histogram
+          data:
+            variable: experiment::omanPassedQc::${variable}
+          color: 'blue'
+          label: 'observations minus analysis'
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
 
-    # Map plots
-    # ---------
-    # Increment
-    - batch figure:
-        variables: *variables
-      dynamic options:
-        - type: vminvmaxcmap
-          data variable: experiment::ombgPassedQc::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [2,1]
-        title: '{{instrument_title}} | Passed QC'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/ombg_oman_{{instrument}}_${variable}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: ObsValue
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::ombgPassedQc::${variable}
-            markersize: 2
-            label: OmAn
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+  # Map plots
+  # ---------
+  # Increment
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::ombgPassedQc::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [2,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::ombgPassedQc::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
 
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: ObsValue
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::omanPassedQc::${variable}
-            markersize: 2
-            label: OmBg
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::omanPassedQc::${variable}
+          markersize: 2
+          label: OmBg
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
 
-    - batch figure:
-        variables: *variables
-      dynamic options:
-        - type: vminvmaxcmap
-          data variable: experiment::EffectiveQC1::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [1,1]
-        title: '{{instrument_title}} | Passed QC'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/effectiveQC_{{instrument}}_${variable}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: EffectiveQC1
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::EffectiveQC1::${variable}
-            markersize: 2
-            label: OmAn
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::EffectiveQC1::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/effectiveQC_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: EffectiveQC1
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::EffectiveQC1::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
 
-    - batch figure:
-        variables: *variables
-      dynamic options:
-        - type: vminvmaxcmap
-          data variable: experiment::increment::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [1,1]
-        title: '{{instrument_title}} | Passed QC'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/increment_{{instrument}}_${variable}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: Increment (OmBg - OmAn)
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::increment::${variable}
-            markersize: 2
-            label: OmAn
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::increment::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/increment_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Increment (OmBg - OmAn)
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::increment::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}

--- a/src/swell/suites/3dvar_cycle/flow.cylc
+++ b/src/swell/suites/3dvar_cycle/flow.cylc
@@ -240,6 +240,18 @@
 
     [[EvaObservations-{{model_component}}]]
         script = "swell_task EvaObservations $config -d $datetime -m {{model_component}}"
+        platform = {{platform}}
+        execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
+        [[[directives]]]
+            --account = {{scheduling["EvaObservations"]["account"]}}
+            --qos = {{scheduling["EvaObservations"]["qos"]}}
+            --job-name = EvaObservations
+            --nodes={{scheduling["EvaObservations"]["nodes"]}}
+            --ntasks-per-node={{scheduling["EvaObservations"]["ntasks_per_node"]}}
+            --constraint={{scheduling["EvaObservations"]["constraint"]}}
+            {% if scheduling["EvaObservations"]["partition"] %}
+            --partition={{scheduling["EvaObservations"]["partition"]}}
+            {% endif %}
 
     [[SaveObsDiags-{{model_component}}]]
         script = "swell_task SaveObsDiags $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/hofx/eva/observations-geos_atmosphere.yaml
+++ b/src/swell/suites/hofx/eva/observations-geos_atmosphere.yaml
@@ -1,408 +1,404 @@
-diagnostics:
+datasets:
 
-- data:
-    type: IodaObsSpace
-    datasets:
+- name: experiment
+  type: IodaObsSpace
+  filenames:
+    - {{obs_path_file}}
+  channels: &channels {{channels}}
+  groups:
+    - name: ObsValue
+      variables: &variables {{simulated_variables}}
+    - name: GsiHofXBc
+    #- name: GsiEffectiveQC
+    - name: hofx
+    - name: EffectiveQC
+    - name: MetaData
 
-      - name: experiment
-        filenames:
-          - {{obs_path_file}}
-        channels: &channels {{channels}}
-        groups:
-          - name: ObsValue
-            variables: &variables {{simulated_variables}}
-          - name: GsiHofXBc
-          #- name: GsiEffectiveQC
-          - name: hofx
-          - name: EffectiveQC
-          - name: MetaData
+transforms:
 
-  transforms:
+# Generate omb for GSI
+- transform: arithmetic
+  new name: experiment::ObsValueMinusGsiHofXBc::${variable}
+  equals: experiment::ObsValue::${variable}-experiment::GsiHofXBc::${variable}
+  for:
+    variable: *variables
 
-    # Generate omb for GSI
-    - transform: arithmetic
-      new name: experiment::ObsValueMinusGsiHofXBc::${variable}
-      equals: experiment::ObsValue::${variable}-experiment::GsiHofXBc::${variable}
-      for:
-        variable: *variables
+# Generate omb for JEDI
+- transform: arithmetic
+  new name: experiment::ObsValueMinusHofx::${variable}
+  equals: experiment::ObsValue::${variable}-experiment::hofx::${variable}
+  for:
+    variable: *variables
 
-    # Generate omb for JEDI
-    - transform: arithmetic
-      new name: experiment::ObsValueMinusHofx::${variable}
-      equals: experiment::ObsValue::${variable}-experiment::hofx::${variable}
-      for:
-        variable: *variables
+# Generate hofx difference
+- transform: arithmetic
+  new name: experiment::HofxMinusGsiHofXBc::${variable}
+  equals: experiment::hofx::${variable}-experiment::GsiHofXBc::${variable}
+  for:
+    variable: *variables
 
-    # Generate hofx difference
-    - transform: arithmetic
-      new name: experiment::HofxMinusGsiHofXBc::${variable}
-      equals: experiment::hofx::${variable}-experiment::GsiHofXBc::${variable}
-      for:
-        variable: *variables
+# Generate hofx that passed QC for JEDI
+- transform: accept where
+  new name: experiment::hofxPassedQc::${variable}
+  starting field: experiment::hofx::${variable}
+  where:
+    - experiment::EffectiveQC::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate hofx that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::hofxPassedQc::${variable}
-      starting field: experiment::hofx::${variable}
-      where:
-        - experiment::EffectiveQC::${variable} == 0
-      for:
-        variable: *variables
+# Generate GSI hofx that passed JEDI QC
+- transform: accept where
+  new name: experiment::GsiHofXBcPassedQc::${variable}
+  starting field: experiment::GsiHofXBc::${variable}
+  where:
+    - experiment::EffectiveQC::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate GSI hofx that passed JEDI QC
-    - transform: accept where
-      new name: experiment::GsiHofXBcPassedQc::${variable}
-      starting field: experiment::GsiHofXBc::${variable}
-      where:
-        - experiment::EffectiveQC::${variable} == 0
-      for:
-        variable: *variables
+# Generate omb that passed QC for JEDI
+- transform: accept where
+  new name: experiment::ObsValueMinushofxPassedQc::${variable}
+  starting field: experiment::ObsValueMinusHofx::${variable}
+  where:
+    - experiment::EffectiveQC::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate omb that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::ObsValueMinushofxPassedQc::${variable}
-      starting field: experiment::ObsValueMinusHofx::${variable}
-      where:
-        - experiment::EffectiveQC::${variable} == 0
-      for:
-        variable: *variables
+# Generate omb that passed QC for GSI
+- transform: accept where
+  new name: experiment::ObsValueMinusGsiHofXBcPassedQc::${variable}
+  starting field: experiment::ObsValueMinusGsiHofXBc::${variable}
+  where:
+    - experiment::EffectiveQC::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate omb that passed QC for GSI
-    - transform: accept where
-      new name: experiment::ObsValueMinusGsiHofXBcPassedQc::${variable}
-      starting field: experiment::ObsValueMinusGsiHofXBc::${variable}
-      where:
-        - experiment::EffectiveQC::${variable} == 0
-      for:
-        variable: *variables
+graphics:
 
-  graphics:
+  plotting_backend: Emcpy
+  figure_list:
 
-    # Correlation scatter plots
-    # -------------------------
+  # Correlation scatter plots
+  # -------------------------
 
-    # JEDI h(x) vs Observations
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}${channel}/jedi_hofx_vs_obs_{{instrument}}_${variable}${channel}.png'
-      plots:
-        - add_xlabel: 'Observation Value'
-          add_ylabel: 'JEDI h(x)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            x:
-              variable: experiment::ObsValue::${variable}
-            y:
-              variable: experiment::hofx::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'black'
-            label: 'JEDI h(x) versus obs (all obs)'
-          - type: Scatter
-            x:
-              variable: experiment::ObsValue::${variable}
-            y:
-              variable: experiment::hofxPassedQc::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'red'
-            label: 'JEDI h(x) versus obs (passed QC in JEDI)'
-
-    # GSI h(x) vs Observations
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'Observations vs. GSI h(x) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}${channel}/gsi_hofx_vs_obs_{{instrument}}_${variable}${channel}.png'
-      plots:
-        - add_xlabel: 'Observation Value'
-          add_ylabel: 'GSI h(x)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            x:
-              variable: experiment::ObsValue::${variable}
-            y:
-              variable: experiment::GsiHofXBc::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'black'
-            label: 'GSI h(x) versus obs (all obs)'
-          - type: Scatter
-            x:
-              variable: experiment::ObsValue::${variable}
-            y:
-              variable: experiment::GsiHofXBcPassedQc::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'red'
-            label: 'GSI h(x) versus obs (passed QC in JEDI)'
-
-    # JEDI h(x) vs GSI h(x)
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'JEDI h(x) vs. GSI h(x) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}${channel}/gsi_hofx_vs_jedi_hofx_{{instrument}}_${variable}${channel}.png'
-      plots:
-        - add_xlabel: 'GSI h(x)'
-          add_ylabel: 'JEDI h(x)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            x:
-              variable: experiment::GsiHofXBc::${variable}
-            y:
-              variable: experiment::hofx::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'black'
-            label: 'JEDI h(x) versus GSI h(x)'
-          - type: Scatter
-            x:
-              variable: experiment::GsiHofXBcPassedQc::${variable}
-            y:
-              variable: experiment::hofxPassedQc::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'red'
-            label: 'JEDI h(x) versus GSI h(x) (passed QC in JEDI)'
-
-    # JEDI omb vs GSI omb
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'JEDI omb vs. GSI omb | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}${channel}/gsi_omb_vs_jedi_omb_{{instrument}}_${variable}${channel}.png'
-      plots:
-        - add_xlabel: 'GSI observation minus h(x)'
-          add_ylabel: 'JEDI observation minus h(x)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            x:
-              variable: experiment::ObsValueMinusGsiHofXBc::${variable}
-            y:
-              variable: experiment::ObsValueMinusHofx::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'black'
-            label: 'GSI omb vs JEDI omb (all obs)'
-          - type: Scatter
-            x:
-              variable: experiment::ObsValueMinusGsiHofXBcPassedQc::${variable}
-            y:
-              variable: experiment::ObsValueMinushofxPassedQc::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'red'
-            label: 'GSI omb vs JEDI omb (passed QC in JEDI)'
-
-# Map plots
-# ---------
-
-    # Observations
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      dynamic options:
-        - type: vminvmaxcmap
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}${channel}/jedi_hofx_vs_obs_{{instrument}}_${variable}${channel}.png'
+    plots:
+      - add_xlabel: 'Observation Value'
+        add_ylabel: 'JEDI h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofx::${variable}
           channel: ${channel}
-          data variable: experiment::ObsValue::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [1,1]
-        title: 'Observations | {{instrument_title}} | Obs Value'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}${channel}/observations_{{instrument}}_${variable}${channel}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: ObsValue
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::ObsValue::${variable}
-              channel: ${channel}
-            markersize: 2
-            label: ObsValue
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
-
-    # omb jedi
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      dynamic options:
-        - type: vminvmaxcmap
+          markersize: 5
+          color: 'black'
+          label: 'JEDI h(x) versus obs (all obs)'
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofxPassedQc::${variable}
           channel: ${channel}
-          data variable: experiment::ObsValueMinusHofx::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [1,1]
-        title: 'JEDI OmB | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}${channel}/omb_jedi_{{instrument}}_${variable}${channel}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: '${variable}'
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::ObsValueMinusHofx::${variable}
-              channel: ${channel}
-            markersize: 2
-            label: '${variable}'
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+          markersize: 5
+          color: 'red'
+          label: 'JEDI h(x) versus obs (passed QC in JEDI)'
 
-    # omb gsi
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      dynamic options:
-        - type: vminvmaxcmap
+  # GSI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. GSI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}${channel}/gsi_hofx_vs_obs_{{instrument}}_${variable}${channel}.png'
+    plots:
+      - add_xlabel: 'Observation Value'
+        add_ylabel: 'GSI h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::GsiHofXBc::${variable}
           channel: ${channel}
-          data variable: experiment::ObsValueMinusGsiHofXBc::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [1,1]
-        title: 'GSI OmB | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}${channel}/omb_gsi_{{instrument}}_${variable}${channel}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: '${variable}'
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::ObsValueMinusGsiHofXBc::${variable}
-              channel: ${channel}
-            markersize: 2
-            label: '${variable}'
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
-
-    # hofx difference
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      dynamic options:
-        - type: vminvmaxcmap
+          markersize: 5
+          color: 'black'
+          label: 'GSI h(x) versus obs (all obs)'
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::GsiHofXBcPassedQc::${variable}
           channel: ${channel}
-          data variable: experiment::HofxMinusGsiHofXBc::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [1,1]
-        title: 'Hofx Difference | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}${channel}/hofx_difference_{{instrument}}_${variable}${channel}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: '${variable}'
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::HofxMinusGsiHofXBc::${variable}
-              channel: ${channel}
-            markersize: 2
-            label: '${variable}'
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+          markersize: 5
+          color: 'red'
+          label: 'GSI h(x) versus obs (passed QC in JEDI)'
 
-# Histogram plots
-# ---------------
-
-    # omb vs omb
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      dynamic options:
-        - type: histogram_bins
+  # JEDI h(x) vs GSI h(x)
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'JEDI h(x) vs. GSI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}${channel}/gsi_hofx_vs_jedi_hofx_{{instrument}}_${variable}${channel}.png'
+    plots:
+      - add_xlabel: 'GSI h(x)'
+        add_ylabel: 'JEDI h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          x:
+            variable: experiment::GsiHofXBc::${variable}
+          y:
+            variable: experiment::hofx::${variable}
           channel: ${channel}
-          number of bins rule: sturges
-          data variable: experiment::ObsValueMinusHofx::${variable}
-      figure:
-        layout: [1,1]
-        title: 'JEDI omb vs. GSI omb | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/histograms/${variable}${channel}/gsi_omb_vs_jedi_omb_{{instrument}}_${variable}${channel}.png'
-      plots:
-        - add_xlabel: 'Observation minus h(x)'
-          add_ylabel: 'Count'
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Histogram
-            data:
-              variable: experiment::ObsValueMinusGsiHofXBc::${variable}
-              channel: ${channel}
-            color: 'blue'
-            label: 'GSI omb (all obs)'
-            bins: ${dynamic_bins}
-            alpha: 0.5
-          - type: Histogram
-            data:
-              variable: experiment::ObsValueMinusHofx::${variable}
-              channel: ${channel}
-            color: 'red'
-            label: 'JEDI omb (all obs)'
-            bins: ${dynamic_bins}
-            alpha: 0.5
+          markersize: 5
+          color: 'black'
+          label: 'JEDI h(x) versus GSI h(x)'
+        - type: Scatter
+          x:
+            variable: experiment::GsiHofXBcPassedQc::${variable}
+          y:
+            variable: experiment::hofxPassedQc::${variable}
+          channel: ${channel}
+          markersize: 5
+          color: 'red'
+          label: 'JEDI h(x) versus GSI h(x) (passed QC in JEDI)'
+
+  # JEDI omb vs GSI omb
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'JEDI omb vs. GSI omb | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}${channel}/gsi_omb_vs_jedi_omb_{{instrument}}_${variable}${channel}.png'
+    plots:
+      - add_xlabel: 'GSI observation minus h(x)'
+        add_ylabel: 'JEDI observation minus h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          x:
+            variable: experiment::ObsValueMinusGsiHofXBc::${variable}
+          y:
+            variable: experiment::ObsValueMinusHofx::${variable}
+          channel: ${channel}
+          markersize: 5
+          color: 'black'
+          label: 'GSI omb vs JEDI omb (all obs)'
+        - type: Scatter
+          x:
+            variable: experiment::ObsValueMinusGsiHofXBcPassedQc::${variable}
+          y:
+            variable: experiment::ObsValueMinushofxPassedQc::${variable}
+          channel: ${channel}
+          markersize: 5
+          color: 'red'
+          label: 'GSI omb vs JEDI omb (passed QC in JEDI)'
+# Map plots# ---------
+
+  # Observations
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    dynamic options:
+      - type: vminvmaxcmap
+        channel: ${channel}
+        data variable: experiment::ObsValue::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'Observations | {{instrument_title}} | Obs Value'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}${channel}/observations_{{instrument}}_${variable}${channel}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::ObsValue::${variable}
+            channel: ${channel}
+          markersize: 2
+          label: ObsValue
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  # omb jedi
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    dynamic options:
+      - type: vminvmaxcmap
+        channel: ${channel}
+        data variable: experiment::ObsValueMinusHofx::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'JEDI OmB | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}${channel}/omb_jedi_{{instrument}}_${variable}${channel}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: '${variable}'
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::ObsValueMinusHofx::${variable}
+            channel: ${channel}
+          markersize: 2
+          label: '${variable}'
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  # omb gsi
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    dynamic options:
+      - type: vminvmaxcmap
+        channel: ${channel}
+        data variable: experiment::ObsValueMinusGsiHofXBc::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'GSI OmB | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}${channel}/omb_gsi_{{instrument}}_${variable}${channel}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: '${variable}'
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::ObsValueMinusGsiHofXBc::${variable}
+            channel: ${channel}
+          markersize: 2
+          label: '${variable}'
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  # hofx difference
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    dynamic options:
+      - type: vminvmaxcmap
+        channel: ${channel}
+        data variable: experiment::HofxMinusGsiHofXBc::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'Hofx Difference | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}${channel}/hofx_difference_{{instrument}}_${variable}${channel}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: '${variable}'
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::HofxMinusGsiHofXBc::${variable}
+            channel: ${channel}
+          markersize: 2
+          label: '${variable}'
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+# Histogram plots# ---------------
+
+  # omb vs omb
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    dynamic options:
+      - type: histogram_bins
+        channel: ${channel}
+        number of bins rule: sturges
+        data variable: experiment::ObsValueMinusHofx::${variable}
+    figure:
+      layout: [1,1]
+      title: 'JEDI omb vs. GSI omb | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/histograms/${variable}${channel}/gsi_omb_vs_jedi_omb_{{instrument}}_${variable}${channel}.png'
+    plots:
+      - add_xlabel: 'Observation minus h(x)'
+        add_ylabel: 'Count'
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Histogram
+          data:
+            variable: experiment::ObsValueMinusGsiHofXBc::${variable}
+            channel: ${channel}
+          color: 'blue'
+          label: 'GSI omb (all obs)'
+          bins: ${dynamic_bins}
+          alpha: 0.5
+        - type: Histogram
+          data:
+            variable: experiment::ObsValueMinusHofx::${variable}
+            channel: ${channel}
+          color: 'red'
+          label: 'JEDI omb (all obs)'
+          bins: ${dynamic_bins}
+          alpha: 0.5

--- a/src/swell/suites/hofx/eva/observations-geos_ocean.yaml
+++ b/src/swell/suites/hofx/eva/observations-geos_ocean.yaml
@@ -1,148 +1,146 @@
-diagnostics:
+datasets:
 
-- data:
-    type: IodaObsSpace
-    datasets:
+- name: experiment
+  type: IodaObsSpace
+  filenames:
+    - {{obs_path_file}}
+  groups:
+    - name: ObsValue
+      variables: &variables {{simulated_variables}}
+    - name: hofx
+    - name: EffectiveQC
+    - name: MetaData
 
-      - name: experiment
-        filenames:
-          - {{obs_path_file}}
-        groups:
-          - name: ObsValue
-            variables: &variables {{simulated_variables}}
-          - name: hofx
-          - name: EffectiveQC
-          - name: MetaData
+transforms:
 
-  transforms:
+# Generate omb for JEDI
+- transform: arithmetic
+  new name: experiment::ObsValueMinusHofx::${variable}
+  equals: experiment::ObsValue::${variable}-experiment::hofx::${variable}
+  for:
+    variable: *variables
 
-    # Generate omb for JEDI
-    - transform: arithmetic
-      new name: experiment::ObsValueMinusHofx::${variable}
-      equals: experiment::ObsValue::${variable}-experiment::hofx::${variable}
-      for:
-        variable: *variables
+# Generate hofx that passed QC for JEDI
+- transform: accept where
+  new name: experiment::hofxPassedQc::${variable}
+  starting field: experiment::hofx::${variable}
+  where:
+    - experiment::EffectiveQC::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate hofx that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::hofxPassedQc::${variable}
-      starting field: experiment::hofx::${variable}
-      where:
-        - experiment::EffectiveQC::${variable} == 0
-      for:
-        variable: *variables
+# Generate omb that passed QC for JEDI
+- transform: accept where
+  new name: experiment::ObsValueMinushofxPassedQc::${variable}
+  starting field: experiment::ObsValueMinusHofx::${variable}
+  where:
+    - experiment::EffectiveQC::${variable} == 0
+  for:
+    variable: *variables
 
-    # Generate omb that passed QC for JEDI
-    - transform: accept where
-      new name: experiment::ObsValueMinushofxPassedQc::${variable}
-      starting field: experiment::ObsValueMinusHofx::${variable}
-      where:
-        - experiment::EffectiveQC::${variable} == 0
-      for:
-        variable: *variables
+graphics:
 
-  graphics:
+  plotting_backend: Emcpy
+  figure_list:
 
-    # Correlation scatter plots
-    # -------------------------
+  # Correlation scatter plots
+  # -------------------------
 
-    # JEDI h(x) vs Observations
-    - batch figure:
-        variables: *variables
-      figure:
-        layout: [1,1]
-        title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}/jedi_hofx_vs_obs_{{instrument}}_${variable}.png'
-      plots:
-        - add_xlabel: 'Observation Value'
-          add_ylabel: 'JEDI h(x)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            x:
-              variable: experiment::ObsValue::${variable}
-            y:
-              variable: experiment::hofx::${variable}
-            markersize: 5
-            color: 'black'
-            label: 'JEDI h(x) versus obs (all obs)'
-          - type: Scatter
-            x:
-              variable: experiment::ObsValue::${variable}
-            y:
-              variable: experiment::hofxPassedQc::${variable}
-            markersize: 5
-            color: 'red'
-            label: 'JEDI h(x) versus obs (passed QC in JEDI)'
-# Map plots
-# ---------
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}/jedi_hofx_vs_obs_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Observation Value'
+        add_ylabel: 'JEDI h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofx::${variable}
+          markersize: 5
+          color: 'black'
+          label: 'JEDI h(x) versus obs (all obs)'
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofxPassedQc::${variable}
+          markersize: 5
+          color: 'red'
+          label: 'JEDI h(x) versus obs (passed QC in JEDI)'# Map plots# ---------
 
-    # Observations
-    - batch figure:
-        variables: *variables
-      dynamic options:
-        - type: vminvmaxcmap
-          data variable: experiment::ObsValue::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [1,1]
-        title: 'Observations | {{instrument_title}} | Obs Value'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/observations_{{instrument}}_${variable}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: ObsValue
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::ObsValue::${variable}
-            markersize: 2
-            label: ObsValue
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+  # Observations
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::ObsValue::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'Observations | {{instrument_title}} | Obs Value'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/observations_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::ObsValue::${variable}
+          markersize: 2
+          label: ObsValue
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
 
-    # omb jedi
-    - batch figure:
-        variables: *variables
-      dynamic options:
-        - type: vminvmaxcmap
-          data variable: experiment::ObsValueMinusHofx::${variable}
-      figure:
-        figure size: [20,10]
-        layout: [1,1]
-        title: 'JEDI OmB | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/omb_jedi_{{instrument}}_${variable}.png'
-      plots:
-        - mapping:
-            projection: plcarr
-            domain: global
-          add_map_features: ['coastline']
-          add_colorbar:
-            label: '${variable}'
-          add_grid:
-          layers:
-          - type: MapScatter
-            longitude:
-              variable: experiment::MetaData::longitude
-            latitude:
-              variable: experiment::MetaData::latitude
-            data:
-              variable: experiment::ObsValueMinusHofx::${variable}
-            markersize: 2
-            label: '${variable}'
-            colorbar: true
-            cmap: ${dynamic_cmap}
-            vmin: ${dynamic_vmin}
-            vmax: ${dynamic_vmax}
+  # omb jedi
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::ObsValueMinusHofx::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'JEDI OmB | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/omb_jedi_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: '${variable}'
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::ObsValueMinusHofx::${variable}
+          markersize: 2
+          label: '${variable}'
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}

--- a/src/swell/suites/hofx/flow.cylc
+++ b/src/swell/suites/hofx/flow.cylc
@@ -144,6 +144,18 @@
 
     [[EvaObservations-{{model_component}}]]
         script = "swell_task EvaObservations $config -d $datetime -m {{model_component}}"
+        platform = {{platform}}
+        execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
+        [[[directives]]]
+            --account = {{scheduling["EvaObservations"]["account"]}}
+            --qos = {{scheduling["EvaObservations"]["qos"]}}
+            --job-name = EvaObservations
+            --nodes={{scheduling["EvaObservations"]["nodes"]}}
+            --ntasks-per-node={{scheduling["EvaObservations"]["ntasks_per_node"]}}
+            --constraint={{scheduling["EvaObservations"]["constraint"]}}
+            {% if scheduling["EvaObservations"]["partition"] %}
+            --partition={{scheduling["EvaObservations"]["partition"]}}
+            {% endif %}
 
     [[SaveObsDiags-{{model_component}}]]
         script = "swell_task SaveObsDiags $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/ufo_testing/eva/observations-geos_atmosphere.yaml
+++ b/src/swell/suites/ufo_testing/eva/observations-geos_atmosphere.yaml
@@ -1,390 +1,385 @@
-diagnostics:
+datasets:
 
-- data:
-    type: IodaObsSpace
-    datasets:
+- name: experiment
+  type: IodaObsSpace
+  filenames:
+    - {{obs_path_file}}
+  missing_value_threshold: 1.0e06
+  channels: &channels {{channels}}
+  groups:
+    - name: ObsValue
+      variables: &variables {{simulated_variables}}
+    - name: MetaData
+    # Jedi
+    - name: hofx
+    - name: EffectiveQC
+    - name: EffectiveError
+    # Gsi
+    - name: GsiHofX
+    - name: GsiHofXBc
+    - name: GsiEffectiveQC
+    - name: GsiFinalObsError
 
-      - name: experiment
-        filenames:
-          - {{obs_path_file}}
-        missing_value_threshold: 1.0e06
-        channels: &channels {{channels}}
-        groups:
-          - name: ObsValue
-            variables: &variables {{simulated_variables}}
-          - name: MetaData
-          # Jedi
-          - name: hofx
-          - name: EffectiveQC
-          - name: EffectiveError
-          # Gsi
-          - name: GsiHofX
-          - name: GsiHofXBc
-          - name: GsiEffectiveQC
-          - name: GsiFinalObsError
+transforms:
 
-  transforms:
+# Hofx differences
+# ----------------
 
-    # Hofx differences
-    # ----------------
+- transform: arithmetic
+  new name: experiment::hofxDiff::${variable}
+  equals: experiment::hofx::${variable}-experiment::GsiHofX::${variable}
+  for:
+    variable: *variables
 
-    - transform: arithmetic
-      new name: experiment::hofxDiff::${variable}
-      equals: experiment::hofx::${variable}-experiment::GsiHofX::${variable}
-      for:
-        variable: *variables
+- transform: arithmetic
+  new name: experiment::hofxDiffBc::${variable}
+  equals: experiment::hofx::${variable}-experiment::GsiHofXBc::${variable}
+  for:
+    variable: *variables
 
-    - transform: arithmetic
-      new name: experiment::hofxDiffBc::${variable}
-      equals: experiment::hofx::${variable}-experiment::GsiHofXBc::${variable}
-      for:
-        variable: *variables
+# Observation minus Hofx
+# ----------------------
 
-    # Observation minus Hofx
-    # ----------------------
+- transform: arithmetic
+  new name: experiment::ObsValueMinusHofx::${variable}
+  equals: experiment::ObsValue::${variable}-experiment::hofx::${variable}
+  for:
+    variable: *variables
 
-    - transform: arithmetic
-      new name: experiment::ObsValueMinusHofx::${variable}
-      equals: experiment::ObsValue::${variable}-experiment::hofx::${variable}
-      for:
-        variable: *variables
+- transform: arithmetic
+  new name: experiment::ObsValueMinusGsiHofX::${variable}
+  equals: experiment::ObsValue::${variable}-experiment::GsiHofX::${variable}
+  for:
+    variable: *variables
 
-    - transform: arithmetic
-      new name: experiment::ObsValueMinusGsiHofX::${variable}
-      equals: experiment::ObsValue::${variable}-experiment::GsiHofX::${variable}
-      for:
-        variable: *variables
+- transform: arithmetic
+  new name: experiment::ObsValueMinusGsiHofXBc::${variable}
+  equals: experiment::ObsValue::${variable}-experiment::GsiHofXBc::${variable}
+  for:
+    variable: *variables
 
-    - transform: arithmetic
-      new name: experiment::ObsValueMinusGsiHofXBc::${variable}
-      equals: experiment::ObsValue::${variable}-experiment::GsiHofXBc::${variable}
-      for:
-        variable: *variables
+# Effective error that passed QC
+# ------------------------------
 
-    # Effective error that passed QC
-    # ------------------------------
+- transform: accept where
+  new name: experiment::EffectiveErrorPassedQc::${variable}
+  starting field: experiment::EffectiveError::${variable}
+  where:
+    - experiment::EffectiveQC::${variable} == 0
+  for:
+    variable: *variables
 
-    - transform: accept where
-      new name: experiment::EffectiveErrorPassedQc::${variable}
-      starting field: experiment::EffectiveError::${variable}
-      where:
-        - experiment::EffectiveQC::${variable} == 0
-      for:
-        variable: *variables
+- transform: accept where
+  new name: experiment::FinalObsErrorPassedQc::${variable}
+  starting field: experiment::GsiFinalObsError::${variable}
+  where:
+    - experiment::GsiFinalObsError::${variable} > 0
+  for:
+    variable: *variables
 
-    - transform: accept where
-      new name: experiment::FinalObsErrorPassedQc::${variable}
-      starting field: experiment::GsiFinalObsError::${variable}
-      where:
-        - experiment::GsiFinalObsError::${variable} > 0
-      for:
-        variable: *variables
+# Error Difference
+# ----------------
+- transform: arithmetic
+  new name: experiment::EffectiveErrorPassedQcDiff::${variable}
+  equals: experiment::FinalObsErrorPassedQc::${variable}-experiment::EffectiveErrorPassedQc::${variable}
+  for:
+    variable: *variables
 
-    # Error Difference
-    # ----------------
-    - transform: arithmetic
-      new name: experiment::EffectiveErrorPassedQcDiff::${variable}
-      equals: experiment::FinalObsErrorPassedQc::${variable}-experiment::EffectiveErrorPassedQc::${variable}
-      for:
-        variable: *variables
+# Observation minus Hofx passing QC
+# ---------------------------------
+- transform: accept where
+  new name: experiment::ObsValueMinusHofxPassedQc::${variable}
+  starting field: experiment::ObsValueMinusHofx::${variable}
+  where:
+    - experiment::EffectiveQC::${variable} == 0
+  for:
+    variable: *variables
 
-    # Observation minus Hofx passing QC
-    # ---------------------------------
-    - transform: accept where
-      new name: experiment::ObsValueMinusHofxPassedQc::${variable}
-      starting field: experiment::ObsValueMinusHofx::${variable}
-      where:
-        - experiment::EffectiveQC::${variable} == 0
-      for:
-        variable: *variables
+- transform: accept where
+  new name: experiment::ObsValueMinusGsiHofXPassedQc::${variable}
+  starting field: experiment::ObsValueMinusGsiHofX::${variable}
+  where:
+    - experiment::GsiEffectiveQC::${variable} == 0
+  for:
+    variable: *variables
 
-    - transform: accept where
-      new name: experiment::ObsValueMinusGsiHofXPassedQc::${variable}
-      starting field: experiment::ObsValueMinusGsiHofX::${variable}
-      where:
-        - experiment::GsiEffectiveQC::${variable} == 0
-      for:
-        variable: *variables
+- transform: accept where
+  new name: experiment::ObsValueMinusGsiHofXBcPassedQc::${variable}
+  starting field: experiment::ObsValueMinusGsiHofXBc::${variable}
+  where:
+    - experiment::GsiEffectiveQC::${variable} == 0
+  for:
+    variable: *variables
 
-    - transform: accept where
-      new name: experiment::ObsValueMinusGsiHofXBcPassedQc::${variable}
-      starting field: experiment::ObsValueMinusGsiHofXBc::${variable}
-      where:
-        - experiment::GsiEffectiveQC::${variable} == 0
-      for:
-        variable: *variables
+graphics:
 
+  plotting_backend: Emcpy
+  figure_list:
 
-  graphics:
+  # Correlation scatter JEDI h(x) vs GSI h(x)
+  # -----------------------------------------
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'JEDI h(x) vs. GSI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_a_hofx_vs_gsihofx.png'
+    plots:
+      - add_xlabel: 'GSI h(x)'
+        add_ylabel: 'JEDI h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          y:
+            variable: experiment::hofx::${variable}
+          x:
+            variable: experiment::GsiHofX::${variable}
+          channel: ${channel}
+          markersize: 5
+          color: 'blue'
+          label: 'JEDI h(x) versus GSI h(x)'
 
-    # Correlation scatter JEDI h(x) vs GSI h(x)
-    # -----------------------------------------
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'JEDI h(x) vs. GSI h(x) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_a_hofx_vs_gsihofx.png'
-      plots:
-        - add_xlabel: 'GSI h(x)'
-          add_ylabel: 'JEDI h(x)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            y:
-              variable: experiment::hofx::${variable}
-            x:
-              variable: experiment::GsiHofX::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'blue'
-            label: 'JEDI h(x) versus GSI h(x)'
+  # Correlation scatter JEDI h(x) vs GSI h(x) BC
+  # --------------------------------------------
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'JEDI h(x) vs. GSI h(x) BC | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_b_hofx_vs_gsihofxbc.png'
+    plots:
+      - add_xlabel: 'GSI h(x) BC'
+        add_ylabel: 'JEDI h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          y:
+            variable: experiment::hofx::${variable}
+          x:
+            variable: experiment::GsiHofXBc::${variable}
+          channel: ${channel}
+          markersize: 5
+          color: 'blue'
+          label: 'JEDI h(x) versus GSI h(x)'
 
-    # Correlation scatter JEDI h(x) vs GSI h(x) BC
-    # --------------------------------------------
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'JEDI h(x) vs. GSI h(x) BC | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_b_hofx_vs_gsihofxbc.png'
-      plots:
-        - add_xlabel: 'GSI h(x) BC'
-          add_ylabel: 'JEDI h(x)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            y:
-              variable: experiment::hofx::${variable}
-            x:
-              variable: experiment::GsiHofXBc::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'blue'
-            label: 'JEDI h(x) versus GSI h(x)'
+  # Correlation scatter JEDI h(x) - GSI H(x) vs GSI h(x)
+  # ----------------------------------------------------
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'JEDI h(x) - GSI h(x) vs. GSI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_c_hofxdiff_vs_gsihofx.png'
+    plots:
+      - add_xlabel: 'GSI h(x)'
+        add_ylabel: 'JEDI h(x) - GSI h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          y:
+            variable: experiment::hofxDiff::${variable}
+          x:
+            variable: experiment::GsiHofX::${variable}
+          channel: ${channel}
+          markersize: 5
+          color: 'blue'
+          label: 'JEDI h(x) versus GSI h(x)'
 
-    # Correlation scatter JEDI h(x) - GSI H(x) vs GSI h(x)
-    # ----------------------------------------------------
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'JEDI h(x) - GSI h(x) vs. GSI h(x) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_c_hofxdiff_vs_gsihofx.png'
-      plots:
-        - add_xlabel: 'GSI h(x)'
-          add_ylabel: 'JEDI h(x) - GSI h(x)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            y:
-              variable: experiment::hofxDiff::${variable}
-            x:
-              variable: experiment::GsiHofX::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'blue'
-            label: 'JEDI h(x) versus GSI h(x)'
+  # Correlation scatter JEDI h(x) - GSI H(x) BC vs GSI h(x) BC
+  # ----------------------------------------------------------
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'JEDI h(x) - GSI h(x) BC vs. GSI h(x) BC | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_d_hofxdiffbc_vs_gsihofxbc.png'
+    plots:
+      - add_xlabel: 'GSI h(x) BC'
+        add_ylabel: 'JEDI h(x) - GSI h(x) BC'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          y:
+            variable: experiment::hofxDiffBc::${variable}
+          x:
+            variable: experiment::GsiHofXBc::${variable}
+          channel: ${channel}
+          markersize: 5
+          color: 'blue'
+          label: 'JEDI h(x) versus GSI h(x)'
 
-    # Correlation scatter JEDI h(x) - GSI H(x) BC vs GSI h(x) BC
-    # ----------------------------------------------------------
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'JEDI h(x) - GSI h(x) BC vs. GSI h(x) BC | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_d_hofxdiffbc_vs_gsihofxbc.png'
-      plots:
-        - add_xlabel: 'GSI h(x) BC'
-          add_ylabel: 'JEDI h(x) - GSI h(x) BC'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            y:
-              variable: experiment::hofxDiffBc::${variable}
-            x:
-              variable: experiment::GsiHofXBc::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'blue'
-            label: 'JEDI h(x) versus GSI h(x)'
+  # Effective Error vs GSI Final Error (Passed QC)
+  # ----------------------------------------------
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'JEDI Effective Error vs. GSI FinalObsError (Passing QC) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_e_effectiveerror_vs_gsifinalerror.png'
+    plots:
+      - add_xlabel: 'GSI FinalObsError (Passed QC)'
+        add_ylabel: 'JEDI Effective Error (Passed QC)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          y:
+            variable: experiment::EffectiveErrorPassedQc::${variable}
+          x:
+            variable: experiment::FinalObsErrorPassedQc::${variable}
+          channel: ${channel}
+          markersize: 5
+          color: 'blue'
+          label: 'JEDI h(x) versus GSI h(x)'
 
+  # Effective Error - GSI Final Error vs GSI Final Error (Passed QC)
+  # ----------------------------------------------------------------
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'JEDI Effective Error vs. GSI FinalObsError (Passing QC) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_f_effectiveerrordiff_vs_gsifinalerror.png'
+    plots:
+      - add_xlabel: 'GSI FinalObsError (Passed QC)'
+        add_ylabel: 'JEDI Effective Error (Passed QC) - GSI FinalObsError (Passed QC)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          y:
+            variable: experiment::EffectiveErrorPassedQcDiff::${variable}
+          x:
+            variable: experiment::FinalObsErrorPassedQc::${variable}
+          channel: ${channel}
+          markersize: 5
+          color: 'blue'
+          label: 'JEDI h(x) versus GSI h(x)'
 
-    # Effective Error vs GSI Final Error (Passed QC)
-    # ----------------------------------------------
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'JEDI Effective Error vs. GSI FinalObsError (Passing QC) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_e_effectiveerror_vs_gsifinalerror.png'
-      plots:
-        - add_xlabel: 'GSI FinalObsError (Passed QC)'
-          add_ylabel: 'JEDI Effective Error (Passed QC)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            y:
-              variable: experiment::EffectiveErrorPassedQc::${variable}
-            x:
-              variable: experiment::FinalObsErrorPassedQc::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'blue'
-            label: 'JEDI h(x) versus GSI h(x)'
-
-
-    # Effective Error - GSI Final Error vs GSI Final Error (Passed QC)
-    # ----------------------------------------------------------------
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'JEDI Effective Error vs. GSI FinalObsError (Passing QC) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_f_effectiveerrordiff_vs_gsifinalerror.png'
-      plots:
-        - add_xlabel: 'GSI FinalObsError (Passed QC)'
-          add_ylabel: 'JEDI Effective Error (Passed QC) - GSI FinalObsError (Passed QC)'
-          add_grid:
-          add_legend:
-            loc: 'upper left'
-          layers:
-          - type: Scatter
-            y:
-              variable: experiment::EffectiveErrorPassedQcDiff::${variable}
-            x:
-              variable: experiment::FinalObsErrorPassedQc::${variable}
-            channel: ${channel}
-            markersize: 5
-            color: 'blue'
-            label: 'JEDI h(x) versus GSI h(x)'
-
-
-    # Density plot for observation minus background passed QC
-    # -------------------------------------------------------
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'Observation minus Background Density (Passing QC) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_g_omb_density.png'
-      plots:
-        - add_xlabel: 'Observation minus h(x)'
-          add_ylabel: 'Density'
-          add_legend:
-            loc: 'upper left'
-          statistics:
-            fields:
-              - field_name: experiment::ObsValueMinusGsiHofXPassedQc::${variable}
-                channel: ${channel}
-                xloc: 0.5
-                yloc: -0.10
-                kwargs:
-                  color: 'blue'
-                  fontsize: 8
-                  fontfamily: monospace
-              - field_name: experiment::ObsValueMinusHofxPassedQc::${variable}
-                channel: ${channel}
-                xloc: 0.5
-                yloc: -0.13
-                kwargs:
-                  color: 'red'
-                  fontsize: 8
-                  fontfamily: monospace
-            statistics_variables:
-            - n
-            - min
-            - mean
-            - max
-            - std
-          layers:
-          - type: Density
-            data:
-              variable: experiment::ObsValueMinusGsiHofXPassedQc::${variable}
+  # Density plot for observation minus background passed QC
+  # -------------------------------------------------------
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'Observation minus Background Density (Passing QC) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_g_omb_density.png'
+    plots:
+      - add_xlabel: 'Observation minus h(x)'
+        add_ylabel: 'Density'
+        add_legend:
+          loc: 'upper left'
+        statistics:
+          fields:
+            - field_name: experiment::ObsValueMinusGsiHofXPassedQc::${variable}
               channel: ${channel}
-            color: 'blue'
-            label: 'GSI omb (Passed QC)'
-            alpha: 0.5
-            bw_adjust: 0.1  # Reduce this value to fit the data more closely
-          - type: Density
-            data:
-              variable: experiment::ObsValueMinusHofxPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.10
+              kwargs:
+                color: 'blue'
+                fontsize: 8
+                fontfamily: monospace
+            - field_name: experiment::ObsValueMinusHofxPassedQc::${variable}
               channel: ${channel}
-            color: 'red'
-            label: 'JEDI omb (Passed QC)'
-            alpha: 0.5
-            bw_adjust: 0.1  # Reduce this value to fit the data more closely
+              xloc: 0.5
+              yloc: -0.13
+              kwargs:
+                color: 'red'
+                fontsize: 8
+                fontfamily: monospace
+          statistics_variables:
+          - n
+          - min
+          - mean
+          - max
+          - std
+        layers:
+        - type: Density
+          data:
+            variable: experiment::ObsValueMinusGsiHofXPassedQc::${variable}
+            channel: ${channel}
+          color: 'blue'
+          label: 'GSI omb (Passed QC)'
+          alpha: 0.5
+          bw_adjust: 0.1  # Reduce this value to fit the data more closely
+        - type: Density
+          data:
+            variable: experiment::ObsValueMinusHofxPassedQc::${variable}
+            channel: ${channel}
+          color: 'red'
+          label: 'JEDI omb (Passed QC)'
+          alpha: 0.5
+          bw_adjust: 0.1  # Reduce this value to fit the data more closely
 
-
-    # Density plot for observation minus background passed QC (bias corrected)
-    # ------------------------------------------------------------------------
-    - batch figure:
-        variables: *variables
-        channels: *channels
-      figure:
-        layout: [1,1]
-        title: 'Observation minus Background Density (Passing QC) | {{instrument_title}} | ${variable_title}'
-        output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_h_ombbc_density.png'
-      plots:
-        - add_xlabel: 'Observation minus h(x)'
-          add_ylabel: 'Density'
-          add_legend:
-            loc: 'upper left'
-          statistics:
-            fields:
-              - field_name: experiment::ObsValueMinusGsiHofXBcPassedQc::${variable}
-                channel: ${channel}
-                xloc: 0.5
-                yloc: -0.10
-                kwargs:
-                  color: 'blue'
-                  fontsize: 8
-                  fontfamily: monospace
-              - field_name: experiment::ObsValueMinusHofxPassedQc::${variable}
-                channel: ${channel}
-                xloc: 0.5
-                yloc: -0.13
-                kwargs:
-                  color: 'red'
-                  fontsize: 8
-                  fontfamily: monospace
-            statistics_variables:
-            - n
-            - min
-            - mean
-            - max
-            - std
-          layers:
-          - type: Density
-            data:
-              variable: experiment::ObsValueMinusGsiHofXBcPassedQc::${variable}
+  # Density plot for observation minus background passed QC (bias corrected)
+  # ------------------------------------------------------------------------
+  - batch figure:
+      variables: *variables
+      channels: *channels
+    figure:
+      layout: [1,1]
+      title: 'Observation minus Background Density (Passing QC) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/${variable}${channel}_h_ombbc_density.png'
+    plots:
+      - add_xlabel: 'Observation minus h(x)'
+        add_ylabel: 'Density'
+        add_legend:
+          loc: 'upper left'
+        statistics:
+          fields:
+            - field_name: experiment::ObsValueMinusGsiHofXBcPassedQc::${variable}
               channel: ${channel}
-            color: 'blue'
-            label: 'GSI omb BC (Passed QC)'
-            alpha: 0.5
-            bw_adjust: 0.1  # Reduce this value to fit the data more closely
-          - type: Density
-            data:
-              variable: experiment::ObsValueMinusHofxPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.10
+              kwargs:
+                color: 'blue'
+                fontsize: 8
+                fontfamily: monospace
+            - field_name: experiment::ObsValueMinusHofxPassedQc::${variable}
               channel: ${channel}
-            color: 'red'
-            label: 'JEDI omb (Passed QC)'
-            alpha: 0.5
-            bw_adjust: 0.1  # Reduce this value to fit the data more closely
+              xloc: 0.5
+              yloc: -0.13
+              kwargs:
+                color: 'red'
+                fontsize: 8
+                fontfamily: monospace
+          statistics_variables:
+          - n
+          - min
+          - mean
+          - max
+          - std
+        layers:
+        - type: Density
+          data:
+            variable: experiment::ObsValueMinusGsiHofXBcPassedQc::${variable}
+            channel: ${channel}
+          color: 'blue'
+          label: 'GSI omb BC (Passed QC)'
+          alpha: 0.5
+          bw_adjust: 0.1  # Reduce this value to fit the data more closely
+        - type: Density
+          data:
+            variable: experiment::ObsValueMinusHofxPassedQc::${variable}
+            channel: ${channel}
+          color: 'red'
+          label: 'JEDI omb (Passed QC)'
+          alpha: 0.5
+          bw_adjust: 0.1  # Reduce this value to fit the data more closely

--- a/src/swell/suites/ufo_testing/flow.cylc
+++ b/src/swell/suites/ufo_testing/flow.cylc
@@ -133,6 +133,18 @@
 
     [[EvaObservations]]
         script = "swell_task EvaObservations $config -d $datetime -m geos_atmosphere"
+        platform = {{platform}}
+        execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
+        [[[directives]]]
+            --account = {{scheduling["EvaObservations"]["account"]}}
+            --qos = {{scheduling["EvaObservations"]["qos"]}}
+            --job-name = EvaObservations
+            --nodes={{scheduling["EvaObservations"]["nodes"]}}
+            --ntasks-per-node={{scheduling["EvaObservations"]["ntasks_per_node"]}}
+            --constraint={{scheduling["EvaObservations"]["constraint"]}}
+            {% if scheduling["EvaObservations"]["partition"] %}
+            --partition={{scheduling["EvaObservations"]["partition"]}}
+            {% endif %}
 
     [[CleanCycle]]
         script = "swell_task CleanCycle $config -d $datetime -m geos_atmosphere"

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -141,5 +141,5 @@ class EvaObservations(taskBase):
 
         # Call eva in parallel
         # --------------------
-        with Pool(processes=20) as pool:
+        with Pool(processes=40) as pool:
             pool.map(run_eva, eva_dicts)

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -8,15 +8,25 @@
 # --------------------------------------------------------------------------------------------------
 
 
+from multiprocessing import Pool
 import os
 import yaml
 
-from eva.eva_base import eva
+from eva.eva_driver import eva
 
 from swell.tasks.base.task_base import taskBase
 from swell.utilities.dictionary import remove_matching_keys, replace_string_in_dictionary
 from swell.utilities.jinja2 import template_string_jinja2
 from swell.utilities.observations import ioda_name_to_long_name
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+# Pass through to avoid confusion with optional logger argument inside eva
+def run_eva(eva_dict):
+    eva(eva_dict)
+
 
 # --------------------------------------------------------------------------------------------------
 
@@ -62,8 +72,10 @@ class EvaObservations(taskBase):
                              445, 552, 573, 906, 1121, 1194, 1427, 1585],
             }
 
-        # Loop over observations
-        # -------------------
+        # Loop over observations and create dictionaries
+        # ----------------------------------------------
+        eva_dicts = []  # Empty list of dictionaries
+
         for observation in self.config.observations():
 
             # Load the observation dictionary
@@ -85,13 +97,6 @@ class EvaObservations(taskBase):
             # Get instrument ioda and full name
             ioda_name = observation
             full_name = ioda_name_to_long_name(ioda_name, self.logger)
-
-            # Log the operator being worked on
-            # --------------------------------
-            info_string = 'Running Eva for ' + full_name
-            self.logger.info('')
-            self.logger.info(info_string)
-            self.logger.info('-'*len(info_string))
 
             # Create dictionary used to override the eva config
             eva_override = {}
@@ -130,6 +135,11 @@ class EvaObservations(taskBase):
             with open(conf_output, 'w') as outfile:
                 yaml.dump(eva_dict, outfile, default_flow_style=False)
 
-            # Call eva
-            # --------
-            eva(eva_dict)
+            # Add eva dictionary to list
+            # --------------------------
+            eva_dicts.append(eva_dict)
+
+        # Call eva in parallel
+        # --------------------
+        with Pool(processes=20) as pool:
+            pool.map(run_eva, eva_dicts)

--- a/src/swell/tasks/run_jedi_ufo_tests_executable.py
+++ b/src/swell/tasks/run_jedi_ufo_tests_executable.py
@@ -160,7 +160,7 @@ class RunJediUfoTestsExecutable(taskBase):
             # Run the Test Obs Filters executable
             # -----------------------------------
             if not generate_yaml_and_exit:
-                run_executable(self.logger, self.cycle_dir(), 24, jedi_executable_path,
+                run_executable(self.logger, self.cycle_dir(), 36, jedi_executable_path,
                                jedi_config_file, output_log_file)
             else:
                 self.logger.info('YAML generated, now exiting.')


### PR DESCRIPTION
## Description

- Bring swell into compliance with a more modern Eva 1.3.5 to the upcoming 1.6.0 version. This makes for a number of YAML changes in the eva Yamls.
- Parallelize the EvaObservations task, reducing the cost of producing plots for the atmospheric runs by a factor of 10. _But bringing in the cost of being in the queue._ 

This would be merged once the Eva PR is merged, incase of any requested changes there. However the module for eva is built on Discover so this can be tested now.

## Dependencies

- [ ] https://github.com/JCSDA-internal/eva/pull/158

## Impact

N/A
