### PR TITLE
Re-instate hofx scaling in observation operators.

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/aircraft.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/aircraft.yaml
@@ -24,8 +24,25 @@ obs operator:
     - name: windNorthward
 
     # Hofx scaling
-#   hofx scaling field: SurfaceWindScalingPressure
-#   hofx scaling field group: DerivedVariables
+    hofx scaling field: SurfaceWindScalingPressure
+    hofx scaling field group: DerivedVariables
+
+  - name: VertInterp
+    observation alias file: '{{experiment_root}}/{{experiment_id}}/configuration/jedi/interfaces/{{model_component}}/observations/obsop_name_map.yaml'
+    variables: [airTemperature]
+
+linear obs operator:
+  name: Composite
+  components:
+
+  - name: VertInterp
+    variables:
+    - name: windEastward
+    - name: windNorthward
+
+    # Hofx scaling
+    hofx scaling field: SurfaceWindScalingPressure
+    hofx scaling field group: DerivedVariables
 
   - name: VertInterp
     observation alias file: '{{experiment_root}}/{{experiment_id}}/configuration/jedi/interfaces/{{model_component}}/observations/obsop_name_map.yaml'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pibal.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pibal.yaml
@@ -33,8 +33,30 @@ obs operator:
       interpolation method backup: log-linear
 
       # Hofx scaling
-#     hofx scaling field: SurfaceWindScalingCombined
-#     hofx scaling field group: DerivedVariables
+      hofx scaling field: SurfaceWindScalingCombined
+      hofx scaling field group: DerivedVariables
+
+linear obs operator:
+  name: Composite
+  components:
+    - name: VertInterp
+      observation alias file: '{{experiment_root}}/{{experiment_id}}/configuration/jedi/interfaces/{{model_component}}/observations/obsop_name_map.yaml'
+
+      # Use height vertical coordinate first
+      vertical coordinate: geopotential_height
+      observation vertical coordinate group: DerivedVariables
+      observation vertical coordinate: adjustedHeight
+      interpolation method: linear
+
+      # Use pressure vertical coordinate backup
+      vertical coordinate backup: air_pressure
+      observation vertical coordinate group backup: MetaData
+      observation vertical coordinate backup: pressure
+      interpolation method backup: log-linear
+
+      # Hofx scaling
+      hofx scaling field: SurfaceWindScalingCombined
+      hofx scaling field group: DerivedVariables
 
 obs pre filters:
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/satwind.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/satwind.yaml
@@ -13,8 +13,14 @@ obs space:
 obs operator:
   name: VertInterp
   observation alias file: '{{experiment_root}}/{{experiment_id}}/configuration/jedi/interfaces/{{model_component}}/observations/obsop_name_map.yaml'
-# hofx scaling field: SurfaceWindScalingPressure
-# hofx scaling field group: DerivedVariables
+  hofx scaling field: SurfaceWindScalingPressure
+  hofx scaling field group: DerivedVariables
+
+linear obs operator:
+  name: VertInterp
+  observation alias file: '{{experiment_root}}/{{experiment_id}}/configuration/jedi/interfaces/{{model_component}}/observations/obsop_name_map.yaml'
+  hofx scaling field: SurfaceWindScalingPressure
+  hofx scaling field group: DerivedVariables
 
 obs prior filters:
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/scatwind.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/scatwind.yaml
@@ -20,8 +20,21 @@ obs operator:
   observation vertical coordinate group: DerivedVariables
   observation vertical coordinate: adjustedHeight
   interpolation method: linear
-# hofx scaling field: SurfaceWindScalingHeight
-# hofx scaling field group: DerivedVariables
+  hofx scaling field: SurfaceWindScalingHeight
+  hofx scaling field group: DerivedVariables
+
+linear obs operator:
+
+  name: VertInterp
+  observation alias file: '{{experiment_root}}/{{experiment_id}}/configuration/jedi/interfaces/{{model_component}}/observations/obsop_name_map.yaml'
+
+  # Use height vertical coordinate first
+  vertical coordinate: geopotential_height
+  observation vertical coordinate group: DerivedVariables
+  observation vertical coordinate: adjustedHeight
+  interpolation method: linear
+  hofx scaling field: SurfaceWindScalingHeight
+  hofx scaling field group: DerivedVariables
 
 obs prior filters:
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
@@ -25,8 +25,8 @@ obs operator:
      observation vertical coordinate group: DerivedVariables
      observation vertical coordinate: adjustedHeight
      interpolation method: linear
-#    hofx scaling field: SurfaceWindScalingHeight
-#    hofx scaling field group: DerivedVariables
+     hofx scaling field: SurfaceWindScalingHeight
+     hofx scaling field group: DerivedVariables
 
    # Temperatures use vertical interpolation
    - name: VertInterp
@@ -64,8 +64,8 @@ linear obs operator:
      observation vertical coordinate group: DerivedVariables
      observation vertical coordinate: adjustedHeight
      interpolation method: linear
-#    hofx scaling field: SurfaceWindScalingHeight
-#    hofx scaling field group: DerivedVariables
+     hofx scaling field: SurfaceWindScalingHeight
+     hofx scaling field group: DerivedVariables
 
    # Temperatures use vertical interpolation
    - name: VertInterp

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfcship.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfcship.yaml
@@ -24,8 +24,8 @@ obs operator:
      observation vertical coordinate group: DerivedVariables
      observation vertical coordinate: adjustedHeight
      interpolation method: linear
-#    hofx scaling field: SurfaceWindScalingHeight
-#    hofx scaling field group: DerivedVariables
+     hofx scaling field: SurfaceWindScalingHeight
+     hofx scaling field group: DerivedVariables
 
    - name: VertInterp
      observation alias file: '{{experiment_root}}/{{experiment_id}}/configuration/jedi/interfaces/{{model_component}}/observations/obsop_name_map.yaml'
@@ -60,8 +60,8 @@ linear obs operator:
      observation vertical coordinate group: DerivedVariables
      observation vertical coordinate: adjustedHeight
      interpolation method: linear
-#    hofx scaling field: SurfaceWindScalingHeight
-#    hofx scaling field group: DerivedVariables
+     hofx scaling field: SurfaceWindScalingHeight
+     hofx scaling field group: DerivedVariables
 
    - name: VertInterp
      observation alias file: '{{experiment_root}}/{{experiment_id}}/configuration/jedi/interfaces/{{model_component}}/observations/obsop_name_map.yaml'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sondes.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sondes.yaml
@@ -52,8 +52,8 @@ linear obs operator:
     - name: windNorthward
 
     # Hofx scaling
-#   hofx scaling field: SurfaceWindScalingPressure
-#   hofx scaling field group: DerivedVariables
+    hofx scaling field: SurfaceWindScalingPressure
+    hofx scaling field group: DerivedVariables
 
   - name: VertInterp
     variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ufo_tests.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ufo_tests.yaml
@@ -122,11 +122,11 @@ satwind:
 
 scatwind:
   filter_test:
-    passedBenchmark: 16262
+    passedBenchmark: 16384
 
 sfcship:
   filter_test:
-    passedBenchmark: 99068
+    passedBenchmark: 99142
 
 sfc:
   filter_test:


### PR DESCRIPTION

Add back hofx scaling in linear and non-linear observation operators for convectional data.

Dependencies

- [x] waiting on https://github.com/JCSDA-internal/ufo/pull/3299

Solves the issue https://github.com/GEOS-ESM/swell/issues/304