### PR TITLE
Remove co2 for now

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
@@ -7,4 +7,4 @@ filenames: ['{{cycle_dir}}/bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4',
 state variables: [ua,va,t,delp,ps,q,qi,ql,qr,qs,o3ppmv,phis,
                   qls,qcn,cfcn,frocean,frland,varflt,ustar,bstar,
                   zpbl,cm,ct,cq,kcbl,tsm,khl,khu,frlake,frseaice,vtype,
-                  stype,vfrac,sheleg,ts,soilt,soilm,u10m,v10m,co2]
+                  stype,vfrac,sheleg,ts,soilt,soilm,u10m,v10m]


### PR DESCRIPTION
## Description

This is in association w/ issue #371 

We need to remove CO2 from the background until JEDI is fixed and capable of handling CO2 correctly.

## Dependencies

None

## Impact

Will now produce correct results for 3dvar and 3dfgat atmos.
