### PR TITLE
add co2 to atmos background

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
@@ -7,4 +7,4 @@ filenames: ['{{cycle_dir}}/bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4',
 state variables: [u,v,ua,va,t,delp,ps,q,qi,ql,qr,qs,o3ppmv,phis,
                   qls,qcn,cfcn,frocean,frland,varflt,ustar,bstar,
                   zpbl,cm,ct,cq,kcbl,tsm,khl,khu,frlake,frseaice,vtype,
-                  stype,vfrac,sheleg,ts,soilt,soilm,u10m,v10m]
+                  stype,vfrac,sheleg,ts,soilt,soilm,u10m,v10m,co2]


### PR DESCRIPTION
## Description

This makes JEDI background a little more consistent w/ GEOS/GSI background - adding CO2 as part of it.

I don't expect significant changes from adding this, but some obs could be knocked in or out.

## Dependencies

None

## Impact

Should allow for geoval comps w/ GSI - w/ caution of level reversal.
