### PR TITLE
Flexible SLURM configuration

### DIFF
--- a/src/swell/deployment/create_experiment.py
+++ b/src/swell/deployment/create_experiment.py
@@ -435,11 +435,15 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
                              'there are no model components to gather them from or ' +
                              'they are not provided in the experiment dictionary.')
 
-    render_dictionary["scheduling"] = prepare_scheduling_dict(logger, experiment_dict)
+    render_dictionary['scheduling'] = prepare_scheduling_dict(logger, experiment_dict)
+
+    # Default execution time limit for everthing is PT1H
+    for slurm_task in render_dictionary['scheduling'].keys():
+        render_dictionary['scheduling'][slurm_task]['execution_time_limit'] = 'PT1H'
 
     # Set some specific values for:
     # ------------------------------
-    # run time
+    # run time (note: these overwrite defaults above)
     render_dictionary['scheduling']['BuildJedi']['execution_time_limit'] = 'PT3H'
     render_dictionary['scheduling']['EvaObservations']['execution_time_limit'] = 'PT30M'
 

--- a/src/swell/suites/3dfgat_atmos/flow.cylc
+++ b/src/swell/suites/3dfgat_atmos/flow.cylc
@@ -118,15 +118,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildJedi"]["account"]}}
-            --qos = {{scheduling["BuildJedi"]["qos"]}}
-            --job-name = BuildJedi
-            --nodes={{scheduling["BuildJedi"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
-            --constraint={{scheduling["BuildJedi"]["constraint"]}}
-            {% if scheduling["BuildJedi"]["partition"] %}
-            --partition={{scheduling["BuildJedi"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     {% for model_component in model_components %}
 
@@ -156,15 +150,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["RunJediVariationalExecutable"]["account"]}}
-            --qos = {{scheduling["RunJediVariationalExecutable"]["qos"]}}
-            --job-name = RunJediVariationalExecutable
-            --nodes={{scheduling["RunJediVariationalExecutable"]["nodes"]}}
-            --ntasks-per-node={{scheduling["RunJediVariationalExecutable"]["ntasks_per_node"]}}
-            --constraint={{scheduling["RunJediVariationalExecutable"]["constraint"]}}
-            {% if scheduling["RunJediVariationalExecutable"]["partition"] %}
-            --partition={{scheduling["RunJediVariationalExecutable"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[EvaJediLog-{{model_component}}]]
         script = "swell task EvaJediLog $config -d $datetime -m {{model_component}}"
@@ -177,15 +165,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["EvaObservations"]["account"]}}
-            --qos = {{scheduling["EvaObservations"]["qos"]}}
-            --job-name = EvaObservations
-            --nodes={{scheduling["EvaObservations"]["nodes"]}}
-            --ntasks-per-node={{scheduling["EvaObservations"]["ntasks_per_node"]}}
-            --constraint={{scheduling["EvaObservations"]["constraint"]}}
-            {% if scheduling["EvaObservations"]["partition"] %}
-            --partition={{scheduling["EvaObservations"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[SaveObsDiags-{{model_component}}]]
         script = "swell task SaveObsDiags $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/3dfgat_atmos/flow.cylc
+++ b/src/swell/suites/3dfgat_atmos/flow.cylc
@@ -118,7 +118,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+        {% for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -150,7 +150,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"].items() %}
+        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -165,7 +165,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+        {% for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/3dvar/flow.cylc
+++ b/src/swell/suites/3dvar/flow.cylc
@@ -112,15 +112,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildJedi"]["account"]}}
-            --qos = {{scheduling["BuildJedi"]["qos"]}}
-            --job-name = BuildJedi
-            --nodes={{scheduling["BuildJedi"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
-            --constraint={{scheduling["BuildJedi"]["constraint"]}}
-            {% if scheduling["BuildJedi"]["partition"] %}
-            --partition={{scheduling["BuildJedi"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     {% for model_component in model_components %}
     [[StageJedi-{{model_component}}]]
@@ -143,30 +137,18 @@
         platform = {{platform}}
         execution time limit = {{scheduling["GenerateBClimatology"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["GenerateBClimatology"]["account"]}}
-            --qos = {{scheduling["GenerateBClimatology"]["qos"]}}
-            --job-name = GenerateBClimatology
-            --nodes={{scheduling["GenerateBClimatology"]["nodes"]}}
-            --ntasks-per-node={{scheduling["GenerateBClimatology"]["ntasks_per_node"]}}
-            --constraint={{scheduling["GenerateBClimatology"]["constraint"]}}
-            {% if scheduling["GenerateBClimatology"]["partition"] %}
-            --partition={{scheduling["GenerateBClimatology"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["GenerateBClimatology"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[RunJediVariationalExecutable-{{model_component}}]]
         script = "swell task RunJediVariationalExecutable $config -d $datetime -m {{model_component}}"
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["RunJediVariationalExecutable"]["account"]}}
-            --qos = {{scheduling["RunJediVariationalExecutable"]["qos"]}}
-            --job-name = RunJediVariationalExecutable
-            --nodes={{scheduling["RunJediVariationalExecutable"]["nodes"]}}
-            --ntasks-per-node={{scheduling["RunJediVariationalExecutable"]["ntasks_per_node"]}}
-            --constraint={{scheduling["RunJediVariationalExecutable"]["constraint"]}}
-            {% if scheduling["RunJediVariationalExecutable"]["partition"] %}
-            --partition={{scheduling["RunJediVariationalExecutable"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[EvaJediLog-{{model_component}}]]
         script = "swell task EvaJediLog $config -d $datetime -m {{model_component}}"
@@ -176,15 +158,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["EvaObservations"]["account"]}}
-            --qos = {{scheduling["EvaObservations"]["qos"]}}
-            --job-name = EvaObservations
-            --nodes={{scheduling["EvaObservations"]["nodes"]}}
-            --ntasks-per-node={{scheduling["EvaObservations"]["ntasks_per_node"]}}
-            --constraint={{scheduling["EvaObservations"]["constraint"]}}
-            {% if scheduling["EvaObservations"]["partition"] %}
-            --partition={{scheduling["EvaObservations"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[SaveObsDiags-{{model_component}}]]
         script = "swell task SaveObsDiags $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/3dvar/flow.cylc
+++ b/src/swell/suites/3dvar/flow.cylc
@@ -112,7 +112,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+        {% for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -137,7 +137,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["GenerateBClimatology"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["GenerateBClimatology"]["directives"].items() %}
+        {% for key, value in scheduling["GenerateBClimatology"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -146,7 +146,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"].items() %}
+        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -158,7 +158,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+        {% for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/3dvar_atmos/flow.cylc
+++ b/src/swell/suites/3dvar_atmos/flow.cylc
@@ -118,15 +118,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildJedi"]["account"]}}
-            --qos = {{scheduling["BuildJedi"]["qos"]}}
-            --job-name = BuildJedi
-            --nodes={{scheduling["BuildJedi"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
-            --constraint={{scheduling["BuildJedi"]["constraint"]}}
-            {% if scheduling["BuildJedi"]["partition"] %}
-            --partition={{scheduling["BuildJedi"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     {% for model_component in model_components %}
 
@@ -156,15 +150,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["RunJediVariationalExecutable"]["account"]}}
-            --qos = {{scheduling["RunJediVariationalExecutable"]["qos"]}}
-            --job-name = RunJediVariationalExecutable
-            --nodes={{scheduling["RunJediVariationalExecutable"]["nodes"]}}
-            --ntasks-per-node={{scheduling["RunJediVariationalExecutable"]["ntasks_per_node"]}}
-            --constraint={{scheduling["RunJediVariationalExecutable"]["constraint"]}}
-            {% if scheduling["RunJediVariationalExecutable"]["partition"] %}
-            --partition={{scheduling["RunJediVariationalExecutable"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[EvaJediLog-{{model_component}}]]
         script = "swell task EvaJediLog $config -d $datetime -m {{model_component}}"
@@ -177,15 +165,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["EvaObservations"]["account"]}}
-            --qos = {{scheduling["EvaObservations"]["qos"]}}
-            --job-name = EvaObservations
-            --nodes={{scheduling["EvaObservations"]["nodes"]}}
-            --ntasks-per-node={{scheduling["EvaObservations"]["ntasks_per_node"]}}
-            --constraint={{scheduling["EvaObservations"]["constraint"]}}
-            {% if scheduling["EvaObservations"]["partition"] %}
-            --partition={{scheduling["EvaObservations"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[SaveObsDiags-{{model_component}}]]
         script = "swell task SaveObsDiags $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/3dvar_atmos/flow.cylc
+++ b/src/swell/suites/3dvar_atmos/flow.cylc
@@ -118,7 +118,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+        {% for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -150,7 +150,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"].items() %}
+        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -165,7 +165,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+        {% for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/3dvar_cycle/flow.cylc
+++ b/src/swell/suites/3dvar_cycle/flow.cylc
@@ -143,14 +143,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildGeos"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildGeos"]["account"]}}
-            --qos = {{scheduling["BuildGeos"]["qos"]}}
-            --job-name = BuildGeos
-            --nodes={{scheduling["BuildGeos"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildGeos"]["ntasks_per_node"]}}
-            {% if scheduling["BuildGeos"]["partition"] %}
-            --partition={{scheduling["BuildGeos"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildGeos"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[CloneJedi]]
         script = "swell task CloneJedi $config"
@@ -163,30 +158,18 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildJedi"]["account"]}}
-            --qos = {{scheduling["BuildJedi"]["qos"]}}
-            --job-name = BuildJedi
-            --nodes={{scheduling["BuildJedi"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
-            --constraint={{scheduling["BuildJedi"]["constraint"]}}
-            {% if scheduling["BuildJedi"]["partition"] %}
-            --partition={{scheduling["BuildJedi"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[RunGeosExecutable]]
         script = "swell task RunGeosExecutable $config -d $datetime"
         platform = {{platform}}
         execution time limit = {{scheduling["RunGeosExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["RunGeosExecutable"]["account"]}}
-            --qos = {{scheduling["RunGeosExecutable"]["qos"]}}
-            --job-name = RunGeosExecutable
-            --nodes={{scheduling["RunGeosExecutable"]["nodes"]}}
-            --ntasks-per-node={{scheduling["RunGeosExecutable"]["ntasks_per_node"]}}
-            --constraint={{scheduling["RunGeosExecutable"]["constraint"]}}
-            {% if scheduling["RunGeosExecutable"]["partition"] %}
-            --partition={{scheduling["RunGeosExecutable"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["RunGeosExecutable"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[PrepGeosRunDir]]
         script = "swell task PrepGeosRunDir $config -d $datetime"
@@ -225,15 +208,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["RunJediVariationalExecutable"]["account"]}}
-            --qos = {{scheduling["RunJediVariationalExecutable"]["qos"]}}
-            --job-name = RunJediVariationalExecutable
-            --nodes={{scheduling["RunJediVariationalExecutable"]["nodes"]}}
-            --ntasks-per-node={{scheduling["RunJediVariationalExecutable"]["ntasks_per_node"]}}
-            --constraint={{scheduling["RunJediVariationalExecutable"]["constraint"]}}
-            {% if scheduling["RunJediVariationalExecutable"]["partition"] %}
-            --partition={{scheduling["RunJediVariationalExecutable"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[EvaJediLog-{{model_component}}]]
         script = "swell task EvaJediLog $config -d $datetime -m {{model_component}}"
@@ -243,15 +220,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["EvaObservations"]["account"]}}
-            --qos = {{scheduling["EvaObservations"]["qos"]}}
-            --job-name = EvaObservations
-            --nodes={{scheduling["EvaObservations"]["nodes"]}}
-            --ntasks-per-node={{scheduling["EvaObservations"]["ntasks_per_node"]}}
-            --constraint={{scheduling["EvaObservations"]["constraint"]}}
-            {% if scheduling["EvaObservations"]["partition"] %}
-            --partition={{scheduling["EvaObservations"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[SaveObsDiags-{{model_component}}]]
         script = "swell task SaveObsDiags $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/3dvar_cycle/flow.cylc
+++ b/src/swell/suites/3dvar_cycle/flow.cylc
@@ -143,7 +143,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildGeos"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildGeos"]["directives"].items() %}
+        {% for key, value in scheduling["BuildGeos"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -158,7 +158,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+        {% for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -167,7 +167,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunGeosExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["RunGeosExecutable"]["directives"].items() %}
+        {% for key, value in scheduling["RunGeosExecutable"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -208,7 +208,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"].items() %}
+        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -220,7 +220,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+        {% for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/build_geos/flow.cylc
+++ b/src/swell/suites/build_geos/flow.cylc
@@ -49,7 +49,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildGeos"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildGeos"]["directives"].items() %}
+        {% for key, value in scheduling["BuildGeos"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/build_geos/flow.cylc
+++ b/src/swell/suites/build_geos/flow.cylc
@@ -49,14 +49,8 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildGeos"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildGeos"]["account"]}}
-            --qos = {{scheduling["BuildGeos"]["qos"]}}
-            --job-name = SwellBuildGeos
-            --nodes={{scheduling["BuildGeos"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildGeos"]["ntasks_per_node"]}}
-            --constraint={{scheduling["BuildGeos"]["constraint"]}}
-            {% if scheduling["BuildGeos"]["partition"] %}
-            --partition={{scheduling["BuildGeos"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildGeos"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/build_jedi/flow.cylc
+++ b/src/swell/suites/build_jedi/flow.cylc
@@ -49,14 +49,8 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildJedi"]["account"]}}
-            --qos = {{scheduling["BuildJedi"]["qos"]}}
-            --job-name = SwellBuildJedi
-            --nodes={{scheduling["BuildJedi"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
-            --constraint={{scheduling["BuildJedi"]["constraint"]}}
-            {% if scheduling["BuildJedi"]["partition"] %}
-            --partition={{scheduling["BuildJedi"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/build_jedi/flow.cylc
+++ b/src/swell/suites/build_jedi/flow.cylc
@@ -49,7 +49,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+        {% for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/convert_ncdiags/flow.cylc
+++ b/src/swell/suites/convert_ncdiags/flow.cylc
@@ -80,7 +80,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+        {% for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/convert_ncdiags/flow.cylc
+++ b/src/swell/suites/convert_ncdiags/flow.cylc
@@ -80,15 +80,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildJedi"]["account"]}}
-            --qos = {{scheduling["BuildJedi"]["qos"]}}
-            --job-name = BuildJedi
-            --nodes={{scheduling["BuildJedi"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
-            --constraint={{scheduling["BuildJedi"]["constraint"]}}
-            {% if scheduling["BuildJedi"]["partition"] %}
-            --partition={{scheduling["BuildJedi"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[ GetGsiBc ]]
         script = "swell task GetGsiBc $config -d $datetime -m geos_atmosphere"

--- a/src/swell/suites/forecast_geos/flow.cylc
+++ b/src/swell/suites/forecast_geos/flow.cylc
@@ -85,7 +85,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildGeos"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildGeos"]["directives"].items() %}
+        {% for key, value in scheduling["BuildGeos"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -109,7 +109,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunGeosExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["RunGeosExecutable"]["directives"].items() %}
+        {% for key, value in scheduling["RunGeosExecutable"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/forecast_geos/flow.cylc
+++ b/src/swell/suites/forecast_geos/flow.cylc
@@ -85,14 +85,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildGeos"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildGeos"]["account"]}}
-            --qos = {{scheduling["BuildGeos"]["qos"]}}
-            --job-name = BuildGeos
-            --nodes={{scheduling["BuildGeos"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildGeos"]["ntasks_per_node"]}}
-            {% if scheduling["BuildGeos"]["partition"] %}
-            --partition={{scheduling["BuildGeos"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildGeos"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[PrepGeosRunDir]]
         script = "swell task PrepGeosRunDir $config -d $datetime"
@@ -114,13 +109,8 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunGeosExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["RunGeosExecutable"]["account"]}}
-            --qos = {{scheduling["RunGeosExecutable"]["qos"]}}
-            --job-name = RunGeosExecutable
-            --nodes={{scheduling["RunGeosExecutable"]["nodes"]}}
-            --ntasks-per-node={{scheduling["RunGeosExecutable"]["ntasks_per_node"]}}
-            {% if scheduling["RunGeosExecutable"]["partition"] %}
-            --partition={{scheduling["RunGeosExecutable"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["RunGeosExecutable"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/geosadas/flow.cylc
+++ b/src/swell/suites/geosadas/flow.cylc
@@ -111,15 +111,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["RunJediVariationalExecutable"]["account"]}}
-            --qos = {{scheduling["RunJediVariationalExecutable"]["qos"]}}
-            --job-name = RunJediVariationalExecutable
-            --nodes={{scheduling["RunJediVariationalExecutable"]["nodes"]}}
-            --ntasks-per-node={{scheduling["RunJediVariationalExecutable"]["ntasks_per_node"]}}
-            --constraint={{scheduling["RunJediVariationalExecutable"]["constraint"]}}
-            {% if scheduling["RunJediVariationalExecutable"]["partition"] %}
-            --partition={{scheduling["RunJediVariationalExecutable"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[CleanCycle]]
         script = "swell task CleanCycle $config -d $datetime -m geos_atmosphere"

--- a/src/swell/suites/geosadas/flow.cylc
+++ b/src/swell/suites/geosadas/flow.cylc
@@ -111,7 +111,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"].items() %}
+        {% for key, value in scheduling["RunJediVariationalExecutable"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/hofx/flow.cylc
+++ b/src/swell/suites/hofx/flow.cylc
@@ -112,7 +112,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+        {% for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -141,7 +141,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediHofxExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["RunJediHofxExecutable"]["directives"].items() %}
+        {% for key, value in scheduling["RunJediHofxExecutable"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -150,7 +150,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+        {% for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/hofx/flow.cylc
+++ b/src/swell/suites/hofx/flow.cylc
@@ -112,15 +112,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildJedi"]["account"]}}
-            --qos = {{scheduling["BuildJedi"]["qos"]}}
-            --job-name = BuildJedi
-            --nodes={{scheduling["BuildJedi"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
-            --constraint={{scheduling["BuildJedi"]["constraint"]}}
-            {% if scheduling["BuildJedi"]["partition"] %}
-            --partition={{scheduling["BuildJedi"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     {% for model_component in model_components %}
 
@@ -147,30 +141,18 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediHofxExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["RunJediHofxExecutable"]["account"]}}
-            --qos = {{scheduling["RunJediHofxExecutable"]["qos"]}}
-            --job-name = RunJediHofxExecutable
-            --nodes={{scheduling["RunJediHofxExecutable"]["nodes"]}}
-            --ntasks-per-node={{scheduling["RunJediHofxExecutable"]["ntasks_per_node"]}}
-            --constraint={{scheduling["RunJediHofxExecutable"]["constraint"]}}
-            {% if scheduling["RunJediHofxExecutable"]["partition"] %}
-            --partition={{scheduling["RunJediHofxExecutable"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["RunJediHofxExecutable"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[EvaObservations-{{model_component}}]]
         script = "swell task EvaObservations $config -d $datetime -m {{model_component}}"
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["EvaObservations"]["account"]}}
-            --qos = {{scheduling["EvaObservations"]["qos"]}}
-            --job-name = EvaObservations
-            --nodes={{scheduling["EvaObservations"]["nodes"]}}
-            --ntasks-per-node={{scheduling["EvaObservations"]["ntasks_per_node"]}}
-            --constraint={{scheduling["EvaObservations"]["constraint"]}}
-            {% if scheduling["EvaObservations"]["partition"] %}
-            --partition={{scheduling["EvaObservations"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[SaveObsDiags-{{model_component}}]]
         script = "swell task SaveObsDiags $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/localensembleda/flow.cylc
+++ b/src/swell/suites/localensembleda/flow.cylc
@@ -133,7 +133,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+        {% for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -176,7 +176,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediLocalEnsembleDaExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["RunJediLocalEnsembleDaExecutable"]["directives"].items() %}
+        {% for key, value in scheduling["RunJediLocalEnsembleDaExecutable"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -185,7 +185,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+        {% for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/localensembleda/flow.cylc
+++ b/src/swell/suites/localensembleda/flow.cylc
@@ -133,15 +133,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildJedi"]["account"]}}
-            --qos = {{scheduling["BuildJedi"]["qos"]}}
-            --job-name = BuildJedi
-            --nodes={{scheduling["BuildJedi"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
-            --constraint={{scheduling["BuildJedi"]["constraint"]}}
-            {% if scheduling["BuildJedi"]["partition"] %}
-            --partition={{scheduling["BuildJedi"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     {% for model_component in model_components %}
 
@@ -182,30 +176,18 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediLocalEnsembleDaExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["RunJediLocalEnsembleDaExecutable"]["account"]}}
-            --qos = {{scheduling["RunJediLocalEnsembleDaExecutable"]["qos"]}}
-            --job-name = RunJediLocalEnsembleDaExecutable
-            --nodes={{scheduling["RunJediLocalEnsembleDaExecutable"]["nodes"]}}
-            --ntasks-per-node={{scheduling["RunJediLocalEnsembleDaExecutable"]["ntasks_per_node"]}}
-            --constraint={{scheduling["RunJediLocalEnsembleDaExecutable"]["constraint"]}}
-            {% if scheduling["RunJediLocalEnsembleDaExecutable"]["partition"] %}
-            --partition={{scheduling["RunJediLocalEnsembleDaExecutable"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["RunJediLocalEnsembleDaExecutable"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[EvaObservations-{{model_component}}]]
         script = "swell task EvaObservations $config -d $datetime -m {{model_component}}"
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["EvaObservations"]["account"]}}
-            --qos = {{scheduling["EvaObservations"]["qos"]}}
-            --job-name = EvaObservations
-            --nodes={{scheduling["EvaObservations"]["nodes"]}}
-            --ntasks-per-node={{scheduling["EvaObservations"]["ntasks_per_node"]}}
-            --constraint={{scheduling["EvaObservations"]["constraint"]}}
-            {% if scheduling["EvaObservations"]["partition"] %}
-            --partition={{scheduling["EvaObservations"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[SaveObsDiags-{{model_component}}]]
         script = "swell task SaveObsDiags $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/ufo_testing/flow.cylc
+++ b/src/swell/suites/ufo_testing/flow.cylc
@@ -98,7 +98,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+        {% for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -128,7 +128,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediUfoTestsExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["RunJediUfoTestsExecutable"]["directives"].items() %}
+        {% for key, value in scheduling["RunJediUfoTestsExecutable"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 
@@ -137,7 +137,7 @@
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+        {% for key, value in scheduling["EvaObservations"]["directives"]["all"].items() %}
             --{{key}} = {{value}}
         {% endfor %}
 

--- a/src/swell/suites/ufo_testing/flow.cylc
+++ b/src/swell/suites/ufo_testing/flow.cylc
@@ -98,15 +98,9 @@
         platform = {{platform}}
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["BuildJedi"]["account"]}}
-            --qos = {{scheduling["BuildJedi"]["qos"]}}
-            --job-name = BuildJedi
-            --nodes={{scheduling["BuildJedi"]["nodes"]}}
-            --ntasks-per-node={{scheduling["BuildJedi"]["ntasks_per_node"]}}
-            --constraint={{scheduling["BuildJedi"]["constraint"]}}
-            {% if scheduling["BuildJedi"]["partition"] %}
-            --partition={{scheduling["BuildJedi"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["BuildJedi"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[CloneGeosMksi]]
         script = "swell task CloneGeosMksi $config -m geos_atmosphere"
@@ -134,30 +128,18 @@
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediUfoTestsExecutable"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["RunJediUfoTestsExecutable"]["account"]}}
-            --qos = {{scheduling["RunJediUfoTestsExecutable"]["qos"]}}
-            --job-name = RunJediUfoTestsExecutable
-            --nodes={{scheduling["RunJediUfoTestsExecutable"]["nodes"]}}
-            --ntasks-per-node={{scheduling["RunJediUfoTestsExecutable"]["ntasks_per_node"]}}
-            --constraint={{scheduling["RunJediUfoTestsExecutable"]["constraint"]}}
-            {% if scheduling["RunJediUfoTestsExecutable"]["partition"] %}
-            --partition={{scheduling["RunJediUfoTestsExecutable"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["RunJediUfoTestsExecutable"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[EvaObservations]]
         script = "swell task EvaObservations $config -d $datetime -m geos_atmosphere"
         platform = {{platform}}
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
-            --account = {{scheduling["EvaObservations"]["account"]}}
-            --qos = {{scheduling["EvaObservations"]["qos"]}}
-            --job-name = EvaObservations
-            --nodes={{scheduling["EvaObservations"]["nodes"]}}
-            --ntasks-per-node={{scheduling["EvaObservations"]["ntasks_per_node"]}}
-            --constraint={{scheduling["EvaObservations"]["constraint"]}}
-            {% if scheduling["EvaObservations"]["partition"] %}
-            --partition={{scheduling["EvaObservations"]["partition"]}}
-            {% endif %}
+        {% for key, value in scheduling["EvaObservations"]["directives"].items() %}
+            --{{key}} = {{value}}
+        {% endfor %}
 
     [[CleanCycle]]
         script = "swell task CleanCycle $config -d $datetime -m geos_atmosphere"

--- a/src/swell/swell.py
+++ b/src/swell/swell.py
@@ -76,6 +76,11 @@ model_help = 'Data assimilation system. I.e. the model being initialized by data
 ensemble_help = 'When handling ensemble workflows using a parallel strategy, ' + \
                 'specify which packet of ensemble members to consider.'
 
+slurm_help = """
+Customize SLURM directives, globally (e.g., account name), for specific tasks,
+or for task-model combinations.
+"""
+
 
 # --------------------------------------------------------------------------------------------------
 
@@ -88,7 +93,8 @@ ensemble_help = 'When handling ensemble workflows using a parallel strategy, ' +
               type=click.Choice(get_platforms()), help=platform_help)
 @click.option('-o', '--override', 'override', default=None, help=override_help)
 @click.option('-a', '--advanced', 'advanced', default=False, help=advanced_help)
-def create(suite, input_method, platform, override, advanced):
+@click.option('-s', '--slurm', 'slurm', default=None, help=slurm_help)
+def create(suite, input_method, platform, override, advanced, slurm):
     """
     Create a new experiment
 
@@ -99,7 +105,7 @@ def create(suite, input_method, platform, override, advanced):
 
     """
     # First create the configuration for the experiment.
-    experiment_dict_str = prepare_config(suite, input_method, platform, override, advanced)
+    experiment_dict_str = prepare_config(suite, input_method, platform, override, advanced, slurm)
 
     # Create the experiment directory
     create_experiment_directory(experiment_dict_str)

--- a/src/swell/test/code_tests/code_tests.py
+++ b/src/swell/test/code_tests/code_tests.py
@@ -13,6 +13,7 @@ import unittest
 
 from swell.test.code_tests.question_dictionary_comparison_test import QuestionDictionaryTest
 from swell.test.code_tests.unused_variables_test import UnusedVariablesTest
+from swell.test.code_tests.slurm_test import SLURMConfigTest
 from swell.utilities.logger import Logger
 
 
@@ -35,6 +36,9 @@ def code_tests():
 
     # Load tests from UnusedVariablesTest
     test_suite.addTests(unittest.TestLoader().loadTestsFromTestCase(QuestionDictionaryTest))
+
+    # Load SLURM tests
+    test_suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SLURMConfigTest))
 
     # Create a test runner
     test_runner = unittest.TextTestRunner()

--- a/src/swell/test/code_tests/slurm_test.py
+++ b/src/swell/test/code_tests/slurm_test.py
@@ -1,0 +1,67 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+import unittest
+import logging
+
+from swell.utilities.slurm import prepare_scheduling_dict
+
+# --------------------------------------------------------------------------------------------------
+
+class SLURMConfigTest(unittest.TestCase):
+
+    def test_slurm_config(self):
+
+        logger = logging.getLogger()
+
+        # Nested example
+        experiment_dict = {
+            "model_components": ["geos_atmosphere", "geos_ocean"],
+            "slurm_directives_globals": {
+                "account": "x1234",
+                "nodes": 1
+            },
+            "slurm_directives_tasks": {
+                "EvaObservations": {
+                    "all": {
+                        "account": "x5678",
+                        "nodes": 2,
+                        "ntasks_per_node": 4
+                    },
+                    "geos_atmosphere": {
+                        "nodes": 4
+                    }
+                }
+            }
+        }
+
+        sd = prepare_scheduling_dict(logger, experiment_dict)
+
+        for mc in ["all", "geos_atmosphere", "geos_ocean"]:
+            # Hard-coded global defaults
+            assert sd["BuildJedi"]["directives"][mc]["account"] == "g0613"
+            assert sd["EvaObservations"]["directives"][mc]["qos"] == "allnccs"
+            assert sd["EvaObservations"]["directives"][mc]["constraint"] == "cas|sky"
+            # Hard-coded task-specific defaults
+            assert sd["RunJediVariationalExecutable"]["directives"][mc]["nodes"] == 3
+            assert sd["RunJediVariationalExecutable"]["directives"][mc]["ntasks_per_node"] == 36
+            assert sd["RunJediUfoTestsExecutable"]["directives"][mc]["ntasks_per_node"] == 1
+            # Global defaults from experiment dict
+            assert sd["BuildJedi"]["directives"][mc]["account"] == "x1234"
+            assert sd["RunJediUfoTestsExecutable"]["directives"][mc]["account"] == "x1234"
+            # Task-specific, model-generic config
+            assert sd["EvaObservations"]["directives"][mc]["account"] == "x5678"
+            assert sd["EvaObservations"]["directives"][mc]["ntasks_per_node"] == 4
+
+        # Task-specific, model-specific configs
+        assert sd["EvaObservations"]["directives"]["geos_ocean"]["nodes"] == 2
+        assert sd["EvaObservations"]["directives"]["geos_atmosphere"]["nodes"] == 4
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/test/code_tests/slurm_test.py
+++ b/src/swell/test/code_tests/slurm_test.py
@@ -25,7 +25,7 @@ class SLURMConfigTest(unittest.TestCase):
         # Nested example
         experiment_dict = {
             "model_components": ["geos_atmosphere", "geos_ocean"],
-            "slurm_directives_globals": {
+            "slurm_directives_global": {
                 "account": "x1234",
                 "nodes": 1
             },

--- a/src/swell/test/code_tests/slurm_test.py
+++ b/src/swell/test/code_tests/slurm_test.py
@@ -27,7 +27,6 @@ class SLURMConfigTest(unittest.TestCase):
             "model_components": ["geos_atmosphere", "geos_ocean"],
             "slurm_directives_global": {
                 "account": "x1234",
-                "nodes": 1
             },
             "slurm_directives_tasks": {
                 "EvaObservations": {
@@ -47,7 +46,6 @@ class SLURMConfigTest(unittest.TestCase):
 
         for mc in ["all", "geos_atmosphere", "geos_ocean"]:
             # Hard-coded global defaults
-            assert sd["BuildJedi"]["directives"][mc]["account"] == "g0613"
             assert sd["EvaObservations"]["directives"][mc]["qos"] == "allnccs"
             assert sd["EvaObservations"]["directives"][mc]["constraint"] == "cas|sky"
             # Hard-coded task-specific defaults

--- a/src/swell/test/code_tests/slurm_test.py
+++ b/src/swell/test/code_tests/slurm_test.py
@@ -33,7 +33,7 @@ class SLURMConfigTest(unittest.TestCase):
                     "all": {
                         "account": "x5678",
                         "nodes": 2,
-                        "ntasks_per_node": 4
+                        "ntasks-per-node": 4
                     },
                     "geos_atmosphere": {
                         "nodes": 4
@@ -50,14 +50,14 @@ class SLURMConfigTest(unittest.TestCase):
             assert sd["EvaObservations"]["directives"][mc]["constraint"] == "cas|sky"
             # Hard-coded task-specific defaults
             assert sd["RunJediVariationalExecutable"]["directives"][mc]["nodes"] == 3
-            assert sd["RunJediVariationalExecutable"]["directives"][mc]["ntasks_per_node"] == 36
-            assert sd["RunJediUfoTestsExecutable"]["directives"][mc]["ntasks_per_node"] == 1
+            assert sd["RunJediVariationalExecutable"]["directives"][mc]["ntasks-per-node"] == 36
+            assert sd["RunJediUfoTestsExecutable"]["directives"][mc]["ntasks-per-node"] == 1
             # Global defaults from experiment dict
             assert sd["BuildJedi"]["directives"][mc]["account"] == "x1234"
             assert sd["RunJediUfoTestsExecutable"]["directives"][mc]["account"] == "x1234"
             # Task-specific, model-generic config
             assert sd["EvaObservations"]["directives"][mc]["account"] == "x5678"
-            assert sd["EvaObservations"]["directives"][mc]["ntasks_per_node"] == 4
+            assert sd["EvaObservations"]["directives"][mc]["ntasks-per-node"] == 4
 
         # Task-specific, model-specific configs
         assert sd["EvaObservations"]["directives"]["geos_ocean"]["nodes"] == 2

--- a/src/swell/test/code_tests/slurm_test.py
+++ b/src/swell/test/code_tests/slurm_test.py
@@ -15,6 +15,7 @@ from swell.utilities.slurm import prepare_scheduling_dict
 
 # --------------------------------------------------------------------------------------------------
 
+
 class SLURMConfigTest(unittest.TestCase):
 
     def test_slurm_config(self):

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -37,9 +37,9 @@ def prepare_scheduling_dict(logger, experiment_dict):
     # Global SLURM settings from experiment dict (questionary / overrides YAML)
     # ----------------------------------------------
     experiment_globals = {}
-    if "slurm_directives_common" in experiment_dict:
+    if "slurm_directives_global" in experiment_dict:
         logger.info(f"Loading additional SLURM globals from experiment dict")
-        experiment_globals = experiment_dict["slurm_directives_common"]
+        experiment_globals = experiment_dict["slurm_directives_global"]
 
     # Task-specific SLURM settings from experiment dict (questionary / overrides YAML)
     # ----------------------------------------------

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -17,7 +17,6 @@ def prepare_scheduling_dict(logger, experiment_dict):
     global_defaults = {
         "account": "g0613",
         "qos": "allnccs",
-        "partition": None,
         "nodes": 1,
         "ntasks-per-node": 24,
         "constraint": "cas|sky"

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -72,7 +72,9 @@ def prepare_scheduling_dict(logger, experiment_dict):
     assert len(non_slurm_tasks) == 0, \
         f"The following tasks cannot use SLURM: {non_slurm_tasks}"
 
-    model_components = experiment_dict["model_components"]
+    model_components = experiment_dict["model_components"] \
+        if "model_components" in experiment_dict \
+        else []
 
     scheduling_dict = {}
     for slurm_task in slurm_tasks:

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -50,7 +50,7 @@ def prepare_scheduling_dict(logger, experiment_dict):
 
     # List of tasks using slurm
     # -------------------------
-    default_slurm_tasks = {
+    slurm_tasks = {
         'BuildJedi',
         'BuildGeos',
         'EvaObservations',
@@ -63,8 +63,12 @@ def prepare_scheduling_dict(logger, experiment_dict):
         'RunGeosExecutable'
         }
 
+    # Throw an error if a user tries to set SLURM directives for a task that
+    # doesn't use SLURM.
     experiment_slurm_tasks = set(experiment_task_directives.keys())
-    slurm_tasks = default_slurm_tasks.union(experiment_slurm_tasks)
+    non_slurm_tasks = experiment_slurm_tasks.difference(slurm_tasks)
+    assert len(non_slurm_tasks) == 0, \
+        f"The following tasks cannot use SLURM: {non_slurm_tasks}"
 
     model_components = experiment_dict["model_components"]
 

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -168,13 +168,19 @@ def add_directives(target_dict, input_dict, key):
 
 def validate_directives(directive_dict):
     directive_pattern = r'(?<=--)[a-zA-Z-]+'
+    # Parse sbatch docs and extract all directives (e.g., `--account`)
     directive_list = {
         re.search(directive_pattern, s).group(0)
         for s in man_sbatch.split("\n")
         if re.search(directive_pattern, s)
     }
+    # Make sure that everything in `directive_dict` is in `directive_list`;
+    # i.e., that all entries are valid slurm directives.
     invalid_directives = set(directive_dict.keys()).difference(directive_list)
-    assert len(invalid_directives) == 0, f"The following are invalid SLURM directives: {invalid_directives}"
+    assert \
+        len(invalid_directives) == 0, \
+        f"The following are invalid SLURM directives: {invalid_directives}"
+
 
 man_sbatch = """
 Parallel run options:

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -7,6 +7,7 @@
 # --------------------------------------------------------------------------------------------------
 
 import os
+import re
 import yaml
 
 
@@ -104,6 +105,7 @@ def prepare_scheduling_dict(logger, experiment_dict):
                     **experiment_task_directives[slurm_task]["all"]
                 }
         # Set model_agnostic directives
+        validate_directives(directives)
         scheduling_dict[slurm_task] = {"directives": {"all": directives}}
 
         # Now, add model component-specific logic. The inheritance here is more
@@ -148,6 +150,7 @@ def prepare_scheduling_dict(logger, experiment_dict):
                     experiment_task_directives[slurm_task],
                     model_component
                 )
+            validate_directives(model_directives)
             scheduling_dict[slurm_task]["directives"][model_component] = model_directives
 
     return scheduling_dict
@@ -161,5 +164,153 @@ def add_directives(target_dict, input_dict, key):
         }
     else:
         return target_dict
+
+
+def validate_directives(directive_dict):
+    directive_pattern = r'(?<=--)[a-zA-Z-]+'
+    directive_list = {
+        re.search(directive_pattern, s).group(0)
+        for s in man_sbatch.split("\n")
+        if re.search(directive_pattern, s)
+    }
+    invalid_directives = set(directive_dict.keys()).difference(directive_list)
+    assert len(invalid_directives) == 0, f"The following are invalid SLURM directives: {invalid_directives}"
+
+man_sbatch = """
+Parallel run options:
+  -a, --array=indexes         job array index values
+  -A, --account=name          charge job to specified account
+      --bb=<spec>             burst buffer specifications
+      --bbf=<file_name>       burst buffer specification file
+  -b, --begin=time            defer job until HH:MM MM/DD/YY
+      --comment=name          arbitrary comment
+      --cpu-freq=min[-max[:gov]] requested cpu frequency (and governor)
+  -c, --cpus-per-task=ncpus   number of cpus required per task
+  -d, --dependency=type:jobid[:time] defer job until condition on jobid is satisfied
+      --deadline=time         remove the job if no ending possible before
+                              this deadline (start > (deadline - time[-min]))
+      --delay-boot=mins       delay boot for desired node features
+  -D, --chdir=directory       set working directory for batch script
+  -e, --error=err             file for batch script's standard error
+      --export[=names]        specify environment variables to export
+      --export-file=file|fd   specify environment variables file or file
+                              descriptor to export
+      --get-user-env          load environment from local cluster
+      --gid=group_id          group ID to run job as (user root only)
+      --gres=list             required generic resources
+      --gres-flags=opts       flags related to GRES management
+  -H, --hold                  submit job in held state
+      --ignore-pbs            Ignore #PBS and #BSUB options in the batch script
+  -i, --input=in              file for batch script's standard input
+  -J, --job-name=jobname      name of job
+  -k, --no-kill               do not kill job on node failure
+  -L, --licenses=names        required license, comma separated
+  -M, --clusters=names        Comma separated list of clusters to issue
+                              commands to.  Default is current cluster.
+                              Name of 'all' will submit to run on all clusters.
+                              NOTE: SlurmDBD must up.
+      --container             Path to OCI container bundle
+  -m, --distribution=type     distribution method for processes to nodes
+                              (type = block|cyclic|arbitrary)
+      --mail-type=type        notify on state change: BEGIN, END, FAIL or ALL
+      --mail-user=user        who to send email notification for job state
+                              changes
+      --mcs-label=mcs         mcs label if mcs plugin mcs/group is used
+  -n, --ntasks=ntasks         number of tasks to run
+      --nice[=value]          decrease scheduling priority by value
+      --no-requeue            if set, do not permit the job to be requeued
+      --ntasks-per-node=n     number of tasks to invoke on each node
+  -N, --nodes=N               number of nodes on which to run (N = min[-max])
+  -o, --output=out            file for batch script's standard output
+  -O, --overcommit            overcommit resources
+  -p, --partition=partition   partition requested
+      --parsable              outputs only the jobid and cluster name (if present),
+                              separated by semicolon, only on successful submission.
+      --power=flags           power management options
+      --priority=value        set the priority of the job to value
+      --profile=value         enable acct_gather_profile for detailed data
+                              value is all or none or any combination of
+                              energy, lustre, network or task
+      --propagate[=rlimits]   propagate all [or specific list of] rlimits
+  -q, --qos=qos               quality of service
+  -Q, --quiet                 quiet mode (suppress informational messages)
+      --reboot                reboot compute nodes before starting job
+      --requeue               if set, permit the job to be requeued
+  -s, --oversubscribe         over subscribe resources with other jobs
+  -S, --core-spec=cores       count of reserved cores
+      --signal=[[R][B]:]num[@time] send signal when time limit within time seconds
+      --spread-job            spread job across as many nodes as possible
+      --switches=max-switches{@max-time-to-wait}
+                              Optimum switches and max time to wait for optimum
+      --thread-spec=threads   count of reserved threads
+  -t, --time=minutes          time limit
+      --time-min=minutes      minimum time limit (if distinct)
+      --uid=user_id           user ID to run job as (user root only)
+      --use-min-nodes         if a range of node counts is given, prefer the
+                              smaller count
+  -v, --verbose               verbose mode (multiple -v's increase verbosity)
+  -W, --wait                  wait for completion of submitted job
+      --wckey=wckey           wckey to run job under
+      --wrap[=command string] wrap command string in a sh script and submit
+
+Constraint options:
+      --cluster-constraint=[!]list specify a list of cluster constraints
+      --contiguous            demand a contiguous range of nodes
+  -C, --constraint=list       specify a list of constraints
+  -F, --nodefile=filename     request a specific list of hosts
+      --mem=MB                minimum amount of real memory
+      --mincpus=n             minimum number of logical processors (threads)
+                              per node
+      --reservation=name      allocate resources from named reservation
+      --tmp=MB                minimum amount of temporary disk
+  -w, --nodelist=hosts...     request a specific list of hosts
+  -x, --exclude=hosts...      exclude a specific list of hosts
+
+Consumable resources related options:
+      --exclusive[=user]      allocate nodes in exclusive mode when
+                              cpu consumable resource is enabled
+      --exclusive[=mcs]       allocate nodes in exclusive mode when
+                              cpu consumable resource is enabled
+                              and mcs plugin is enabled
+      --mem-per-cpu=MB        maximum amount of real memory per allocated
+                              cpu required by the job.
+                              --mem >= --mem-per-cpu if --mem is specified.
+
+Affinity/Multi-core options: (when the task/affinity plugin is enabled)
+                              For the following 4 options, you are
+                              specifying the minimum resources available for
+                              the node(s) allocated to the job.
+      --sockets-per-node=S    number of sockets per node to allocate
+      --cores-per-socket=C    number of cores per socket to allocate
+      --threads-per-core=T    number of threads per core to allocate
+  -B  --extra-node-info=S[:C[:T]]  combine request of sockets per node,
+                              cores per socket and threads per core.
+                              Specify an asterisk (*) as a placeholder,
+                              a minimum value, or a min-max range.
+
+      --ntasks-per-core=n     number of tasks to invoke on each core
+      --ntasks-per-socket=n   number of tasks to invoke on each socket
+      --hint=                 Bind tasks according to application hints
+                              (see "--hint=help" for options)
+      --mem-bind=             Bind memory to locality domains (ldom)
+                              (see "--mem-bind=help" for options)
+
+GPU scheduling options:
+      --cpus-per-gpu=n        number of CPUs required per allocated GPU
+  -G, --gpus=n                count of GPUs required for the job
+      --gpu-bind=...          task to gpu binding options
+      --gpu-freq=...          frequency and voltage of GPUs
+      --gpus-per-node=n       number of GPUs required per allocated node
+      --gpus-per-socket=n     number of GPUs required per allocated socket
+      --gpus-per-task=n       number of GPUs required per spawned task
+      --mem-per-gpu=n         real memory required per allocated GPU
+
+Help options:
+  -h, --help                  show this help message
+      --usage                 display brief usage message
+
+Other options:
+  -V, --version               output version information and exit
+"""
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -9,6 +9,7 @@
 import os
 import yaml
 
+
 def prepare_scheduling_dict(logger, experiment_dict):
     # Hard-coded defaults
     # ----------------------------------------------
@@ -70,17 +71,22 @@ def prepare_scheduling_dict(logger, experiment_dict):
     scheduling_dict = {}
     for slurm_task in slurm_tasks:
         # Priority order (first = highest priority)
-            # 1. Task- *and* model-specific directives from experiment
-            #    (experiment_task_directives[slurm_task][model_component])
-            # 2. Task-specific (model-generic) directives from experiment
-            #    (experiment_task_directives[slurm_task]["all"])
-            # 3. Global directives from experiment (experiment_globals)
-            # 4. Directives from user config (user_globals)
-            # 5. Hard-coded task-specific defaults (task_defaults)
-            # 6. Hard-coded global defaults (global_defaults)
+        # 1. Task- *and* model-specific directives from experiment
+        #    (experiment_task_directives[slurm_task][model_component])
+        # 2. Task-specific (model-generic) directives from experiment
+        #    (experiment_task_directives[slurm_task]["all"])
+        # 3. Global directives from experiment (experiment_globals)
+        # 4. Directives from user config (user_globals)
+        # 5. Hard-coded task-specific defaults (task_defaults)
+        # 6. Hard-coded global defaults (global_defaults)
         # NOTE: Hard-code "job-name" to SWELL task here but it can be
         # overwritten in task-specific directives.
-        directives = {"job-name": slurm_task, **global_defaults, **user_globals, **experiment_globals}
+        directives = {
+            "job-name": slurm_task,
+            **global_defaults,
+            **user_globals,
+            **experiment_globals
+        }
         if slurm_task in task_defaults:
             directives = {**directives, **task_defaults[slurm_task]}
         if slurm_task in experiment_task_directives:

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -17,6 +17,8 @@ def prepare_scheduling_dict(logger, experiment_dict):
         "account": "g0613",
         "qos": "allnccs",
         "partition": None,
+        "nodes": 1,
+        "ntasks_per_node": 24,
         "constraint": "cas|sky"
     }
 

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -18,13 +18,13 @@ def prepare_scheduling_dict(logger, experiment_dict):
         "qos": "allnccs",
         "partition": None,
         "nodes": 1,
-        "ntasks_per_node": 24,
+        "ntasks-per-node": 24,
         "constraint": "cas|sky"
     }
 
     task_defaults = {
-        "RunJediVariationalExecutable": {"all": {"nodes": 3, "ntasks_per_node": 36}},
-        "RunJediUfoTestsExecutable": {"all": {"ntasks_per_node": 1}}
+        "RunJediVariationalExecutable": {"all": {"nodes": 3, "ntasks-per-node": 36}},
+        "RunJediUfoTestsExecutable": {"all": {"ntasks-per-node": 1}}
     }
 
     # Global SLURM settings stored in $HOME/.swell/swell-slurm.yaml

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -1,0 +1,84 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# --------------------------------------------------------------------------------------------------
+
+import os
+import yaml
+
+def prepare_scheduling_dict(logger, experiment_dict):
+    # Hard-coded defaults
+    # ----------------------------------------------
+    global_defaults = {
+        "account": "g0613",
+        "qos": "allnccs",
+        "partition": None,
+        "constraint": "cas|sky"
+    }
+
+    task_defaults = {
+        "RunJediVariationalExecutable": { "nodes": 3, "ntasks_per_node": 36},
+        "RunJediUfoTestsExecutable": {"ntasks_per_node": 1}
+    }
+
+    # Global SLURM settings stored in $HOME/.swell/swell-slurm.yaml
+    # ----------------------------------------------
+    yaml_path = os.path.expanduser("~/.swell/swell-slurm.yaml")
+    user_globals = {}
+    if os.path.exists(yaml_path):
+        logger.info(f"Loading SLURM user configuration from {yaml_path}")
+        with open(yaml_path, "r") as yaml_file:
+            user_globals = yaml.safe_load(yaml_file)
+
+    # Global SLURM settings from experiment dict (questionary / overrides YAML)
+    # ----------------------------------------------
+    experiment_globals = {}
+    if "slurm_directives_common" in experiment_dict:
+        logger.info(f"Loading additional SLURM globals from experiment dict")
+        experiment_globals = experiment_dict["slurm_directives_common"]
+
+    # Task-specific SLURM settings from experiment dict (questionary / overrides YAML)
+    # ----------------------------------------------
+    experiment_task_directives = {}
+    if "slurm_directives_tasks" in experiment_dict:
+        logger.info(f"Loading experiment-specific SLURM configs from experiment dict")
+        experiment_task_directives = experiment_dict["slurm_directives_tasks"]
+
+    # List of tasks using slurm
+    # -------------------------
+    slurm_tasks = [
+        'BuildJedi',
+        'BuildGeos',
+        'EvaObservations',
+        'GenerateBClimatology',
+        'RunJediHofxEnsembleExecutable',
+        'RunJediHofxExecutable',
+        'RunJediLocalEnsembleDaExecutable',
+        'RunJediUfoTestsExecutable',
+        'RunJediVariationalExecutable',
+        'RunGeosExecutable',
+        ]
+
+    # Ap
+    scheduling_dict = {}
+    for slurm_task in slurm_tasks:
+        # Priority order (first = highest priority)
+            # 1. Task-specific directives from experiment (experiment_task_directives)
+            # 2. Global directives from experiment (experiment_globals)
+            # 3. Directives from user config (user_globals)
+            # 4. Hard-coded task-specific defaults (task_defaults)
+            # 5. Hard-coded global defaults (global_defaults)
+        # NOTE: Hard-code "job-name" to SWELL task here...
+        directives = {"job-name": slurm_task, **global_defaults, **user_globals, **experiment_globals}
+        if slurm_task in task_defaults:
+            directives = {**directives, **task_defaults[slurm_task]}
+        if slurm_task in experiment_task_directives:
+            directives = {**directives, **experiment_task_directives[slurm_task]}
+        scheduling_dict[slurm_task]["directives"] = directives
+
+    return scheduling_dict
+
+# --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- **Refactor SLURM directives**
- **Support model-specific SLURM directives**
- **Add SLURM unit tests**

## Description

Support passing arbitrary SLURM configurations via ~`experiment.yaml`.~ new option -- `-s <slurmfile.yaml>` (e.g., `swell create 3dvar -s myslurm.yaml`.

The general idea is that more _specific_ and _explicit_ configurations always override _generic_ and _implicit_ (hard-coded) values.
Any values set in the ~`experiment.yaml`~ `<slurmfile.yaml>` override corresponding hard-coded defaults in the source code, so the ~`experiment.yaml`~ `<slurmfile.yaml>` can be used to exert _complete_ control over _every possible_ SLURM directive.

The structure of the ~`experiment.yaml`~ `<slurmfile.yaml>` SLURM directives is as follows:

```yaml
# slurmfile.yaml

# Global user-specified default values. These apply to all tasks, and override
# all hard-coded values (including task-specific ones).
slurm_directives_global:
  account: x1234
  nodes: 1

# Task-specific settings. These always override the globals (above) and any
# hard-coded values.
slurm_directives_tasks:
  RunGEOSExecutable:
    # Values specific to this task for *all* models.
    all:
      nodes: 2   # <-- This implies nodes=2 for RunGEOSExecutable-geos_ocean
    # Overrides specifically for `RunGEOSExecutable-geos_atmosphere`
    geos_atmosphere:
      nodes: 4
```

Note also: This also allows _any valid (or invalid!) SLURM directive_ to be passed to the configuration.

Inheritance logic and default values are embedded in the `src/swell/utilities/slurm.py` file.
The current way to add new default configurations is to modify that file.

## Dependencies

None

## Impact

Closes #308 and #325.
