### PR TITLE
Get background geos exp not catching dev/null

### DIFF
--- a/src/swell/tasks/get_background_geos_experiment.py
+++ b/src/swell/tasks/get_background_geos_experiment.py
@@ -51,7 +51,10 @@ class GetBackgroundGeosExperiment(taskBase):
         # Since this is an optional task, check if the geos_x_background_directory is
         # set to /dev/null, if so fail the task
         # ---------------------------------------------------------------------
-        if geos_x_background_directory == '/dev/null':
+        if (
+                (geos_x_background_directory is None) or
+                (geos_x_background_directory.startswith("/dev/null"))
+        ):
             self.logger.abort('No X background location specified, failing task')
             return
 


### PR DESCRIPTION
Default value for `geos_x_background_directory` is `/dev/null/` but we are checking only against `/dev/null`. Make this check more robust. Also, check against `None` for good measure.