### PR TITLE
Add option to cycle VarBC

### DIFF
--- a/pycodestyle.cfg
+++ b/pycodestyle.cfg
@@ -8,4 +8,4 @@
 max-line-length = 100
 indent-size = 4
 statistics = True
-#ignore = build
+exclude = ._*, build

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click>=8.0.0
 jinja2>=3.0.3
 pyyaml>=6.0
 pycodestyle>=2.11.0
+numpy<2
 pandas>=1.4.0
 isodate>=0.5.4
 f90nml>=1.4.3

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
@@ -24,7 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/avhrr3_n19.{{background_time}}.satbias.nc4'
-  output file: '{{cycle_dir}}/avhrr3_n19.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/avhrr3_n19.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -36,6 +36,12 @@ clean_patterns:
   - '*.txt'
   - logfile.*.out
 
+cycling_varbc:
+  default_value: false
+  options:
+  - true
+  - false
+
 ensemble_hofx_packets:
   default_value: 2
   options: None

--- a/src/swell/deployment/create_experiment.py
+++ b/src/swell/deployment/create_experiment.py
@@ -425,6 +425,15 @@ def prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experime
                              'there are no model components to gather them from or ' +
                              'they are not provided in the experiment dictionary.')
 
+    # Cycling VarBC exception (only for geos_atmosphere)
+    if 'cycling_varbc' in suite_file:
+        if 'geos_atmosphere' in model_components:
+            render_dictionary['cycling_varbc'] = \
+                experiment_dict['models']['geos_atmosphere']['cycling_varbc']
+        else:
+            logger.abort('The suite file required cycling_varbc but ' +
+                         'geos_atmosphere is not in the model components.')
+
     render_dictionary['scheduling'] = prepare_scheduling_dict(logger, experiment_dict)
 
     # Default execution time limit for everthing is PT1H

--- a/src/swell/suites/3dfgat_atmos/flow.cylc
+++ b/src/swell/suites/3dfgat_atmos/flow.cylc
@@ -58,7 +58,15 @@
             GetBackgroundGeosExperiment-{{model_component}} :fail? => GetBackground-{{model_component}}
 
             # Get observations
+            {% if cycling_varbc %}
+            # Cycling VarBC is active, biases from the previous cycle will be used
+
+            RunJediVariationalExecutable-{{model_component}}[-PT6H] => GetObservations-{{model_component}}
+            {% else %}
+
+            # Cycling VarBC is inactive, static bias files will be used
             GetObservations-{{model_component}}
+            {% endif %}
 
             # Perform staging that is cycle dependent
             StageJediCycle-{{model_component}}

--- a/src/swell/suites/3dvar_atmos/flow.cylc
+++ b/src/swell/suites/3dvar_atmos/flow.cylc
@@ -58,7 +58,15 @@
             GetBackgroundGeosExperiment-{{model_component}} :fail? => GetBackground-{{model_component}}
 
             # Get observations
+            {% if cycling_varbc %}
+            # Cycling VarBC is active, biases from the previous cycle will be used
+
+            RunJediVariationalExecutable-{{model_component}}[-PT6H] => GetObservations-{{model_component}}
+            {% else %}
+
+            # Cycling VarBC is inactive, static bias files will be used
             GetObservations-{{model_component}}
+            {% endif %}
 
             # Perform staging that is cycle dependent
             StageJediCycle-{{model_component}}

--- a/src/swell/tasks/base/task_base.py
+++ b/src/swell/tasks/base/task_base.py
@@ -70,6 +70,7 @@ class taskBase(ABC):
         self.__experiment_root__ = self.config.__experiment_root__
         self.__experiment_id__ = self.config.__experiment_id__
         self.__platform__ = self.config.__platform__
+        self.__start_cycle_point__ = Datetime(self.config.__start_cycle_point__)
 
         # Save the model components
         # -------------------------
@@ -221,6 +222,16 @@ class taskBase(ABC):
         return self.__datetime__.string_iso()
 
     # ----------------------------------------------------------------------------------------------
+
+    def first_cycle_time(self):
+
+        return self.__start_cycle_point__.string_iso()
+
+    # ----------------------------------------------------------------------------------------------
+
+    def first_cycle_time_dto(self):
+
+        return self.__start_cycle_point__.dto()
 
 # --------------------------------------------------------------------------------------------------
 

--- a/src/swell/tasks/get_observations.py
+++ b/src/swell/tasks/get_observations.py
@@ -296,7 +296,6 @@ class GetObservations(taskBase):
         # Get the previous cycle datetime string and replace it in the bias path
         previous_cycle_dto = self.cycle_time_dto() - isodate.parse_duration(window_length)
         previous_cycle_dt_str = previous_cycle_dto.strftime(datetime_formats['directory_format'])
-        dt_obj = dt.strptime(dt_str, datetime_formats['directory_format'])
 
         bias_path = bias_path.replace(dt_str, previous_cycle_dt_str)
 

--- a/src/swell/tasks/get_observations.py
+++ b/src/swell/tasks/get_observations.py
@@ -99,7 +99,7 @@ class GetObservations(taskBase):
         crtm_coeff_dir = self.config.crtm_coeff_dir(None)
         window_offset = self.config.window_offset()
         r2d2_local_path = self.config.r2d2_local_path()
-        cycling_varbc = self.config.cycling_varbc()
+        cycling_varbc = self.config.cycling_varbc(None)
 
         # Set the observing system records path
         self.jedi_rendering.set_obs_records_path(self.config.observing_system_records_path(None))

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -139,6 +139,16 @@ crtm_coeff_dir:
   - SaveObsDiags
   type: string
 
+cycling_varbc:
+  ask_question: true
+  default_value: defer_to_model
+  models:
+  - geos_atmosphere
+  prompt: Do you want to use cycling VarBC option?
+  tasks:
+  - GetObservations
+  type: boolean
+
 ensemble_hofx_packets:
   ask_question: true
   default_value: defer_to_model

--- a/src/swell/test/suite_tests/3dfgat_atmos-tier1.yaml
+++ b/src/swell/test/suite_tests/3dfgat_atmos-tier1.yaml
@@ -52,4 +52,3 @@ models:
     clean_patterns:
     - '*.txt'
     - '*.csv'
-    - '*satbias.nc4'

--- a/src/swell/test/suite_tests/3dvar_atmos-tier1.yaml
+++ b/src/swell/test/suite_tests/3dvar_atmos-tier1.yaml
@@ -55,4 +55,3 @@ models:
     clean_patterns:
     - '*.txt'
     - '*.csv'
-    - '*satbias.nc4'

--- a/src/swell/utilities/config.py
+++ b/src/swell/utilities/config.py
@@ -57,6 +57,7 @@ class Config():
         self.__experiment_root__ = experiment_dict.get('experiment_root')
         self.__experiment_id__ = experiment_dict.get('experiment_id')
         self.__platform__ = experiment_dict.get('platform')
+        self.__start_cycle_point__ = experiment_dict.get('start_cycle_point')
 
         # If experiment_dict contains models key add the model components to the object
         if 'models' in experiment_dict.keys():

--- a/src/swell/utilities/geos.py
+++ b/src/swell/utilities/geos.py
@@ -174,6 +174,11 @@ class Geos():
         if dst == '':
             dst = os.path.basename(src)
 
+        # Check if src file exists
+        # ------------------------
+        if not os.path.exists(src):
+            self.logger.abort(f'Source file does not exist: {src}')
+
         # Assures existing links will be unlinked
         # -----------------------------------
         if os.path.lexists(os.path.join(dst_dir, dst)):

--- a/src/swell/utilities/render_jedi_interface_files.py
+++ b/src/swell/utilities/render_jedi_interface_files.py
@@ -61,6 +61,7 @@ class JediConfigRendering():
             'background_frequency',
             'background_time',
             'crtm_coeff_dir',
+            'cycling_varbc',
             'ensemble_hofx_packets',
             'ensemble_hofx_strategy',
             'ensemble_num_members',


### PR DESCRIPTION
The linking from the previous cycle works, I'm still receiving errors with the variational task but @rtodling you can test this and see what the problem could be.

`cycling_varbc` is introduced as a bool option that impacts the suite behavior. I also added `first_cycle_dto` as an object.

Cylc graph outputs to explain `flow.cylc` changes:

- ## Cycling turned off
All cycles start with the lack of inter-cycle dependencies, except the tasks dependecies on initial cycle (R1) tasks.
![no_cycling](https://github.com/GEOS-ESM/swell/assets/38666458/f185a245-52bc-4fa2-b438-06a9baf4dd19)

- ## Cycling turned on
`get_observations.py` will wait until previous cycle Variational task is complete.
![yes_cycling](https://github.com/GEOS-ESM/swell/assets/38666458/a7a1b394-fefb-4b24-8d28-ea486c53f27d)
