### PR TITLE
Update to Skylab7 Modules - Part 1 (SLES12)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 click>=8.0.0
-jinja2>=3.1.2
+jinja2>=3.0.3
 pyyaml>=6.0
-pycodestyle>=2.8.0
+pycodestyle>=2.11.0
 pandas>=1.4.0
 isodate>=0.5.4
 f90nml>=1.4.3
 questionary>=1.10.0
 h5py>=3.7.0
-flake8==6.0.0
+flake8==6.1.0
 netCDF4

--- a/src/swell/deployment/platforms/nccs_discover/modules
+++ b/src/swell/deployment/platforms/nccs_discover/modules
@@ -8,14 +8,14 @@ module purge
 
 # Spack stack modules
 # -------------------
-module use /discover/swdev/jcsda/spack-stack/modulefiles
+module purge
+module use /discover/swdev/jcsda/spack-stack/scu16/modulefiles
 module load miniconda/3.9.7
 module load ecflow/5.8.4
-module load mysql/8.0.31
-module use /gpfsm/dswdev/jcsda/spack-stack/spack-stack-dev-20231114/envs/unified-env/install/modulefiles/Core
-module load stack-intel/2022.0.1
-module load stack-intel-oneapi-mpi/2021.5.0
-module load stack-python/3.10.8
+module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.7.0/envs/ue-intel-2021.6.0/install/modulefiles/Core
+module load stack-intel/2021.6.0
+module load stack-intel-oneapi-mpi/2021.6.0
+module load stack-python/3.10.13
 module load jedi-fv3-env
 module load soca-env
 module load gmao-swell-env/1.0.0
@@ -37,15 +37,14 @@ module load other/mepo
 # Load r2d2 modules
 # -----------------
 module use -a /discover/nobackup/projects/gmao/advda/JediOpt/modulefiles/core
-module load solo/spack-202311
+module load solo/sles12_skylab7
 module load py-boto3
-module load r2d2/spack-202311
+module load r2d2/sles12_skylab7
 
 # Load eva and jedi_bundle
 # ------------------------
-module use -a /discover/nobackup/projects/gmao/advda/JediOpt/modulefiles/core
-module load eva/1.6.1
-module load jedi_bundle/1.0.18_py310
+module load eva/sles12_skylab7
+module load jedi_bundle/sles12_skylab7
 
 # Set the swell paths
 # -------------------

--- a/src/swell/deployment/platforms/nccs_discover/modules
+++ b/src/swell/deployment/platforms/nccs_discover/modules
@@ -8,7 +8,6 @@ module purge
 
 # Spack stack modules
 # -------------------
-module purge
 module use /discover/swdev/jcsda/spack-stack/scu16/modulefiles
 module load miniconda/3.9.7
 module load ecflow/5.8.4


### PR DESCRIPTION
We are updating the modules to conform with the official spack-stack release (1.7.0) and skylab 7.

https://spack-stack--1052.org.readthedocs.build/en/1052/PreConfiguredSites.html#nasa-discover-scu16

`jedi_bundle` is also updated so the new JEDI bundles will be built with the skylab 7 modules.