### PR TITLE
Refactor SLURM user global defaults for test

### DIFF
--- a/src/swell/test/code_tests/slurm_test.py
+++ b/src/swell/test/code_tests/slurm_test.py
@@ -11,6 +11,8 @@
 import unittest
 import logging
 
+from unittest.mock import patch
+
 from swell.utilities.slurm import prepare_scheduling_dict
 
 # --------------------------------------------------------------------------------------------------
@@ -18,7 +20,13 @@ from swell.utilities.slurm import prepare_scheduling_dict
 
 class SLURMConfigTest(unittest.TestCase):
 
-    def test_slurm_config(self):
+    # Mock the `slurm_global_directives` function to ignore "real"
+    # configuration.
+    @patch("swell.utilities.slurm.slurm_global_defaults")
+    def test_slurm_config(self, mock_global_defaults):
+
+        # Fake user-specified global values (for consistent unit tests)
+        mock_global_defaults.return_value = {"qos": "dastest"}
 
         logger = logging.getLogger()
 
@@ -46,8 +54,9 @@ class SLURMConfigTest(unittest.TestCase):
 
         for mc in ["all", "geos_atmosphere", "geos_ocean"]:
             # Hard-coded global defaults
-            assert sd["EvaObservations"]["directives"][mc]["qos"] == "allnccs"
             assert sd["EvaObservations"]["directives"][mc]["constraint"] == "cas|sky"
+            # Global user-specific defaults (NOTE: mocked above!)
+            assert sd["EvaObservations"]["directives"][mc]["qos"] == "dastest"
             # Hard-coded task-specific defaults
             assert sd["RunJediVariationalExecutable"]["directives"][mc]["nodes"] == 3
             assert sd["RunJediVariationalExecutable"]["directives"][mc]["ntasks-per-node"] == 36

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -10,8 +10,13 @@ import os
 import re
 import yaml
 
+from swell.utilities.logger import Logger
 
-def prepare_scheduling_dict(logger, experiment_dict):
+
+def prepare_scheduling_dict(
+    logger: Logger,
+    experiment_dict: dict
+):
     # Hard-coded defaults
     # ----------------------------------------------
     global_defaults = {
@@ -29,12 +34,9 @@ def prepare_scheduling_dict(logger, experiment_dict):
 
     # Global SLURM settings stored in $HOME/.swell/swell-slurm.yaml
     # ----------------------------------------------
-    yaml_path = os.path.expanduser("~/.swell/swell-slurm.yaml")
-    user_globals = {}
-    if os.path.exists(yaml_path):
-        logger.info(f"Loading SLURM user configuration from {yaml_path}")
-        with open(yaml_path, "r") as yaml_file:
-            user_globals = yaml.safe_load(yaml_file)
+    # NOTE: Separate function to allow it to be mocked in unit tests.
+    # See https://github.com/GEOS-ESM/swell/issues/351
+    user_globals = slurm_global_defaults(logger)
 
     # Global SLURM settings from experiment dict (questionary / overrides YAML)
     # ----------------------------------------------
@@ -181,6 +183,19 @@ def validate_directives(directive_dict):
     assert \
         len(invalid_directives) == 0, \
         f"The following are invalid SLURM directives: {invalid_directives}"
+
+
+def slurm_global_defaults(
+    logger: Logger,
+    yaml_path: str = "~/.swell/swell-slurm.yaml"
+) -> dict:
+    yaml_path = os.path.expanduser(yaml_path)
+    user_globals = {}
+    if os.path.exists(yaml_path):
+        logger.info(f"Loading SLURM user configuration from {yaml_path}")
+        with open(yaml_path, "r") as yaml_file:
+            user_globals = yaml.safe_load(yaml_file)
+    return user_globals
 
 
 man_sbatch = """


### PR DESCRIPTION
Use a mock (https://docs.python.org/3/library/unittest.mock.html) to "fake" the behavior of the new global user defaults funciton in unit tests to always produce consistent behavior.

Closes #351.