### PR TITLE
Fix to check for missing obs in SaveObsDiag

### DIFF
--- a/src/swell/__init__.py
+++ b/src/swell/__init__.py
@@ -9,4 +9,4 @@ import os
 repo_directory = os.path.dirname(__file__)
 
 # Set the version for swell
-__version__ = '1.8.1'
+__version__ = '1.8.3'

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -87,7 +87,6 @@ class EvaObservations(taskBase):
 
         # Set the observing system records path
         self.jedi_rendering.set_obs_records_path(self.config.observing_system_records_path(None))
-        cycle_time_dto = self.cycle_time_dto()
 
         for observation in self.config.observations():
 
@@ -96,22 +95,12 @@ class EvaObservations(taskBase):
 
             # Check if observation was used
             use_obs = check_obs(self.jedi_rendering.observing_system_records_path, observation,
-                                observation_dict, cycle_time_dto)
+                                observation_dict, self.cycle_time_dto())
             if not use_obs:
                 continue
 
             # Split the full path into path and filename
             obs_path_file = observation_dict['obs space']['obsdataout']['engine']['obsfile']
-
-            # Prevent Eva from failing if there are observation files with 0 observations
-            with nc.Dataset(obs_path_file, 'r') as ds:
-                loc_size = len(ds.dimensions['Location'])
-
-            if (loc_size) < 1:
-                self.logger.info(f'No observations were found for {obs_path_file}. ' +
-                                 'No plots will be produced')
-                continue
-
             cycle_dir, obs_file = os.path.split(obs_path_file)
 
             # Check for need to add 0000 to the file

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -9,7 +9,6 @@
 
 
 from multiprocessing import Pool
-import netCDF4 as nc
 import os
 import yaml
 

--- a/src/swell/tasks/save_obs_diags.py
+++ b/src/swell/tasks/save_obs_diags.py
@@ -10,6 +10,7 @@
 import os
 from swell.tasks.base.task_base import taskBase
 from r2d2 import store
+from swell.utilities.run_jedi_executables import check_obs
 
 # --------------------------------------------------------------------------------------------------
 
@@ -48,6 +49,12 @@ class SaveObsDiags(taskBase):
 
             # Load the observation dictionary
             observation_dict = self.jedi_rendering.render_interface_observations(observation)
+
+            # Check if observation was used
+            use_obs = check_obs(self.jedi_rendering.observing_system_records_path, observation,
+                                observation_dict, self.cycle_time_dto())
+            if not use_obs:
+                continue
 
             # Store observation files
             # -----------------------


### PR DESCRIPTION
## Description

Adds `check_obs` function to `SaveObsDiag` to make sure code downstream isn't trying to execute if obs is missing. Also removed some logic added earlier in `eva_observations.py` because the `check_obs` function takes care of it now.

Added `sst_ostia` back to geos-ocean hofx swell run and everything seems to be working as expected

Closes #295 
(Thanks for finding this bug @Dooruk!)

