### PR TITLE
[Bugfix] Support slurm directives without args

### DIFF
--- a/docs/configs/slurm_configuration.md
+++ b/docs/configs/slurm_configuration.md
@@ -12,12 +12,26 @@ The syntax of this file is unnested YAML that directly maps SLURM directives (e.
 account: x1234
 nodes: 1
 qos: allqueues
+no-requeue: null
 ```
 
 This corresponds to the command:
 
 ```sh
-sbatch ... --account=x1234 --nodes=1 --qos=allqueues
+sbatch ... --account=x1234 --nodes=1 --qos=allqueues --no-requeue
+```
+
+Note that the slurm directive `--no-requeue` takes no arguments, so it was set to `null`. The following are all equivalent and will produce the same result.
+
+```yaml
+# null (recommended)
+no-requeue: null
+# blank (note: colon is required!)
+no-requeue:
+# empty string (not recommended because converted to '' (rather than None) in Python)
+no-requeue: ''
+# tilde (not recommended to avoid confusion with home directory)
+no-requeue: ~
 ```
 
 Since there are a few SLURM directives that are platform specific, they are stored under `deployment/platforms/{platform_name}/slurm.yaml`. For instance, this would set `constraint: cas` for `nccs_discover` or `constraint: mil` for `nccs_discover_sles15`.

--- a/src/swell/suites/3dfgat_atmos/flow.cylc
+++ b/src/swell/suites/3dfgat_atmos/flow.cylc
@@ -127,7 +127,7 @@
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     {% for model_component in model_components %}
@@ -162,7 +162,7 @@
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["RunJediVariationalExecutable"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[EvaJediLog-{{model_component}}]]
@@ -177,7 +177,7 @@
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[SaveObsDiags-{{model_component}}]]

--- a/src/swell/suites/3dvar/flow.cylc
+++ b/src/swell/suites/3dvar/flow.cylc
@@ -116,7 +116,7 @@
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     {% for model_component in model_components %}
@@ -141,7 +141,7 @@
         execution time limit = {{scheduling["GenerateBClimatology"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["GenerateBClimatology"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[RunJediVariationalExecutable-{{model_component}}]]
@@ -150,7 +150,7 @@
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["RunJediVariationalExecutable"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[EvaJediLog-{{model_component}}]]
@@ -165,7 +165,7 @@
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[SaveObsDiags-{{model_component}}]]

--- a/src/swell/suites/3dvar_atmos/flow.cylc
+++ b/src/swell/suites/3dvar_atmos/flow.cylc
@@ -127,7 +127,7 @@
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     {% for model_component in model_components %}
@@ -162,7 +162,7 @@
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["RunJediVariationalExecutable"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[EvaJediLog-{{model_component}}]]
@@ -177,7 +177,7 @@
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[SaveObsDiags-{{model_component}}]]

--- a/src/swell/suites/3dvar_cycle/flow.cylc
+++ b/src/swell/suites/3dvar_cycle/flow.cylc
@@ -144,7 +144,7 @@
         execution time limit = {{scheduling["BuildGeos"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildGeos"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[CloneJedi]]
@@ -159,7 +159,7 @@
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[RunGeosExecutable]]
@@ -168,7 +168,7 @@
         execution time limit = {{scheduling["RunGeosExecutable"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["RunGeosExecutable"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[PrepGeosRunDir]]
@@ -209,7 +209,7 @@
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["RunJediVariationalExecutable"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[EvaJediLog-{{model_component}}]]
@@ -221,7 +221,7 @@
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[SaveObsDiags-{{model_component}}]]

--- a/src/swell/suites/build_geos/flow.cylc
+++ b/src/swell/suites/build_geos/flow.cylc
@@ -50,7 +50,7 @@
         execution time limit = {{scheduling["BuildGeos"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildGeos"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/build_jedi/flow.cylc
+++ b/src/swell/suites/build_jedi/flow.cylc
@@ -50,7 +50,7 @@
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/convert_ncdiags/flow.cylc
+++ b/src/swell/suites/convert_ncdiags/flow.cylc
@@ -81,7 +81,7 @@
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[ GetGsiBc ]]

--- a/src/swell/suites/forecast_geos/flow.cylc
+++ b/src/swell/suites/forecast_geos/flow.cylc
@@ -86,7 +86,7 @@
         execution time limit = {{scheduling["BuildGeos"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildGeos"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[PrepGeosRunDir]]
@@ -110,7 +110,7 @@
         execution time limit = {{scheduling["RunGeosExecutable"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["RunGeosExecutable"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/geosadas/flow.cylc
+++ b/src/swell/suites/geosadas/flow.cylc
@@ -112,7 +112,7 @@
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["RunJediVariationalExecutable"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[CleanCycle]]

--- a/src/swell/suites/hofx/flow.cylc
+++ b/src/swell/suites/hofx/flow.cylc
@@ -113,7 +113,7 @@
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     {% for model_component in model_components %}
@@ -142,7 +142,7 @@
         execution time limit = {{scheduling["RunJediHofxExecutable"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["RunJediHofxExecutable"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[EvaObservations-{{model_component}}]]
@@ -151,7 +151,7 @@
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[SaveObsDiags-{{model_component}}]]

--- a/src/swell/suites/localensembleda/flow.cylc
+++ b/src/swell/suites/localensembleda/flow.cylc
@@ -134,7 +134,7 @@
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     {% for model_component in model_components %}
@@ -177,7 +177,7 @@
         execution time limit = {{scheduling["RunJediLocalEnsembleDaExecutable"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["RunJediLocalEnsembleDaExecutable"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[EvaObservations-{{model_component}}]]
@@ -186,7 +186,7 @@
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[SaveObsDiags-{{model_component}}]]

--- a/src/swell/suites/ufo_testing/flow.cylc
+++ b/src/swell/suites/ufo_testing/flow.cylc
@@ -99,7 +99,7 @@
         execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[CloneGeosMksi]]
@@ -129,7 +129,7 @@
         execution time limit = {{scheduling["RunJediUfoTestsExecutable"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["RunJediUfoTestsExecutable"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[EvaObservations]]
@@ -138,7 +138,7 @@
         execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["EvaObservations"]["directives"]["all"].items() %}
-            --{{key}} = {{value}}
+            --{{key}}{% if value %}={{value}}{% endif %}
         {%- endfor %}
 
     [[CleanCycle]]


### PR DESCRIPTION
Support slurm directives like `--no-requeue` that don't take any arguments. Set these by passing any "false-y" value to the corresponding directive in the YAML --- recommendation is `null`, but a blank or an empty string works too.

See #388.