### PR TITLE
Change behaviour of the EvaObservations task on login vs compute node

### DIFF
--- a/src/swell/__init__.py
+++ b/src/swell/__init__.py
@@ -9,4 +9,4 @@ import os
 repo_directory = os.path.dirname(__file__)
 
 # Set the version for swell
-__version__ = '1.7.0'
+__version__ = '1.7.1'

--- a/src/swell/deployment/platforms/nccs_discover/properties.yaml
+++ b/src/swell/deployment/platforms/nccs_discover/properties.yaml
@@ -1,0 +1,3 @@
+hostname:
+  login: discover
+  compute: borg

--- a/src/swell/deployment/platforms/platforms.py
+++ b/src/swell/deployment/platforms/platforms.py
@@ -9,6 +9,7 @@
 
 
 import os
+import yaml
 
 from swell.swell_path import get_swell_path
 
@@ -16,19 +17,52 @@ from swell.swell_path import get_swell_path
 # --------------------------------------------------------------------------------------------------
 
 
+def platform_path():
+
+    return os.path.join(get_swell_path(), 'deployment', 'platforms')
+
+
+# --------------------------------------------------------------------------------------------------
+
+
 def get_platforms():
 
-    # Path to platforms
-    platform_directory = os.path.join(get_swell_path(), 'deployment', 'platforms')
-
-    platforms = [dir for dir in os.listdir(platform_directory)
-                 if os.path.isdir(os.path.join(platform_directory, dir))]
+    # Get list of supported platforms
+    platforms = [dir for dir in os.listdir(platform_path())
+                 if os.path.isdir(os.path.join(platform_path(), dir))]
 
     # If anything in platforms contains '__' remove it from platforms list
     platforms = [platform for platform in platforms if '__' not in platform]
 
-    # List all directories in platform_directory
+    # List all directories in directory
     return platforms
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+def login_or_compute(platform):
+
+    # Open the properties file
+    properties_file = os.path.join(platform_path(), 'properties.yaml')
+
+    # If properties file does not exist return login to be safe
+    if not os.path.exists(properties_file):
+        return 'login'
+
+    with open(properties_file, 'r') as properties_file_open:
+        properties = yaml.safe_load(properties_file_open)
+
+    # Query the hostname by issuing shell command hostname
+    hostname = os.popen('hostname').read().strip()
+
+    if properties['hostname']['login'] in hostname:
+        return 'login'
+    elif properties['hostname']['compute'] in hostname:
+        return 'compute'
+
+    # Fallback to returning login to be safe
+    return 'login'
 
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/base/task_base.py
+++ b/src/swell/tasks/base/task_base.py
@@ -65,6 +65,7 @@ class taskBase(ABC):
         # --------------------------------------------------------
         self.__experiment_root__ = self.config.__experiment_root__
         self.__experiment_id__ = self.config.__experiment_id__
+        self.__platform__ = self.config.__platform__
 
         # Save the model components
         # -------------------------
@@ -126,6 +127,12 @@ class taskBase(ABC):
     # Method to get the experiment directory
     def experiment_path(self):
         return os.path.join(self.__experiment_root__, self.__experiment_id__)
+
+    # ----------------------------------------------------------------------------------------------
+
+    # Method to get the experiment ID
+    def platform(self):
+        return self.__platform__
 
     # ----------------------------------------------------------------------------------------------
 

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -15,6 +15,7 @@ import yaml
 
 from eva.eva_driver import eva
 
+from swell.deployment.platforms.platforms import login_or_compute
 from swell.tasks.base.task_base import taskBase
 from swell.utilities.dictionary import remove_matching_keys, replace_string_in_dictionary
 from swell.utilities.jinja2 import template_string_jinja2
@@ -50,6 +51,13 @@ class EvaObservations(taskBase):
         # Get the model
         # -------------
         model = self.get_model()
+
+        # Determine if running on login or compute node and set workers
+        # -------------------------------------------------------------
+        number_of_workers = 6
+        if login_or_compute(self.platform()) == 'compute':
+            number_of_workers = 40
+        self.logger.info(f'Running parallel plot generation with {number_of_workers} workers')
 
         # Read Eva template file into dictionary
         # --------------------------------------
@@ -152,5 +160,5 @@ class EvaObservations(taskBase):
 
         # Call eva in parallel
         # --------------------
-        with Pool(processes=40) as pool:
+        with Pool(processes=number_of_workers) as pool:
             pool.map(run_eva, eva_dicts)

--- a/src/swell/utilities/config.py
+++ b/src/swell/utilities/config.py
@@ -53,9 +53,10 @@ class Config():
         with open(input_file, 'r') as ymlfile:
             experiment_dict = yaml.safe_load(ymlfile)
 
-        # Save some things that all tasks can use
+        # Save some things that all tasks can use (suite level questions)
         self.__experiment_root__ = experiment_dict.get('experiment_root')
         self.__experiment_id__ = experiment_dict.get('experiment_id')
+        self.__platform__ = experiment_dict.get('platform')
 
         # If experiment_dict contains models key add the model components to the object
         if 'models' in experiment_dict.keys():


### PR DESCRIPTION
## Description

As requested by @Dooruk, EvaObservations can be run on a login node without using a large number of threads and annoying everyone on said node. Offers some protection when the task is accidentally run on a login node; unlike MPI, there is nothing to stop people overloading a login node when using threading in Python.

## Dependencies

N/A

## Impact

N/A
