### PR TITLE
Added useflag checks for AMSR2 and GMI channels.

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
@@ -9,7 +9,7 @@ obs space:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.amsr2_gcom-w1.{{window_begin}}.nc4'
   simulated variables: [brightnessTemperature]
-  channels: &amsr2_gcom-w1_available_channels 1-14
+  channels: &amsr2_gcom-w1_available_channels {{amsr2_gcomw1_avail_channels}}
 
 obs operator:
   name: CRTM
@@ -17,7 +17,7 @@ obs operator:
   Clouds: [Water, Ice, Rain, Snow]
   Cloud_Fraction: 1.0
   obs options:
-    Sensor_ID: amsr2_gcom-w1
+    Sensor_ID: &Sensor_ID amsr2_gcom-w1
     EndianType: little_endian
     CoefficientPath: '{{crtm_coeff_dir}}/'
 
@@ -210,5 +210,21 @@ obs filters:
   - name: brightnessTemperature
     channels: 11-14
   absolute threshold: 50
+  action:
+    name: reject
+#  Useflag check
+- filter: Bounds Check
+  filter variables:
+  - name: brightnessTemperature
+    channels: *amsr2_gcom-w1_available_channels
+  test variables:
+  - name: ObsFunction/ChannelUseflagCheckRad
+    channels: *amsr2_gcom-w1_available_channels
+    options:
+      channels: *amsr2_gcom-w1_available_channels
+#     use passive_bc: true
+      sensor: *Sensor_ID
+      use_flag: &amsr2_gcom-w1_use_flag {{amsr2_gcomw1_active_channels}}
+  minvalue: 1.0e-12
   action:
     name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
@@ -9,7 +9,7 @@ obs space:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.gmi_gpm.{{window_begin}}.nc4'
   simulated variables: [brightnessTemperature]
-  channels: &gmi_gpm_available_channels 1-13
+  channels: &gmi_gpm_available_channels {{gmi_gpm_avail_channels}}
 
 obs operator:
   name: CRTM
@@ -17,7 +17,7 @@ obs operator:
   Clouds: [Water, Ice, Rain, Snow]
   Cloud_Fraction: 1.0
   obs options:
-    Sensor_ID: gmi_gpm
+    Sensor_ID: &Sensor_ID gmi_gpm
     EndianType: little_endian
     CoefficientPath: '{{crtm_coeff_dir}}/'
   linear obs operator:
@@ -327,3 +327,20 @@ obs filters:
   absolute threshold: 5.0
   action:
     name: reject
+#  Useflag check
+- filter: Bounds Check
+  filter variables:
+  - name: brightnessTemperature
+    channels: *gmi_gpm_available_channels
+  test variables:
+  - name: ObsFunction/ChannelUseflagCheckRad
+    channels: *gmi_gpm_available_channels
+    options:
+      channels: *gmi_gpm_available_channels
+#     use passive_bc: true
+      sensor: *Sensor_ID
+      use_flag: &gmi_gpm_use_flag {{gmi_gpm_active_channels}}
+  minvalue: 1.0e-12
+  action:
+    name: reject
+

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
@@ -343,4 +343,3 @@ obs filters:
   minvalue: 1.0e-12
   action:
     name: reject
-

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ufo_tests.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ufo_tests.yaml
@@ -18,7 +18,7 @@ airs_aqua:
 
 amsr2_gcom-w1:
   filter_test:
-    passedBenchmark: 54558
+    passedBenchmark: 8087
 
 amsua_aqua:
   filter_test:
@@ -74,7 +74,7 @@ cris-fsr_npp:
 
 gmi_gpm:
   filter_test:
-    passedBenchmark: 41975
+    passedBenchmark: 18606
 
 gps:
   filter_test:

--- a/src/swell/deployment/platforms/nccs_discover/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover/task_questions.yaml
@@ -8,10 +8,10 @@ existing_geos_gcm_source_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.5.1-Intel-SLES12/GEOSgcm
 
 existing_jedi_build_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca/build-intel-release/
+  default_value: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/build/
 
 existing_jedi_source_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca/
+  default_value: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/source/
 
 geos_experiment_directory:
   default_value: 5deg_v11


### PR DESCRIPTION
## Description

Added "useflag checks" for AMSR2 and GMI to select active channels. It solves the issue https://github.com/GEOS-ESM/swell/issues/317 reported by @rtodling . 
