### PR TITLE
Output from satbias covariance must come from different file

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
@@ -25,6 +25,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/airs_aqua.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/airs_aqua.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -47,11 +48,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/airs_aqua.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/airs_aqua.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/airs_aqua.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/airs_aqua.{{window_begin}}.satbias_cov.nc4'
 
 obs error:
   covariance model: cross variable covariances

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
@@ -28,6 +28,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/amsr2_gcom-w1.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/amsr2_gcom-w1.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -54,11 +55,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/amsr2_gcom-w1.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/amsr2_gcom-w1.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/amsr2_gcom-w1.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/amsr2_gcom-w1.{{window_begin}}.satbias_cov.nc4'
 
 obs filters:
 - filter: Bounds Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_aqua.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/amsua_aqua.{{window_begin}}.satbias.nc4'
   variables without bc: [brightnessTemperature]
   channels: 14
   variational bc:
@@ -52,11 +53,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/amsua_aqua.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/amsua_aqua.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/amsua_aqua.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/amsua_aqua.{{window_begin}}.satbias_cov.nc4'
 
 obs prior filters:
 # Assign obs error

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_metop-b.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/amsua_metop-b.{{window_begin}}.satbias.nc4'
   variables without bc: [brightnessTemperature]
   channels: 14
   variational bc:
@@ -52,11 +53,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/amsua_metop-b.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/amsua_metop-b.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/amsua_metop-b.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/amsua_metop-b.{{window_begin}}.satbias_cov.nc4'
 
 obs prior filters:
 # Assign obs error

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_metop-c.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/amsua_metop-c.{{window_begin}}.satbias.nc4'
   variables without bc: [brightnessTemperature]
   channels: 14
   variational bc:
@@ -52,11 +53,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/amsua_metop-c.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/amsua_metop-c.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/amsua_metop-c.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/amsua_metop-c.{{window_begin}}.satbias_cov.nc4'
 
 obs prior filters:
 # Assign obs error

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_n15.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/amsua_n15.{{window_begin}}.satbias.nc4'
   variables without bc: [brightnessTemperature]
   channels: 14
   variational bc:
@@ -52,11 +53,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/amsua_n15.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/amsua_n15.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/amsua_n15.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/amsua_n15.{{window_begin}}.satbias_cov.nc4'
 
 obs prior filters:
 # Assign obs error

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_n18.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/amsua_n18.{{window_begin}}.satbias.nc4'
   variables without bc: [brightnessTemperature]
   channels: 14
   variational bc:
@@ -52,11 +53,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/amsua_n18.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/amsua_n18.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/amsua_n18.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/amsua_n18.{{window_begin}}.satbias_cov.nc4'
 
 obs prior filters:
 # Assign obs error

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_n19.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/amsua_n19.{{window_begin}}.satbias.nc4'
   variables without bc: [brightnessTemperature]
   channels: 14
   variational bc:
@@ -52,11 +53,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/amsua_n19.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/amsua_n19.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/amsua_n19.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/amsua_n19.{{window_begin}}.satbias_cov.nc4'
 
 obs prior filters:
 # Assign obs error

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/atms_n20.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/atms_n20.{{window_begin}}.satbias.nc4'
   variables without bc: [brightnessTemperature]
   channels: 15
   variational bc:
@@ -52,11 +53,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/atms_n20.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/atms_n20.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/atms_n20.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/atms_n20.{{window_begin}}.satbias_cov.nc4'
 
 obs prior filters:
 # Assign obs error

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/atms_npp.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/atms_npp.{{window_begin}}.satbias.nc4'
   variables without bc: [brightnessTemperature]
   channels: 15
   variational bc:
@@ -52,11 +53,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/atms_npp.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/atms_npp.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/atms_npp.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/atms_npp.{{window_begin}}.satbias_cov.nc4'
 
 obs prior filters:
 # Assign obs error

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-b.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/avhrr3_metop-b.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/avhrr3_metop-b.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -46,11 +47,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/avhrr3_metop-b.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/avhrr3_metop-b.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/avhrr3_metop-b.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/avhrr3_metop-b.{{window_begin}}.satbias_cov.nc4'
 
 obs prior filters:
 - filter: Perform Action

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n18.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/avhrr3_n18.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/avhrr3_n18.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -46,11 +47,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/avhrr3_n18.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/avhrr3_n18.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/avhrr3_n18.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/avhrr3_n18.{{window_begin}}.satbias_cov.nc4'
 
 obs prior filters:
 - filter: Perform Action

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/avhrr3_n19.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/avhrr3_n19.{{background_time}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -46,11 +47,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/avhrr3_n19.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/avhrr3_n19.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/avhrr3_n19.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/avhrr3_n19.{{window_begin}}.satbias_cov.nc4'
 
 obs prior filters:
 - filter: Perform Action

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/cris-fsr_n20.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/cris-fsr_n20.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -46,11 +47,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/cris-fsr_n20.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/cris-fsr_n20.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/cris-fsr_n20.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/cris-fsr_n20.{{window_begin}}.satbias_cov.nc4'
 
 obs error:
   covariance model: cross variable covariances

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/cris-fsr_npp.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/cris-fsr_npp.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -46,11 +47,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/cris-fsr_npp.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/cris-fsr_npp.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/cris-fsr_npp.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/cris-fsr_npp.{{window_begin}}.satbias_cov.nc4'
 
 obs error:
   covariance model: cross variable covariances

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
@@ -27,6 +27,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/gmi_gpm.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/gmi_gpm.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -64,11 +65,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/gmi_gpm.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/gmi_gpm.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/gmi_gpm.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/gmi_gpm.{{window_begin}}.satbias_cov.nc4'
 
 obs filters:
 - filter: Bounds Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/iasi_metop-b.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/iasi_metop-b.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -46,11 +47,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/iasi_metop-b.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/iasi_metop-b.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/iasi_metop-b.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/iasi_metop-b.{{window_begin}}.satbias_cov.nc4'
 
 obs error:
   covariance model: cross variable covariances

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
@@ -24,6 +24,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/iasi_metop-c.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/iasi_metop-c.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -46,11 +47,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/iasi_metop-c.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/iasi_metop-c.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/iasi_metop-c.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/iasi_metop-c.{{window_begin}}.satbias_cov.nc4'
 
 obs error:
   covariance model: cross variable covariances

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
@@ -27,6 +27,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/mhs_metop-b.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/mhs_metop-b.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -49,11 +50,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/mhs_metop-b.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/mhs_metop-b.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/mhs_metop-b.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/mhs_metop-b.{{window_begin}}.satbias_cov.nc4'
 
 obs filters:
 - filter: Bounds Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
@@ -27,6 +27,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/mhs_metop-c.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/mhs_metop-c.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -49,11 +50,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/mhs_metop-c.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/mhs_metop-c.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/mhs_metop-c.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/mhs_metop-c.{{window_begin}}.satbias_cov.nc4'
 
 obs filters:
 - filter: Bounds Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
@@ -27,6 +27,7 @@ obs operator:
 
 obs bias:
   input file: '{{cycle_dir}}/mhs_n19.{{background_time}}.satbias.nc4'
+  output file: '{{cycle_dir}}/mhs_n19.{{window_begin}}.satbias.nc4'
   variational bc:
     predictors:
     - name: constant
@@ -49,11 +50,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: '{{cycle_dir}}/mhs_n19.{{background_time}}.satbias.nc4'
+      input file: '{{cycle_dir}}/mhs_n19.{{background_time}}.satbias_cov.nc4'
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: '{{cycle_dir}}/mhs_n19.{{window_begin}}.satbias.nc4'
+    output file: '{{cycle_dir}}/mhs_n19.{{window_begin}}.satbias_cov.nc4'
 
 obs filters:
 - filter: Bounds Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ssmis_f17.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ssmis_f17.yaml
@@ -22,6 +22,7 @@
     channels: &ssmis_f17_channels {{ssmis_f17_avail_channels}} 
   obs bias:
     input file: '{{cycle_dir}}/ssmis_f17.{{background_time}}.satbias.nc4'
+    output file: '{{cycle_dir}}/ssmis_f17.{{window_begin}}.satbias.nc4'
     variational bc:
       predictors:
       - name: constant
@@ -59,11 +60,11 @@
       step size: 1.0e-4
       largest analysis variance: 10000.0
       prior:
-        input file: '{{cycle_dir}}/ssmis_f17.{{background_time}}.satbias.nc4'
+        input file: '{{cycle_dir}}/ssmis_f17.{{background_time}}.satbias_cov.nc4'
         inflation:
           ratio: 1.1
           ratio for small dataset: 2.0
-      output file: '{{cycle_dir}}/ssmis_f17.{{window_begin}}.satbias.nc4'
+      output file: '{{cycle_dir}}/ssmis_f17.{{window_begin}}.satbias_cov.nc4'
 
   obs prior filters:
 # Step 1: Initial Observation Error Assignment

--- a/src/swell/tasks/get_observations.py
+++ b/src/swell/tasks/get_observations.py
@@ -221,12 +221,12 @@ class GetObservations(taskBase):
             self.logger.info(f'Processing satellite bias_cov file {target_file}')
 
             fetch(date=background_time,
-                     target_file=target_file,
-                     provider='gsi',
-                     obs_type=observation,
-                     type='bc',
-                     experiment=obs_experiment,
-                     file_type='satbias_cov')
+                  target_file=target_file,
+                  provider='gsi',
+                  obs_type=observation,
+                  type='bc',
+                  experiment=obs_experiment,
+                  file_type='satbias_cov')
 
             # Change permission
             os.chmod(target_file, 0o644)

--- a/src/swell/tasks/get_observations.py
+++ b/src/swell/tasks/get_observations.py
@@ -199,8 +199,8 @@ class GetObservations(taskBase):
             if 'obs bias' not in observation_dict:
                 continue
 
-            # Satellite bias correction files
-            # -------------------------------
+            # Satellite bias correction (coefficient) files
+            # ---------------------------------------------
             target_file = observation_dict['obs bias']['input file']
             self.logger.info(f'Processing satellite bias file {target_file}')
 
@@ -211,6 +211,22 @@ class GetObservations(taskBase):
                   type='bc',
                   experiment=obs_experiment,
                   file_type='satbias')
+
+            # Change permission
+            os.chmod(target_file, 0o644)
+
+            # Satellite bias correction (covariance) files
+            # --------------------------------------------
+            target_file = observation_dict['obs bias']['covariance']['prior']['input file']
+            self.logger.info(f'Processing satellite bias_cov file {target_file}')
+
+            fetch(date=background_time,
+                     target_file=target_file,
+                     provider='gsi',
+                     obs_type=observation,
+                     type='bc',
+                     experiment=obs_experiment,
+                     file_type='satbias_cov')
 
             # Change permission
             os.chmod(target_file, 0o644)


### PR DESCRIPTION
## Description

Add output file for covariance term of VarBC.

## Dependencies


This requires that all R2D2 files for sabias be linked to a file of the same same but ending in satbias_cov ... for example:

```
foreach fn ( `ls *satbias` )
   ln -s $fn ${fn}_cov
end
```
## Impact

Will break without change in r2d2.
