### PR TITLE
no Datetime class without datetime

### DIFF
--- a/src/swell/tasks/base/task_base.py
+++ b/src/swell/tasks/base/task_base.py
@@ -70,7 +70,8 @@ class taskBase(ABC):
         self.__experiment_root__ = self.config.__experiment_root__
         self.__experiment_id__ = self.config.__experiment_id__
         self.__platform__ = self.config.__platform__
-        self.__start_cycle_point__ = Datetime(self.config.__start_cycle_point__)
+        if datetime_input is not None:
+            self.__start_cycle_point__ = Datetime(self.config.__start_cycle_point__)
 
         # Save the model components
         # -------------------------

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -234,6 +234,7 @@ existing_jedi_build_directory:
   prompt: What is the path to the existing JEDI build directory?
   tasks:
   - BuildJediByLinking
+  - CloneJedi
   type: string
 
 existing_jedi_source_directory:

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -234,7 +234,6 @@ existing_jedi_build_directory:
   prompt: What is the path to the existing JEDI build directory?
   tasks:
   - BuildJediByLinking
-  - CloneJedi
   type: string
 
 existing_jedi_source_directory:


### PR DESCRIPTION
The issue was caused by me adding `first_cycle_dto` methods for all tasks, which needs time input. `taskBase` should only add that method if a `datetime` argument was given via `swell task ... -d $datetime`.

Tier 2 is [running now](https://github.com/GEOS-ESM/swell/actions/runs/10251856886), build should work but might fail on `hofx` due to some recent changes in `SOCA`. However should suffice for us to move forward with building using pinned versions https://github.com/GEOS-ESM/swell/issues/345 @asewnath.

