### PR TITLE
Change modules to shared locations

### DIFF
--- a/src/swell/deployment/platforms/nccs_discover/modules
+++ b/src/swell/deployment/platforms/nccs_discover/modules
@@ -36,16 +36,16 @@ module load other/mepo
 
 # Load r2d2 modules
 # -----------------
-module use -a /discover/nobackup/drholdaw/JediOpt/modulefiles/core
-module load solo/swell-1.0.0
+module use -a /discover/nobackup/projects/gmao/advda/JediOpt/modulefiles/core
+module load solo/spack-202311
 module load py-boto3
-module load r2d2/swell-1.0.5
+module load r2d2/spack-202311
 
 # Load eva and jedi_bundle
 # ------------------------
-module use -a /discover/nobackup/drholdaw/JediOpt/modulefiles/core
-module load eva/1.6.1-spack-stack-dev-20231114
-module load jedi_bundle/1.0.18-spack-stack-dev-20231114
+module use -a /discover/nobackup/projects/gmao/advda/JediOpt/modulefiles/core
+module load eva/1.6.1
+module load jedi_bundle/1.0.18_py310
 
 # Set the swell paths
 # -------------------

--- a/src/swell/utilities/run_jedi_executables.py
+++ b/src/swell/utilities/run_jedi_executables.py
@@ -20,14 +20,17 @@ def check_obs(path_to_observing_sys_yamls, observation, obs_dict, cycle_time):
     use_observation = False
 
     # Check if file exists
+    # --------------------
     filename = obs_dict['obs space']['obsdatain']['engine']['obsfile']
     if os.path.exists(filename):
 
-        # Open file and check if number of locations is nonzero
+        # Open file and check if number of location dimension is nonzero
+        # --------------------------------------------------------------
         dataset = nc.Dataset(filename, 'r')
-        locs = dataset.variables['Location']
-        if locs:
-            use_observation = True
+
+        for dim_name, dim in dataset.dimensions.items():
+            if dim_name == 'Location' and dim.size > 0:
+                use_observation = True
 
     return use_observation
 


### PR DESCRIPTION
New `discover` modules are installed on the shared `advda` directories. They work with the new JEDI builds.

This is currently a draft as we need a new version of Tier 2 stable JEDI build for Tier 1 tests to work (chicken & egg conundrum!). Since I don't have `gmao_ci` account (request in process) I can't do that on my own. I will ask @jardizzo's help if that request takes much longer.

We also need YAML changes following [discussion here](https://github.com/GEOS-ESM/swell/issues/292).