### PR TITLE
Cloning GEOS_mksi instead for GSI channel records

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -187,6 +187,9 @@ observations:
 observing_system_records_gsi_path:
   default_value: None
 
+observing_system_records_gsi_path_tag:
+  default_value: None
+
 observing_system_records_path:
   default_value: None
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -184,10 +184,10 @@ observations:
   - omi_aura
   - ompsnm_npp
 
-observing_system_records_gsi_path:
+observing_system_records_mksi_path:
   default_value: None
 
-observing_system_records_gsi_path_tag:
+observing_system_records_mksi_path_tag:
   default_value: None
 
 observing_system_records_path:

--- a/src/swell/suites/geosadas/flow.cylc
+++ b/src/swell/suites/geosadas/flow.cylc
@@ -33,12 +33,12 @@
             CloneJedi => StageJedi
 
             # Clone geos ana for generating observing system records
-            CloneGeosAna
+            CloneGeosMksi
         """
 
         T00 = """
             # Generate satellite channel records
-            CloneGeosAna[^] => GenerateObservingSystemRecords
+            CloneGeosMksi[^] => GenerateObservingSystemRecords
 
             # Get and convert bias correction coefficients
             GetGsiBc => GsiBcToIoda
@@ -76,8 +76,8 @@
 
     # Tasks
     # -----
-    [[CloneGeosAna]]
-        script = "swell task CloneGeosAna $config"
+    [[CloneGeosMksi]]
+        script = "swell task CloneGeosMksi $config"
 
     [[GenerateObservingSystemRecords]]
         script = "swell task GenerateObservingSystemRecords $config -d $datetime -m geos_atmosphere"

--- a/src/swell/suites/hofx/flow.cylc
+++ b/src/swell/suites/hofx/flow.cylc
@@ -40,7 +40,7 @@
             CloneJedi => StageJedi-{{model_component}}
 
             # Clone geos ana for generating observing system records
-            CloneGeosAna-{{model_component}}
+            CloneGeosMksi-{{model_component}}
             {% endfor %}
         """
 
@@ -52,7 +52,7 @@
             # Task triggers for: {{model_component}}
             # ------------------
             # Generate satellite channel records
-            CloneGeosAna-{{model_component}}[^] => GenerateObservingSystemRecords-{{model_component}}
+            CloneGeosMksi-{{model_component}}[^] => GenerateObservingSystemRecords-{{model_component}}
 
             # Get background
             GetBackground-{{model_component}}
@@ -124,8 +124,8 @@
 
     {% for model_component in model_components %}
 
-    [[CloneGeosAna-{{model_component}}]]
-        script = "swell task CloneGeosAna $config -m {{model_component}}"
+    [[CloneGeosMksi-{{model_component}}]]
+        script = "swell task CloneGeosMksi $config -m {{model_component}}"
 
     [[GenerateObservingSystemRecords-{{model_component}}]]
         script = "swell task GenerateObservingSystemRecords $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/ufo_testing/flow.cylc
+++ b/src/swell/suites/ufo_testing/flow.cylc
@@ -36,14 +36,14 @@
             BuildJediByLinking:fail? => BuildJedi
 
             # Clone geos ana for generating observing system records
-            CloneGeosAna
+            CloneGeosMksi
         """
 
         {% for cycle_time in cycle_times %}
         {{cycle_time.cycle_time}} = """
 
             # Generate satellite channel records
-            CloneGeosAna[^] => GenerateObservingSystemRecords
+            CloneGeosMksi[^] => GenerateObservingSystemRecords
 
             # Convert bias correction to ioda
             GetGsiBc
@@ -108,8 +108,8 @@
             --partition={{scheduling["BuildJedi"]["partition"]}}
             {% endif %}
 
-    [[CloneGeosAna]]
-        script = "swell task CloneGeosAna $config -m geos_atmosphere"
+    [[CloneGeosMksi]]
+        script = "swell task CloneGeosMksi $config -m geos_atmosphere"
 
     [[GenerateObservingSystemRecords]]
         script = "swell task GenerateObservingSystemRecords $config -d $datetime -m geos_atmosphere"

--- a/src/swell/tasks/clone_geos_mksi.py
+++ b/src/swell/tasks/clone_geos_mksi.py
@@ -15,12 +15,12 @@ from swell.utilities.build import link_path
 # --------------------------------------------------------------------------------------------------
 
 
-class CloneGeosAna(taskBase):
+class CloneGeosMksi(taskBase):
 
     def execute(self):
 
         """
-        Generate the satellite channel record from GEOSadas files
+        Generate the satellite channel record from GEOSmksi files
         """
 
         # This task should only execute for geos_atmosphere
@@ -31,18 +31,18 @@ class CloneGeosAna(taskBase):
 
         # Parse config
         # ------------
-        path_to_geosana_gridcomp = self.config.observing_system_records_gsi_path()
+        path_to_geos_mksi = self.config.observing_system_records_gsi_path()
 
-        # If observing_system_records_gsi_path is None, clone GEOSana_GridComp repo to experiment
+        # If observing_system_records_gsi_path is None, clone GEOS_mksi repo to experiment
         # directory
-        if path_to_geosana_gridcomp == 'None':
-            # Clone GEOSana_GridComp develop repo to experiment directory
-            os.system('git clone https://github.com/GEOS-ESM/GEOSana_GridComp.git '
-                      + os.path.join(self.experiment_path(), 'GEOSana_GridComp'))
+        if path_to_geos_mksi == 'None':
+            # Clone GEOS_mksi develop repo to experiment directory
+            os.system('git clone https://github.com/GEOS-ESM/GEOS_mksi.git '
+                      + os.path.join(self.experiment_path(), 'GEOS_mksi'))
         else:
             # Link the source code directory
             link_path(self.config.observing_system_records_gsi_path(),
-                      os.path.join(self.experiment_path(), 'GEOSana_GridComp'))
+                      os.path.join(self.experiment_path(), 'GEOS_mksi'))
 
 
 # ----------------------------------------------------------------------------------------------

--- a/src/swell/tasks/clone_geos_mksi.py
+++ b/src/swell/tasks/clone_geos_mksi.py
@@ -32,12 +32,17 @@ class CloneGeosMksi(taskBase):
         # Parse config
         # ------------
         path_to_geos_mksi = self.config.observing_system_records_gsi_path()
+        tag = self.config.observing_system_records_gsi_path_tag()
 
         # If observing_system_records_gsi_path is None, clone GEOS_mksi repo to experiment
         # directory
         if path_to_geos_mksi == 'None':
+            if tag == 'None':
+                branch = 'develop'
+            else:
+                branch = tag
             # Clone GEOS_mksi develop repo to experiment directory
-            os.system('git clone https://github.com/GEOS-ESM/GEOS_mksi.git '
+            os.system(f'git clone -b {branch} https://github.com/GEOS-ESM/GEOS_mksi.git '
                       + os.path.join(self.experiment_path(), 'GEOS_mksi'))
         else:
             # Link the source code directory

--- a/src/swell/tasks/clone_geos_mksi.py
+++ b/src/swell/tasks/clone_geos_mksi.py
@@ -31,10 +31,10 @@ class CloneGeosMksi(taskBase):
 
         # Parse config
         # ------------
-        path_to_geos_mksi = self.config.observing_system_records_gsi_path()
-        tag = self.config.observing_system_records_gsi_path_tag()
+        path_to_geos_mksi = self.config.observing_system_records_mksi_path()
+        tag = self.config.observing_system_records_mksi_path_tag()
 
-        # If observing_system_records_gsi_path is None, clone GEOS_mksi repo to experiment
+        # If observing_system_records_mksi_path is None, clone GEOS_mksi repo to experiment
         # directory
         if path_to_geos_mksi == 'None':
             if tag == 'None':
@@ -46,7 +46,7 @@ class CloneGeosMksi(taskBase):
                       + os.path.join(self.experiment_path(), 'GEOS_mksi'))
         else:
             # Link the source code directory
-            link_path(self.config.observing_system_records_gsi_path(),
+            link_path(self.config.observing_system_records_mksi_path(),
                       os.path.join(self.experiment_path(), 'GEOS_mksi'))
 
 

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -104,13 +104,13 @@ class EvaObservations(taskBase):
             obs_path_file = observation_dict['obs space']['obsdataout']['engine']['obsfile']
 
             # Prevent Eva from failing if there are observation files with 0 observations
-            with nc.Dataset(obs_path_file, 'r') as ds:
-                loc_size = len(ds.dimensions['Location'])
+            #with nc.Dataset(obs_path_file, 'r') as ds:
+            #    loc_size = len(ds.dimensions['Location'])
 
-            if (loc_size) < 1:
-                self.logger.info(f'No observations were found for {obs_path_file}. ' +
-                                 'No plots will be produced')
-                continue
+            #if (loc_size) < 1:
+            #    self.logger.info(f'No observations were found for {obs_path_file}. ' +
+            #                     'No plots will be produced')
+            #    continue
 
             cycle_dir, obs_file = os.path.split(obs_path_file)
 

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -104,13 +104,13 @@ class EvaObservations(taskBase):
             obs_path_file = observation_dict['obs space']['obsdataout']['engine']['obsfile']
 
             # Prevent Eva from failing if there are observation files with 0 observations
-            #with nc.Dataset(obs_path_file, 'r') as ds:
-            #    loc_size = len(ds.dimensions['Location'])
+            with nc.Dataset(obs_path_file, 'r') as ds:
+                loc_size = len(ds.dimensions['Location'])
 
-            #if (loc_size) < 1:
-            #    self.logger.info(f'No observations were found for {obs_path_file}. ' +
-            #                     'No plots will be produced')
-            #    continue
+            if (loc_size) < 1:
+                self.logger.info(f'No observations were found for {obs_path_file}. ' +
+                                 'No plots will be produced')
+                continue
 
             cycle_dir, obs_file = os.path.split(obs_path_file)
 

--- a/src/swell/tasks/generate_observing_system_records.py
+++ b/src/swell/tasks/generate_observing_system_records.py
@@ -21,7 +21,7 @@ class GenerateObservingSystemRecords(taskBase):
     def execute(self):
 
         """
-        Generate the observing system channel records from GEOSadas files
+        Generate the observing system channel records from GEOS_mksi files
         """
 
         # This task should only execute for geos_atmosphere
@@ -38,11 +38,10 @@ class GenerateObservingSystemRecords(taskBase):
             cycle_dir = self.cycle_dir()
             observing_system_records_path = os.path.join(cycle_dir, 'observing_system_records')
 
-        path_to_geosana_gridcomp = self.config.observing_system_records_gsi_path()
-        if path_to_geosana_gridcomp == 'None':
-            path_to_geosana_gridcomp = os.path.join(self.experiment_path(), 'GEOSana_GridComp')
-        path_to_gsi_records = os.path.join(path_to_geosana_gridcomp, 'GEOSaana_GridComp',
-                                           'GSI_GridComp', 'mksi', 'sidb')
+        path_to_geos_mksi = self.config.observing_system_records_gsi_path()
+        if path_to_geos_mksi == 'None':
+            path_to_geos_mksi = os.path.join(self.experiment_path(), 'GEOS_mksi')
+        path_to_gsi_records = os.path.join(path_to_geos_mksi, 'sidb')
         sat_records = ObservingSystemRecords()
         sat_records.parse_records(path_to_gsi_records)
         sat_records.save_yamls(observing_system_records_path, observations)

--- a/src/swell/tasks/generate_observing_system_records.py
+++ b/src/swell/tasks/generate_observing_system_records.py
@@ -38,7 +38,7 @@ class GenerateObservingSystemRecords(taskBase):
             cycle_dir = self.cycle_dir()
             observing_system_records_path = os.path.join(cycle_dir, 'observing_system_records')
 
-        path_to_geos_mksi = self.config.observing_system_records_gsi_path()
+        path_to_geos_mksi = self.config.observing_system_records_mksi_path()
         if path_to_geos_mksi == 'None':
             path_to_geos_mksi = os.path.join(self.experiment_path(), 'GEOS_mksi')
         path_to_gsi_records = os.path.join(path_to_geos_mksi, 'sidb')

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -600,7 +600,7 @@ observations:
   - SaveObsDiags
   type: string-check-list
 
-observing_system_records_gsi_path:
+observing_system_records_mksi_path:
   ask_question: false
   default_value: defer_to_model
   models:
@@ -611,7 +611,7 @@ observing_system_records_gsi_path:
   - GenerateObservingSystemRecords
   type: string
 
-observing_system_records_gsi_path_tag:
+observing_system_records_mksi_path_tag:
   ask_question: false
   default_value: defer_to_model
   models:

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -611,6 +611,16 @@ observing_system_records_gsi_path:
   - GenerateObservingSystemRecords
   type: string
 
+observing_system_records_gsi_path_tag:
+  ask_question: false
+  default_value: defer_to_model
+  models:
+  - geos_atmosphere
+  prompt: What is the GSI formatted observing system records tag?
+  tasks:
+  - CloneGeosMksi
+  type: string
+
 observing_system_records_path:
   ask_question: false
   default_value: defer_to_model

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -607,7 +607,7 @@ observing_system_records_gsi_path:
   - geos_atmosphere
   prompt: What is the path to the GSI formatted observing system records?
   tasks:
-  - CloneGeosAna
+  - CloneGeosMksi
   - GenerateObservingSystemRecords
   type: string
 

--- a/src/swell/test/code_tests/generate_observing_system_test.py
+++ b/src/swell/test/code_tests/generate_observing_system_test.py
@@ -4,10 +4,9 @@ from swell.utilities.observing_system_records import ObservingSystemRecords
 observations = ['airs_aqua']
 observing_system_records_path = './yaml_output/'
 
-# Clone GeosAna
-os.system('git clone https://github.com/GEOS-ESM/GEOSana_GridComp.git')
-path_to_gsi_records = os.path.join('GEOSana_GridComp/', 'GEOSaana_GridComp',
-                                   'GSI_GridComp', 'mksi', 'sidb')
+# Clone Geos_mksi
+os.system('git clone https://github.com/GEOS-ESM/GEOS_mksi.git')
+path_to_gsi_records = os.path.join('GEOS_mksi/', 'sidb')
 sat_records = ObservingSystemRecords()
 sat_records.parse_records(path_to_gsi_records)
 sat_records.save_yamls(observing_system_records_path, observations)

--- a/src/swell/utilities/observing_system_records.py
+++ b/src/swell/utilities/observing_system_records.py
@@ -92,7 +92,7 @@ class ObservingSystemRecords:
 
         '''
             This method reads in the active.tbl and available.tbl files
-            from GEOSAna and loads them into dataframes. These dataframes
+            from GEOS_mksi and loads them into dataframes. These dataframes
             are parsed using GSIRecordParser to get the final dataframes.
         '''
 


### PR DESCRIPTION
## Description

Thanks to @mathomp4, we have a lightweight repository for accessing GSI channel records. 

Changes include:
- Renaming task references to CloneGeosMksi and task script is called clone_geos_mksi.py
- Modifying clone_geos_mksi.py to clone GEOS_mksi instead and updating all paths as necessary
- Adding ability to use a tag for GEOS_mksi (question shows up in experiment.yaml)

Closes #289 

