### PR TITLE
FMS 2023.04 change and using relative paths in config

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
@@ -1,9 +1,9 @@
 datetime: '{{local_background_time_iso}}'
 filetype: cube sphere history
 provider: geos
-datapath: ''
-filenames: ['{{cycle_dir}}/bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4',
-            '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/bkg/geos.crtmsrf.{{horizontal_resolution}}.nc4']
+datapath: '{{cycle_dir}}'
+filenames: ['bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4',
+            'fv3-jedi/bkg/geos.crtmsrf.{{horizontal_resolution}}.nc4']
 state variables: [ua,va,t,delp,ps,q,qi,ql,qr,qs,o3ppmv,phis,
                   qls,qcn,cfcn,frocean,frland,varflt,ustar,bstar,
                   zpbl,cm,ct,cq,kcbl,tsm,khl,khu,frlake,frseaice,vtype,

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
@@ -2,9 +2,9 @@ covariance model: SABER
 saber central block:
   saber block name: gsi hybrid covariance
   read:
-    gsi akbk: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/akbk{{vertical_resolution}}.nc4'
-    gsi error covariance file: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/gsibec/gsibec_coefficients_c{{horizontal_resolution}}.nc4'
-    gsi berror namelist file: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/gsibec/{{gsibec_configuration}}_c{{horizontal_resolution}}.nml'
+    gsi akbk: './fv3-jedi/fv3files/akbk{{vertical_resolution}}.nc4'
+    gsi error covariance file: './fv3-jedi/gsibec/gsibec_coefficients_c{{horizontal_resolution}}.nc4'
+    gsi berror namelist file: './fv3-jedi/gsibec/{{gsibec_configuration}}_c{{horizontal_resolution}}.nml'
     processor layout x direction: {{gsibec_npx_proc}}
     processor layout y direction: {{gsibec_npy_proc}}
     debugging mode: false
@@ -15,9 +15,9 @@ saber outer blocks:
                                       mole_fraction_of_ozone_in_air,
                                       fraction_of_ocean,fraction_of_lake,fraction_of_ice,
                                       sfc_geopotential_height_times_grav]
-  gsi akbk: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/akbk{{vertical_resolution}}.nc4'
-  gsi error covariance file: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/gsibec/gsibec_coefficients_c{{horizontal_resolution}}.nc4'
-  gsi berror namelist file: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/gsibec/{{gsibec_configuration}}_c{{horizontal_resolution}}.nml'
+  gsi akbk: './fv3-jedi/fv3files/akbk{{vertical_resolution}}.nc4'
+  gsi error covariance file: './fv3-jedi/gsibec/gsibec_coefficients_c{{horizontal_resolution}}.nc4'
+  gsi berror namelist file: './fv3-jedi/gsibec/{{gsibec_configuration}}_c{{horizontal_resolution}}.nml'
   processor layout x direction: {{gsibec_npx_proc}}
   processor layout y direction: {{gsibec_npy_proc}}
   debugging mode: false

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/geometry.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/geometry.yaml
@@ -1,9 +1,9 @@
 fms initialization:
-  namelist filename: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/fmsmpp.nml'
-  field table filename: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/field_table_gmao'
-akbk: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/akbk{{vertical_resolution}}.nc4'
+  namelist filename: './fv3-jedi/fv3files/fmsmpp.nml'
+  field table filename: './fv3-jedi/fv3files/field_table_gmao'
+akbk: './fv3-jedi/fv3files/akbk{{vertical_resolution}}.nc4'
 layout: [{{npx_proc}},{{npy_proc}}]
 npx: {{horizontal_resolution}}
 npy: {{horizontal_resolution}}
 npz: {{vertical_resolution}}
-field metadata override: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fieldmetadata/geos.yaml'
+field metadata override: './fv3-jedi/fieldmetadata/geos.yaml'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/geometry_inner.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/geometry_inner.yaml
@@ -1,9 +1,9 @@
 fms initialization:
-  namelist filename: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/fmsmpp.nml'
-  field table filename: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/field_table_gmao'
-akbk: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/akbk{{vertical_resolution}}.nc4'
+  namelist filename: './fv3-jedi/fv3files/fmsmpp.nml'
+  field table filename: './fv3-jedi/fv3files/field_table_gmao'
+akbk: './fv3-jedi/fv3files/akbk{{vertical_resolution}}.nc4'
 layout: [{{npx_proc}},{{npy_proc}}]
 npx: {{horizontal_resolution}}
 npy: {{horizontal_resolution}}
 npz: {{vertical_resolution}}
-field metadata override: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fieldmetadata/geos.yaml'
+field metadata override: './fv3-jedi/fieldmetadata/geos.yaml'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/pseudo-model.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/pseudo-model.yaml
@@ -2,6 +2,6 @@ name: PSEUDO
 tstep: {{background_frequency}}
 filetype: cube sphere history
 provider: geos
-datapath: ''
-filenames: ['{{cycle_dir}}/bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4',
-            '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/bkg/geos.crtmsrf.{{horizontal_resolution}}.nc4']
+datapath: '{{cycle_dir}}'
+filenames: ['bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4',
+            'fv3-jedi/bkg/geos.crtmsrf.{{horizontal_resolution}}.nc4']

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage_cycle.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage_cycle.yaml
@@ -1,0 +1,8 @@
+- link_files:
+    directories:
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/GEOS_CRTM_Surface/geos.crtmsrf.{{horizontal_resolution}}.nc4', '{{cycle_dir}}/fv3-jedi/bkg/']
+      - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi/test/Data/fieldmetadata/*', '{{cycle_dir}}/fv3-jedi/fieldmetadata/']
+      - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi/test/Data/fv3files/*', '{{cycle_dir}}/fv3-jedi/fv3files/']
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/gsibec_coefficients_c{{horizontal_resolution}}.nc4', '{{cycle_dir}}/fv3-jedi/gsibec/']
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/{{gsibec_configuration}}_c{{horizontal_resolution}}.nml', '{{cycle_dir}}/fv3-jedi/gsibec/']
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/rcov/1.0.0/*', '{{cycle_dir}}/fv3-jedi/rcov/']

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
@@ -56,7 +56,7 @@ obs bias:
 
 obs error:
   covariance model: cross variable covariances
-  input file: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/rcov/airs_aqua_119_jedi_rcov.nc4'
+  input file: 'fv3-jedi/rcov/airs_aqua_119_jedi_rcov.nc4'
 
 obs prior filters:
 - filter: Perform Action

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
@@ -55,7 +55,7 @@ obs bias:
 
 obs error:
   covariance model: cross variable covariances
-  input file: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/rcov/cris-fsr_108_jedi_rcov.nc4'
+  input file: 'fv3-jedi/rcov/cris-fsr_108_jedi_rcov.nc4'
 
 obs prior filters:
 - filter: Perform Action

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
@@ -55,7 +55,7 @@ obs bias:
 
 obs error:
   covariance model: cross variable covariances
-  input file: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/rcov/cris-fsr_108_jedi_rcov.nc4'
+  input file: 'fv3-jedi/rcov/cris-fsr_108_jedi_rcov.nc4'
 
 obs prior filters:
 - filter: Perform Action

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
@@ -55,7 +55,7 @@ obs bias:
 
 obs error:
   covariance model: cross variable covariances
-  input file: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/rcov/iasi_metop_141_jedi_rcov.nc4'
+  input file: 'fv3-jedi/rcov/iasi_metop_141_jedi_rcov.nc4'
 
 obs prior filters:
 - filter: Perform Action

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
@@ -55,7 +55,7 @@ obs bias:
 
 obs error:
   covariance model: cross variable covariances
-  input file: '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/rcov/iasi_metop_141_jedi_rcov.nc4'
+  input file: 'fv3-jedi/rcov/iasi_metop_141_jedi_rcov.nc4'
 
 obs prior filters:
 - filter: Perform Action

--- a/src/swell/deployment/platforms/nccs_discover/modules
+++ b/src/swell/deployment/platforms/nccs_discover/modules
@@ -18,7 +18,8 @@ module load stack-python/3.10.13
 module load jedi-fv3-env
 module load soca-env
 module load gmao-swell-env/1.0.0
-module unload gsibec crtm
+module unload gsibec crtm fms
+module load fms/2023.04
 
 # JEDI Python Path
 # ----------------

--- a/src/swell/deployment/platforms/nccs_discover/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover/task_questions.yaml
@@ -8,10 +8,10 @@ existing_geos_gcm_source_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.6.0/
 
 existing_jedi_build_directory:
-  default_value: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/build/
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES12/build-intel-release
 
 existing_jedi_source_directory:
-  default_value: /discover/nobackup/gmao_ci/swell/tier2/stable/build_jedi/jedi_bundle/source/
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES12
 
 geos_experiment_directory:
   default_value: 5deg_v11

--- a/src/swell/deployment/platforms/nccs_discover_sles15/modules
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/modules
@@ -19,7 +19,8 @@ module load py-pip/23.1.2
 module load jedi-fv3-env
 module load soca-env
 module load gmao-swell-env/1.0.0
-module unload gsibec crtm
+module unload gsibec crtm fms
+module load fms/2023.04
 
 # JEDI Python Path
 # ----------------

--- a/src/swell/suites/3dfgat_atmos/flow.cylc
+++ b/src/swell/suites/3dfgat_atmos/flow.cylc
@@ -36,9 +36,6 @@
             BuildJediByLinking:fail? => BuildJedi
 
             {% for model_component in model_components %}
-            # Stage JEDI static files
-            CloneJedi => StageJedi-{{model_component}}
-
             # Clone geos ana for generating observing system records
             CloneGeosMksi-{{model_component}}
             {% endfor %}
@@ -73,7 +70,7 @@
 
             # Run Jedi variational executable
             BuildJediByLinking[^]? | BuildJedi[^]  => RunJediVariationalExecutable-{{model_component}}
-            StageJedi-{{model_component}}[^] => RunJediVariationalExecutable-{{model_component}}
+            CloneJedi[^] => StageJediCycle-{{model_component}}
             StageJediCycle-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GetBackgroundGeosExperiment-{{model_component}}? | GetBackground-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GetObservations-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
@@ -137,9 +134,6 @@
 
     [[GenerateObservingSystemRecords-{{model_component}}]]
         script = "swell task GenerateObservingSystemRecords $config -d $datetime -m {{model_component}}"
-
-    [[StageJedi-{{model_component}}]]
-        script = "swell task StageJedi $config -m {{model_component}}"
 
     [[StageJediCycle-{{model_component}}]]
         script = "swell task StageJedi $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/3dvar_atmos/flow.cylc
+++ b/src/swell/suites/3dvar_atmos/flow.cylc
@@ -36,9 +36,6 @@
             BuildJediByLinking:fail? => BuildJedi
 
             {% for model_component in model_components %}
-            # Stage JEDI static files
-            CloneJedi => StageJedi-{{model_component}}
-
             # Clone geos ana for generating observing system records
             CloneGeosMksi-{{model_component}}
             {% endfor %}
@@ -73,7 +70,7 @@
 
             # Run Jedi variational executable
             BuildJediByLinking[^]? | BuildJedi[^]  => RunJediVariationalExecutable-{{model_component}}
-            StageJedi-{{model_component}}[^] => RunJediVariationalExecutable-{{model_component}}
+            CloneJedi[^] => StageJediCycle-{{model_component}}
             StageJediCycle-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GetBackgroundGeosExperiment-{{model_component}}? | GetBackground-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GetObservations-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
@@ -137,9 +134,6 @@
 
     [[GenerateObservingSystemRecords-{{model_component}}]]
         script = "swell task GenerateObservingSystemRecords $config -d $datetime -m {{model_component}}"
-
-    [[StageJedi-{{model_component}}]]
-        script = "swell task StageJedi $config -m {{model_component}}"
 
     [[StageJediCycle-{{model_component}}]]
         script = "swell task StageJedi $config -d $datetime -m {{model_component}}"

--- a/src/swell/suites/hofx/flow.cylc
+++ b/src/swell/suites/hofx/flow.cylc
@@ -36,9 +36,6 @@
             BuildJediByLinking:fail? => BuildJedi
 
             {% for model_component in model_components %}
-            # Stage JEDI static files
-            CloneJedi => StageJedi-{{model_component}}
-
             # Clone geos ana for generating observing system records
             CloneGeosMksi-{{model_component}}
             {% endfor %}
@@ -65,7 +62,7 @@
 
             # Run Jedi hofx executable
             BuildJediByLinking[^]? | BuildJedi[^]  => RunJediHofxExecutable-{{model_component}}
-            StageJedi-{{model_component}}[^] => RunJediHofxExecutable-{{model_component}}
+            CloneJedi[^] => StageJediCycle-{{model_component}}
             StageJediCycle-{{model_component}} => RunJediHofxExecutable-{{model_component}}
             GetBackground-{{model_component}} => RunJediHofxExecutable-{{model_component}}
             GetObservations-{{model_component}} => RunJediHofxExecutable-{{model_component}}
@@ -123,9 +120,6 @@
 
     [[GenerateObservingSystemRecords-{{model_component}}]]
         script = "swell task GenerateObservingSystemRecords $config -d $datetime -m {{model_component}}"
-
-    [[StageJedi-{{model_component}}]]
-        script = "swell task StageJedi $config -m {{model_component}}"
 
     [[StageJediCycle-{{model_component}}]]
         script = "swell task StageJedi $config -d $datetime -m {{model_component}}"


### PR DESCRIPTION
## Purpose
1) In recent JEDI builds, FMS is loaded as a module rather than building it as an external package. Hence, this PR handles the minor `modules` modifications. The bulk of the work is in the `jedi_bundle` wrapper (see https://github.com/GEOS-ESM/jedi_bundle/pull/41 and https://github.com/GEOS-ESM/jedi_bundle/pull/46)

2) FMS has a limitation of allowing up to 128 characters in path length. There will be a future version allowing up to 1024 characters, but we need to stick with relative paths in the interim.

## Impact
`StageJedi` task had two modes:

 1) (without datetime input) Linking static files to the `stage` directory in the experiment folder. This has the advantage of running this task once.
 2) (with datetime input) Linking files to `cycle_dir` at each cycle. This has the advantage of allowing relative paths.
 
 This PR skips the first option to surmount path length issue.

@rtodling, this points to a recent JEDI build from July 24th `/discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES12/`. While we figure out the pinned versions transition you can run and compare your previous variational outputs with this one, if they compare we can move ahead with the pinned version changes.

Closes https://github.com/GEOS-ESM/swell/issues/340