### PR TITLE
Pass platform to JEDI_BUNDLE for getting CRTM coeffs in place

### DIFF
--- a/src/swell/tasks/build_jedi.py
+++ b/src/swell/tasks/build_jedi.py
@@ -52,9 +52,10 @@ class BuildJedi(taskBase):
             # Generate the build dictionary
             jedi_bundle_dict = set_jedi_bundle_config(self.config.bundles(bundles),
                                                       jedi_bundle_source_path,
-                                                      jedi_bundle_build_path, 24)
+                                                      jedi_bundle_build_path, self.platform(), 24)
 
             # Perform the clone of JEDI repos
+            execute_tasks(['configure', 'make'], jedi_bundle_dict)
             try:
                 execute_tasks(['configure', 'make'], jedi_bundle_dict)
             except Exception:

--- a/src/swell/utilities/build.py
+++ b/src/swell/utilities/build.py
@@ -11,6 +11,7 @@ import os
 import shutil
 
 from jedi_bundle.bin.jedi_bundle import get_default_config
+from jedi_bundle.config.config import check_platform
 
 
 # --------------------------------------------------------------------------------------------------
@@ -50,7 +51,8 @@ def link_path(source, target):
 # --------------------------------------------------------------------------------------------------
 
 
-def set_jedi_bundle_config(bundles, path_to_source, path_to_build, cores_to_use_for_make=6):
+def set_jedi_bundle_config(bundles, path_to_source, path_to_build, platform,
+                           cores_to_use_for_make=6):
 
     # Start from the default jedi_bundle config file
     jedi_bundle_config = get_default_config()
@@ -71,6 +73,13 @@ def set_jedi_bundle_config(bundles, path_to_source, path_to_build, cores_to_use_
 
     # Set the make stage options
     jedi_bundle_config['make_options']['cores_to_use_for_make'] = cores_to_use_for_make
+
+    # Check is swell platform is a jedi_bundle platform and if so use it
+    if check_platform(platform):
+        jedi_bundle_config['configure_options']['platform'] = platform
+
+    # Always use the swell defined modules to build
+    jedi_bundle_config['configure_options']['external_modules'] = True
 
     # Return the dictionary object
     return jedi_bundle_config


### PR DESCRIPTION
## Description

Compliance with new jedi_bundle. Now we need to pass the platform so the CRTM coefficients can be put in place and we can maintain the ability to run configure on a compute node and not rely on Wisconsin S4 to have continual uptime.
