### PR TITLE
changes for shared project location

### DIFF
--- a/docs/platforms/discover/configuring_cylc_discover.md
+++ b/docs/platforms/discover/configuring_cylc_discover.md
@@ -13,7 +13,7 @@ module use /discover/swdev/jcsda/spack-stack/modulefiles
 module load miniconda/3.9.7
 
 # Load cylc module
-module use -a /discover/nobackup/drholdaw/opt/modulefiles/core/
+module use -a /discover/nobackup/projects/gmao/advda/swell/dev/modulefiles/core/
 module load cylc
 
 # Run cylc command

--- a/docs/platforms/discover/installing_swell_discover.md
+++ b/docs/platforms/discover/installing_swell_discover.md
@@ -1,6 +1,8 @@
 # Installing swell using Lmod
 
-Lmod is a powerful tool for managing multiple versions of software. The process of installing is a little involved but software is installed on Discover that eases the process.
+Lmod is a powerful tool for managing multiple versions of software. The process of installing is a little involved but `py_lmod_installer` software is installed on Discover that eases the process.
+
+This tool combines cloning, installation, and module file creation for Swell develop branch under one command.
 
 1. Pick a location that you want to install the software and navigate to that directory
 
@@ -11,13 +13,13 @@ cd $NOBACKUP/opt
 2. Load the modules that swell needs in order to be installed. Swell is designed to work with the spack-stack modules that JEDI uses so load which ever version of spack-stack you wish to use. For convenience the latest stable version can be obtained with:
 
 ```bash
-source /home/drholdaw/jedi_modules/modules-intel
+source /discover/nobackup/projects/gmao/advda/swell/jedi_modules/modules-intel
 ```
 
 3. Load the software that is used to perform the install.
 
 ```bash
-module use -a /discover/nobackup/drholdaw/opt/modulefiles/core
+module use -a /discover/nobackup/projects/gmao/advda/swell/dev/modulefiles/core
 module load py_lmod_installer
 ```
 


### PR DESCRIPTION
Locations for `cylc` and `py_lmod_installer` packages were updated and switched to `projects/advda/swell/dev`. This PR updates the documentation.