### PR TITLE
Sync w/ latest JEDI - Apr 5th 2024

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
@@ -1,6 +1,6 @@
 covariance model: SABER
 saber central block:
-  saber block name: gsi covariance
+  saber block name: gsi hybrid covariance
   read:
     gsi akbk: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/akbk{{vertical_resolution}}.nc4'
     gsi error covariance file: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/gsibec/gsibec_coefficients_c{{horizontal_resolution}}.nc4'


### PR DESCRIPTION
## Description

Tier tests are braking - cannot run 3dvar_atmos and 3dfgat_atmos because of minor change in JEDI. This provides the fix.

## Dependencies

None

## Impact

None
