### PR TITLE
use-flag cannot be wired; comes from satdb

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
@@ -210,11 +210,7 @@ obs post filters:
       channels: *atms_n20_channels
       options:
         channels: *atms_n20_channels
-        use_flag: [-1, -1, -1, -1,  1,
-                    1,  1,  1,  1,  1,
-                    1,  1,  1,  1,  1,
-                   -1,  1,  1,  1,  1,
-                    1,  1]
+        use_flag: *atms_n20_use_flag
     minvalue: 1.0e-12
     action:
       name: reject


### PR DESCRIPTION
## Description

Use flag settings were wired ... these need to come from sat-db (mksi)

## Dependencies

None

## Impact

Correct use of data in general way - for now this is correct since in the test cases the choice wired was consistent w/ satdb, but not in general. This removes the wiring.