### PR TITLE
Add to docs a procedure note on code_tests

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -33,6 +33,11 @@
   - [Task infrastructure](task_infrastructure.md)
   - [Tasks](tasks.md)
 
+- Code test before pull request
+
+  - [Code Tests](code_tests/code_tests.md)
+
+
 - Governance
 
   - [Requirements](requirements.md)

--- a/docs/code_tests/code_tests.md
+++ b/docs/code_tests/code_tests.md
@@ -1,0 +1,9 @@
+## Ready to create a pull request to SWELL?
+
+Here are a few steps the CI test will run online after your PR, but it can be easier if you run on your terminal before hand.
+
+- Python coding norms: run `python pycodestyle_run.py` at your swell root directory and resolve potential code style issues
+
+- Code test:  run `swell test code_tests`. The `swell/test/code_tests/code_tests.py` will test unused variables. 
+  - If you get `assert tq_dicts_rc == 0; AssertionError`, that means your `tasks/task_questions.yaml` source code needs to be updated with the regenerated ymal file, e.g., named '/tmp/task_questions_RKznhVXN.yaml'.  If you do not see the print-out information following the error code, check
+Line 28 of `swell/test/code_tests/code_tests.py`, which may read `os.environ["LOG_INFO"] = "0"  # Set this to 1 when errors are being debugged `.  Set its value to `1`, rebuild swell, and run again `swell test  code_tests`.


### PR DESCRIPTION
## Description

Adding `test codes before pull request` to docs to save the procedure we used in the group. Especially,
set os.environ["LOG_INFO"] = "1"  for ctest 


## Dependencies

## Impact
