### PR TITLE
Updated OMI_AURA and OMPS_NPP observational errors and QC.

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/omi_aura.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/omi_aura.yaml
@@ -23,7 +23,7 @@ obs filters:
   - name: ozoneTotal
   action:
     name: assign error
-    error parameter: 6.0
+    error parameter: 5.0
  # range sanity check
 - filter: Bounds Check
   filter variables:
@@ -42,20 +42,20 @@ obs filters:
   action:
     name: reject
 # Reject rows 25+ (somewhat stringent but thats what we do in GEOS)
-#- filter: Bounds Check
-#  filter variables:
-#  - name: ozoneTotal
-#  test variables:
-#  - name: MetaData/sensorScanPosition
-#  minvalue: 3
-#  maxvalue: 24
-#  action:
-#    name: reject
+- filter: Bounds Check
+  filter variables:
+  - name: ozoneTotal
+  test variables:
+  - name: MetaData/sensorScanPosition
+  minvalue: 3
+  maxvalue: 24
+  action:
+    name: reject
 
  # Gross check
-#- filter: Background Check
-#  filter variables:
-#  - name: ozoneTotal
-#  threshold: 5.0
-#  action:
-#    name: reject
+- filter: Background Check
+  filter variables:
+  - name: ozoneTotal
+  threshold: 5.0
+  action:
+    name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ompsnm_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ompsnm_npp.yaml
@@ -22,7 +22,7 @@ obs filters:
   - name: ozoneTotal
   action:
     name: assign error
-    error parameter: 6.0
+    error parameter: 5.216
  # range sanity check
 - filter: Bounds Check
   filter variables:
@@ -41,9 +41,9 @@ obs filters:
   action:
     name: reject
 # Gross check
-#- filter: Background Check
-#  filter variables:
-#  - name: ozoneTotal
-#  threshold: 5.0
-#  action:
-#    name: reject
+- filter: Background Check
+  filter variables:
+  - name: ozoneTotal
+  threshold: 5.0
+  action:
+    name: reject


### PR DESCRIPTION
Reinstated some quality control for OMI-AURA and OMPS_NPP ozone data.
Updated observational error.

Dependencies

- [x] waiting on a JEDI/UFO bug fix in a linear operator: https://github.com/JCSDA-internal/ufo/pull/3318

Resolves
 GEOS 3DVar Fails for OMPSNM_NPP https://github.com/GEOS-ESM/swell/issues/305
and 3DVar Fails: OMI_AURA https://github.com/GEOS-ESM/swell/issues/306
