### PR TITLE
add linear obs op

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
@@ -50,6 +50,37 @@ obs operator:
      variables:
      - name: specificHumidity
 
+linear obs operator:
+  name: Composite
+  components:
+
+   # Wind fields are handled using wind reduction factor applied to the lowest level.
+   - name: VertInterp
+     variables:
+     - name: windEastward
+     - name: windNorthward
+     # Use height vertical coordinate first
+     vertical coordinate: geopotential_height
+     observation vertical coordinate group: DerivedVariables
+     observation vertical coordinate: adjustedHeight
+     interpolation method: linear
+     hofx scaling field: SurfaceWindScalingHeight
+     hofx scaling field group: DerivedVariables
+
+   # Temperatures use vertical interpolation
+   - name: VertInterp
+     observation alias file: '{{experiment_root}}/{{experiment_id}}/configuration/jedi/interfaces/{{model_component}}/observations/obsop_name_map.yaml'
+     variables:
+     - name: airTemperature
+     - name: virtualTemperature
+
+   # Specific humidity and surface pressure is using the lowest model level (identity)
+   - name: Identity
+     observation alias file: '{{experiment_root}}/{{experiment_id}}/configuration/jedi/interfaces/{{model_component}}/observations/obsop_name_map.yaml'
+     variables:
+     - name: stationPressure
+     - name: specificHumidity
+
 obs prior filters:
 
 # Apply variable changes needed for rescaled height coordinate

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfcship.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfcship.yaml
@@ -47,6 +47,34 @@ obs operator:
      variables:
      - name: specificHumidity
 
+linear obs operator:
+  name: Composite
+  components:
+
+   - name: VertInterp
+     variables:
+     - name: windEastward
+     - name: windNorthward
+     # Use height vertical coordinate first
+     vertical coordinate: geopotential_height
+     observation vertical coordinate group: DerivedVariables
+     observation vertical coordinate: adjustedHeight
+     interpolation method: linear
+     hofx scaling field: SurfaceWindScalingHeight
+     hofx scaling field group: DerivedVariables
+
+   - name: VertInterp
+     observation alias file: '{{experiment_root}}/{{experiment_id}}/configuration/jedi/interfaces/{{model_component}}/observations/obsop_name_map.yaml'
+     variables:
+     - name: airTemperature
+     - name: virtualTemperature
+
+   # Specific humidity and station pressure is using the lowest model level (identity)
+   - name: Identity
+     variables:
+     - name: stationPressure
+     - name: specificHumidity
+
 obs prior filters:
 
 # Apply variable changes needed for rescaled height coordinate

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sondes.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sondes.yaml
@@ -42,6 +42,29 @@ obs operator:
     geovar_sfc_geomz: surface_geometric_height
     station_altitude: height
 
+linear obs operator:
+  name: Composite
+  components:
+
+  - name: VertInterp
+    variables:
+    - name: windEastward
+    - name: windNorthward
+
+    # Hofx scaling
+    hofx scaling field: SurfaceWindScalingPressure
+    hofx scaling field group: DerivedVariables
+
+  - name: VertInterp
+    variables:
+    - name: airTemperature
+    - name: virtualTemperature
+    - name: specificHumidity
+
+  - name: Identity
+    variables:
+    - name: stationPressure
+
 obs prior filters:
 
 # Apply variable changes needed for performing wind scaling

--- a/src/swell/tasks/run_jedi_ufo_tests_executable.py
+++ b/src/swell/tasks/run_jedi_ufo_tests_executable.py
@@ -80,8 +80,8 @@ class RunJediUfoTestsExecutable(taskBase):
         ufo_tests_dict = self.jedi_rendering.render_interface_observations(f'ufo_tests')
         ufo_tests_default = ufo_tests_dict['default']
 
-        # Insert the GeoVaLs section
-        # --------------------------
+        # Remove the LinObsOperatror and Insert the GeoVaLs section
+        # ---------------------------------------------------------
 
         # Loop over the observations
         for index in range(len(observations)):
@@ -103,6 +103,10 @@ class RunJediUfoTestsExecutable(taskBase):
                 geo_va_ls_dict['levels_are_top_down'] = False
 
             jedi_config_dict['observations'][index]['geovals'] = geo_va_ls_dict
+
+            # Check if jedi_config_dict['observations'][index] has linear obs operator and remove
+            if 'linear obs operator' in jedi_config_dict['observations'][index]:
+                del jedi_config_dict['observations'][index]['linear obs operator']
 
         # Copies for each kind of test
         # ----------------------------


### PR DESCRIPTION
## Description

Conventional operators that assimilate station pressure need to have a `linear obs operator` so they can switch station pressure to the identity for the increments.
