### PR TITLE
Move observational error assignments into 'obs prior filters'.

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
@@ -74,7 +74,7 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/airs_aqua.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -122,6 +122,7 @@ obs filters:
         variables:
         - name: ObsErrorData/brightnessTemperature
           channels: *airs_aqua_channels
+obs post filters:
 #  Wavenumber Check
 - filter: BlackList
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
@@ -55,7 +55,19 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/amsua_aqua.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
+# Assign obs error
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *amsua_aqua_available_channels
+    action:
+      name: assign error
+      error parameter vector: &amsua_aqua_oberr
+                  [2.500,  2.000,  2.000,  0.500,  0.400,
+                   0.400,  0.500,  0.300,  0.350,  0.350,
+                   0.450,  1.000,  1.500,  3.750,  6.300]
+obs post filters:
 # Window and surface-sensitive channels check
   - filter: Bounds Check
     filter variables:
@@ -91,17 +103,6 @@ obs filters:
     maxvalue: 0.0
     action:
       name: reject
-# Assign obs error
-  - filter: Perform Action
-    filter variables:
-    - name: brightnessTemperature
-      channels: *amsua_aqua_available_channels
-    action:
-      name: assign error
-      error parameter vector:
-                  [2.500,  2.000,  2.000,  0.500,  0.400,
-                   0.400,  0.500,  0.300,  0.350,  0.350,
-                   0.450,  1.000,  1.500,  3.750,  6.300]
 # Topography check
   - filter: BlackList
     filter variables:
@@ -170,10 +171,7 @@ obs filters:
           options:
             channels: *amsua_aqua_available_channels
             sensor: *Sensor_ID
-        error parameter vector:
-                  [2.500,  2.000,  2.000,  0.500,  0.400,
-                   0.400,  0.500,  0.300,  0.350,  0.350,
-                   0.450,  1.000,  1.500,  3.750,  6.300]
+        error parameter vector: *amsua_aqua_oberr
         obserr_bound_max: [4.5, 4.5, 4.5, 3.0, 2.0,
                            2.0, 2.0, 2.0, 2.0, 2.0,
                            3.0, 3.5, 4.5, 4.5, 4.5]

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
@@ -57,7 +57,19 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/amsua_metop-b.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
+# Assign obs error
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *amsua_metop-b_available_channels
+    action:
+      name: assign error
+      error parameter vector: &amsua_metop-b_oberr
+                  [2.500,  2.000,  2.000,  0.550,  0.300,
+                   0.230,  0.230,  0.250,  0.250,  0.350,
+                   0.400,  0.550,  0.800,  5.000,  2.500]
+obs post filters:
 # Window and surface-sensitive channels check
   - filter: Bounds Check
     filter variables:
@@ -93,17 +105,6 @@ obs filters:
     maxvalue: 0.0
     action:
       name: reject
-# Assign obs error
-  - filter: Perform Action
-    filter variables:
-    - name: brightnessTemperature
-      channels: *amsua_metop-b_available_channels
-    action:
-      name: assign error
-      error parameter vector:
-                  [2.500,  2.000,  2.000,  0.550,  0.300,
-                   0.230,  0.230,  0.250,  0.250,  0.350,
-                   0.400,  0.550,  0.800,  5.000,  2.500]
 # Topography check
   - filter: BlackList
     filter variables:
@@ -172,10 +173,7 @@ obs filters:
           options:
             channels: *amsua_metop-b_available_channels
             sensor: *Sensor_ID
-        error parameter vector:
-                  [2.500,  2.000,  2.000,  0.550,  0.300,
-                   0.230,  0.230,  0.250,  0.250,  0.350,
-                   0.400,  0.550,  0.800,  5.000,  2.500]
+        error parameter vector: *amsua_metop-b_oberr
         obserr_bound_max: [4.5, 4.5, 4.5, 2.5, 2.0,
                            2.0, 2.0, 2.0, 2.0, 2.0,
                            2.5, 3.5, 4.5, 4.5, 4.5]

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
@@ -57,7 +57,19 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/INSTRUMENT.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
+# Assign obs error
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *amsua_metop-c_available_channels
+    action:
+      name: assign error
+      error parameter vector: &amsua_metop-c_oberr
+                  [2.500,  2.000,  2.000,  0.550,  0.300,
+                   0.230,  0.230,  0.250,  0.250,  0.350,
+                   0.400,  0.550,  0.800,  5.000,  2.500]
+obs post filters:
 # Window and surface-sensitive channels check
   - filter: Bounds Check
     filter variables:
@@ -93,17 +105,6 @@ obs filters:
     maxvalue: 0.0
     action:
       name: reject
-# Assign obs error
-  - filter: Perform Action
-    filter variables:
-    - name: brightnessTemperature
-      channels: *amsua_metop-c_available_channels
-    action:
-      name: assign error
-      error parameter vector:
-                  [2.500,  2.000,  2.000,  0.550,  0.300,
-                   0.230,  0.230,  0.250,  0.250,  0.350,
-                   0.400,  0.550,  0.800,  5.000,  2.500]
 # Topography check
   - filter: BlackList
     filter variables:
@@ -172,10 +173,7 @@ obs filters:
           options:
             channels: *amsua_metop-c_available_channels
             sensor: *Sensor_ID
-        error parameter vector:
-                  [2.500,  2.000,  2.000,  0.550,  0.300,
-                   0.230,  0.230,  0.250,  0.250,  0.350,
-                   0.400,  0.550,  0.800,  5.000,  2.500]
+        error parameter vector: *amsua_metop-c_oberr
         obserr_bound_max: [4.5, 4.5, 4.5, 2.5, 2.0,
                            2.0, 2.0, 2.0, 2.0, 2.0,
                            2.5, 3.5, 4.5, 4.5, 4.5]

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
@@ -57,7 +57,19 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/amsua_n15.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
+# Assign obs error
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *amsua_n15_available_channels
+    action:
+      name: assign error
+      error parameter vector: &amsua_n15_oberr
+                  [3.000,  2.000,  2.000,  0.600,  0.300,
+                   0.230,  0.250,  0.275,  0.340,  0.400,
+                   0.600,  1.000,  1.500,  5.000,  3.000]
+obs post filters:
 # Window and surface-sensitive channels check
   - filter: Bounds Check
     filter variables:
@@ -93,17 +105,6 @@ obs filters:
     maxvalue: 0.0
     action:
       name: reject
-# Assign obs error
-  - filter: Perform Action
-    filter variables:
-    - name: brightnessTemperature
-      channels: *amsua_n15_available_channels
-    action:
-      name: assign error
-      error parameter vector:
-                  [3.000,  2.000,  2.000,  0.600,  0.300,
-                   0.230,  0.250,  0.275,  0.340,  0.400,
-                   0.600,  1.000,  1.500,  5.000,  3.000]
 # Topography check
   - filter: BlackList
     filter variables:
@@ -172,10 +173,7 @@ obs filters:
           options:
             channels: *amsua_n15_available_channels
             sensor: *Sensor_ID
-        error parameter vector:
-                  [3.000,  2.000,  2.000,  0.600,  0.300,
-                   0.230,  0.250,  0.275,  0.340,  0.400,
-                   0.600,  1.000,  1.500,  5.000,  3.000]
+        error parameter vector: *amsua_n15_oberr
         obserr_bound_max: [4.5, 4.5, 4.5, 2.5, 2.0,
                            2.0, 2.0, 2.0, 2.0, 2.0,
                            2.5, 3.5, 4.5, 4.5, 4.5]

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
@@ -57,7 +57,19 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/amsua_n18.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
+# Assign obs error
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *amsua_n18_available_channels
+    action:
+      name: assign error
+      error parameter vector: &amsua_n18_oberr
+                  [2.500,  2.000,  2.000,  0.550,  0.300,
+                   0.230,  0.230,  0.250,  0.250,  0.350,
+                   0.400,  0.550,  0.800,  5.000,  2.500]
+obs post filters:
 # Window and surface-sensitive channels check
   - filter: Bounds Check
     filter variables:
@@ -93,17 +105,6 @@ obs filters:
     maxvalue: 0.0
     action:
       name: reject
-# Assign obs error
-  - filter: Perform Action
-    filter variables:
-    - name: brightnessTemperature
-      channels: *amsua_n18_available_channels
-    action:
-      name: assign error
-      error parameter vector:
-                  [2.500,  2.000,  2.000,  0.550,  0.300,
-                   0.230,  0.230,  0.250,  0.250,  0.350,
-                   0.400,  0.550,  0.800,  5.000,  2.500]
 # Topography check
   - filter: BlackList
     filter variables:
@@ -172,10 +173,7 @@ obs filters:
           options:
             channels: *amsua_n18_available_channels
             sensor: *Sensor_ID
-        error parameter vector:
-                  [2.500,  2.000,  2.000,  0.550,  0.300,
-                   0.230,  0.230,  0.250,  0.250,  0.350,
-                   0.400,  0.550,  0.800,  5.000,  2.500]
+        error parameter vector: *amsua_n18_oberr
         obserr_bound_max: [4.5, 4.5, 4.5, 2.5, 2.0,
                            2.0, 2.0, 2.0, 2.0, 2.0,
                            2.5, 3.5, 4.5, 4.5, 4.5]

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
@@ -57,7 +57,19 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/amsua_n19.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
+# Assign obs error
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *amsua_n19_available_channels
+    action:
+      name: assign error
+      error parameter vector: &amsua_n19_oberr
+                  [2.500,  2.000,  2.000,  0.550,  0.300,
+                   0.230,  0.230,  0.250,  0.250,  0.350,
+                   0.400,  0.550,  0.800,  5.000,  2.500]
+obs post filters:
 # Window and surface-sensitive channels check
   - filter: Bounds Check
     filter variables:
@@ -93,17 +105,6 @@ obs filters:
     maxvalue: 0.0
     action:
       name: reject
-# Assign obs error
-  - filter: Perform Action
-    filter variables:
-    - name: brightnessTemperature
-      channels: *amsua_n19_available_channels
-    action:
-      name: assign error
-      error parameter vector:
-                  [2.500,  2.000,  2.000,  0.550,  0.300,
-                   0.230,  0.230,  0.250,  0.250,  0.350,
-                   0.400,  0.550,  0.800,  5.000,  2.500]
 # Topography check
   - filter: BlackList
     filter variables:
@@ -172,10 +173,7 @@ obs filters:
           options:
             channels: *amsua_n19_available_channels
             sensor: *Sensor_ID
-        error parameter vector:
-                  [2.500,  2.000,  2.000,  0.550,  0.300,
-                   0.230,  0.230,  0.250,  0.250,  0.350,
-                   0.400,  0.550,  0.800,  5.000,  2.500]
+        error parameter vector: *amsua_n19_oberr
         obserr_bound_max: [4.5, 4.5, 4.5, 2.5, 2.0,
                            2.0, 2.0, 2.0, 2.0, 2.0,
                            2.5, 3.5, 4.5, 4.5, 4.5]

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
@@ -57,7 +57,21 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/atms_n20.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
+# Assign obs error
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *atms_n20_channels
+    action:
+      name: assign error
+      error parameter vector: &atms_n20_oberr
+                  [5.000,  5.000,  5.000,  3.000,  0.550,
+                   0.300,  0.300,  0.300,  0.300,  0.300,
+                   0.350,  0.400,  0.550,  0.800,  5.000,
+                   5.000,  2.500,  2.500,  2.500,  2.500,
+                   2.500,  2.500]
+obs post filters:
 # Window and surface-sensitive channels check
   - filter: Bounds Check
     filter variables:
@@ -93,19 +107,6 @@ obs filters:
     maxvalue: 0.0
     action:
       name: reject
-# Assign obs error
-  - filter: Perform Action
-    filter variables:
-    - name: brightnessTemperature
-      channels: *atms_n20_channels
-    action:
-      name: assign error
-      error parameter vector:
-                  [5.000,  5.000,  5.000,  3.000,  0.550,
-                   0.300,  0.300,  0.300,  0.300,  0.300,
-                   0.350,  0.400,  0.550,  0.800,  5.000,
-                   5.000,  2.500,  2.500,  2.500,  2.500,
-                   2.500,  2.500]
 # Topography check
   - filter: BlackList
     filter variables:
@@ -174,12 +175,7 @@ obs filters:
           options:
             channels: *atms_n20_channels
             sensor: *Sensor_ID
-        error parameter vector:
-                  [5.000,  5.000,  5.000,  3.000,  0.550,
-                   0.300,  0.300,  0.300,  0.300,  0.300,
-                   0.350,  0.400,  0.550,  0.800,  5.000,
-                   5.000,  2.500,  2.500,  2.500,  2.500,
-                   2.500,  2.500]
+        error parameter vector: *atms_n20_oberr
         obserr_bound_max: [4.5, 4.5, 3.0, 3.0, 1.0,
                            1.0, 1.0, 1.0, 1.0, 1.0,
                            1.0, 1.0, 1.0, 2.0, 4.5,

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
@@ -57,7 +57,21 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/atms_npp.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
+# Assign obs error
+  - filter: Perform Action
+    filter variables:
+    - name: brightnessTemperature
+      channels: *atms_npp_channels
+    action:
+      name: assign error
+      error parameter vector: &atms_npp_oberr
+                  [5.000,  5.000,  5.000,  3.000,  0.550,
+                   0.300,  0.300,  0.300,  0.300,  0.300,
+                   0.350,  0.400,  0.550,  0.800,  5.000,
+                   5.000,  2.500,  2.500,  2.500,  2.500,
+                   2.500,  2.500]
+obs post filters:
 # Window and surface-sensitive channels check
   - filter: Bounds Check
     filter variables:
@@ -93,19 +107,6 @@ obs filters:
     maxvalue: 0.0
     action:
       name: reject
-# Assign obs error
-  - filter: Perform Action
-    filter variables:
-    - name: brightnessTemperature
-      channels: *atms_npp_channels
-    action:
-      name: assign error
-      error parameter vector:
-                  [5.000,  5.000,  5.000,  3.000,  0.550,
-                   0.300,  0.300,  0.300,  0.300,  0.300,
-                   0.350,  0.400,  0.550,  0.800,  5.000,
-                   5.000,  2.500,  2.500,  2.500,  2.500,
-                   2.500,  2.500]
 # Topography check
   - filter: BlackList
     filter variables:
@@ -174,12 +175,7 @@ obs filters:
           options:
             channels: *atms_npp_channels
             sensor: *Sensor_ID
-        error parameter vector:
-                  [5.000,  5.000,  5.000,  3.000,  0.550,
-                   0.300,  0.300,  0.300,  0.300,  0.300,
-                   0.350,  0.400,  0.550,  0.800,  5.000,
-                   5.000,  2.500,  2.500,  2.500,  2.500,
-                   2.500,  2.500]
+        error parameter vector: *atms_npp_oberr
         obserr_bound_max: [4.5, 4.5, 3.0, 3.0, 1.0,
                            1.0, 1.0, 1.0, 1.0, 1.0,
                            1.0, 1.0, 1.0, 2.0, 4.5,

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-b.yaml
@@ -51,7 +51,7 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/avhrr3_metop-b.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -71,6 +71,7 @@ obs filters:
         variables:
         - name: ObsErrorData/brightnessTemperature
           channels: *avhrr3_metop-b_channels
+obs post filters:
 # Wavenumber Check
 - filter: BlackList
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n18.yaml
@@ -51,7 +51,7 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/avhrr3_n18.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -71,6 +71,7 @@ obs filters:
         variables:
         - name: ObsErrorData/brightnessTemperature
           channels: *avhrr3_n18_channels
+obs post filters:
 # Wavenumber Check
 - filter: BlackList
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
@@ -51,7 +51,7 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/avhrr3_n19.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -71,6 +71,7 @@ obs filters:
         variables:
         - name: ObsErrorData/brightnessTemperature
           channels: *avhrr3_n19_channels
+obs post filters:
 # Wavenumber Check
 - filter: BlackList
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
@@ -83,7 +83,7 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/cris-fsr_n20.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -146,6 +146,7 @@ obs filters:
         variables:
         - name: ObsErrorData/brightnessTemperature
           channels: *cris-fsr_n20_channels
+obs post filters:
 - filter: BlackList
   filter variables:
   - name: brightnessTemperature

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
@@ -83,7 +83,7 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/cris-fsr_npp.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -146,6 +146,7 @@ obs filters:
         variables:
         - name: ObsErrorData/brightnessTemperature
           channels: *cris-fsr_npp_channels
+obs post filters:
 - filter: BlackList
   filter variables:
   - name: brightnessTemperature

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
@@ -99,7 +99,7 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/iasi_metop-b.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs prior filters:
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -180,6 +180,7 @@ obs filters:
         variables:
         - name: ObsErrorData/brightnessTemperature
           channels: *iasi_metop-b_channels
+obs post filters:
 # Wavenumber Check
 - filter: BlackList
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
@@ -99,7 +99,7 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/iasi_metop-c.{{window_begin}}.satbias.nc4'
 
-obs filters:
+obs pior filters:
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -180,6 +180,7 @@ obs filters:
         variables:
         - name: ObsErrorData/brightnessTemperature
           channels: *iasi_metop-c_channels
+obs post filters:
 # Wavenumber Check
 - filter: BlackList
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
@@ -99,7 +99,7 @@ obs bias:
         ratio for small dataset: 2.0
     output file: '{{cycle_dir}}/iasi_metop-c.{{window_begin}}.satbias.nc4'
 
-obs pior filters:
+obs prior filters:
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ufo_tests.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ufo_tests.yaml
@@ -14,7 +14,7 @@ aircraft:
 
 airs_aqua:
   filter_test:
-    passedBenchmark: 356480
+    passedBenchmark: 360284
 
 amsr2_gcom-w1:
   filter_test:
@@ -34,11 +34,11 @@ amsua_metop-c:
 
 amsua_n15:
   filter_test:
-    passedBenchmark: 48397
+    passedBenchmark: 56155
 
 amsua_n18:
   filter_test:
-    passedBenchmark: 64308
+    passedBenchmark: 69700
 
 amsua_n19:
   filter_test:
@@ -46,31 +46,31 @@ amsua_n19:
 
 atms_n20:
   filter_test:
-    passedBenchmark: 122696
+    passedBenchmark: 131783
 
 atms_npp:
   filter_test:
-    passedBenchmark: 121831
+    passedBenchmark: 130828
 
 avhrr3_metop-b:
   filter_test:
-    passedBenchmark: 4741
+    passedBenchmark: 4940
 
 avhrr3_n18:
   filter_test:
-    passedBenchmark: 5265
+    passedBenchmark: 5455
 
 avhrr3_n19:
   filter_test:
-    passedBenchmark: 4797
+    passedBenchmark: 4948
 
 cris-fsr_n20:
   filter_test:
-    passedBenchmark: 218099
+    passedBenchmark: 220521
 
 cris-fsr_npp:
   filter_test:
-    passedBenchmark: 207944
+    passedBenchmark: 210980
 
 gmi_gpm:
   filter_test:
@@ -82,11 +82,11 @@ gps:
 
 iasi_metop-b:
   filter_test:
-    passedBenchmark: 532953
+    passedBenchmark: 561875
 
 iasi_metop-c:
   filter_test:
-    passedBenchmark: 530555
+    passedBenchmark: 559038
 
 mhs_metop-b:
   filter_test:


### PR DESCRIPTION
## Description
Solve the issue https://github.com/GEOS-ESM/swell/issues/254 that radiance benchmark counts changed after https://github.com/JCSDA-internal/ufo/pull/3041 was merged into the UFO develop branch. "obs prior filters" and "obs post fiters" have to be configured properly, or the filter to check channels' "use_flag" messes up with the new develop branch. This PR moves observational error assignments into "obs prior filters" and adds "obs post filters".