### PR TITLE
Add command line option to set LOG_INFO  in code_tests.py

### DIFF
--- a/src/swell/test/code_tests/code_tests.py
+++ b/src/swell/test/code_tests/code_tests.py
@@ -25,8 +25,15 @@ def code_tests():
     logger = Logger('TestSuite')
     logger.test('Running Swell Test Suite')
 
-    # Turn off the regular info testing
-    os.environ["LOG_INFO"] = "0"  # Set this to 1 when errors are being debugged
+    # Check for environment variable
+    log_env = os.environ.get('LOG_INFO')
+
+    # If found set element to environment variable
+    if log_env is None:
+        # Turn off the regular info testing (default)
+        os.environ["LOG_INFO"] = "0"  # Set this to 1 when errors are being debugged
+    else:
+        os.environ["LOG_INFO"] = log_env
 
     # Create a test suite
     test_suite = unittest.TestSuite()

--- a/src/swell/test/code_tests/code_tests.py
+++ b/src/swell/test/code_tests/code_tests.py
@@ -25,15 +25,9 @@ def code_tests():
     logger = Logger('TestSuite')
     logger.test('Running Swell Test Suite')
 
-    # Check for environment variable
-    log_env = os.environ.get('LOG_INFO')
-
-    # If found set element to environment variable
-    if log_env is None:
-        # Turn off the regular info testing (default)
-        os.environ["LOG_INFO"] = "0"  # Set this to 1 when errors are being debugged
-    else:
-        os.environ["LOG_INFO"] = log_env
+    # Default log_info testing to false
+    os.environ.setdefault("LOG_INFO", "0")
+    # Set to 1 when errors are being debugged
 
     # Create a test suite
     test_suite = unittest.TestSuite()


### PR DESCRIPTION
## Description

This modification is introduced to allow users to use command line to turn on LOG_INFO in code_tests.py without modifying code_tests.py itself. 
```
export LOG_INFO=1
swell test  code_tests
```
Then compare, e.g., /tmp/geos_atmosphere_task_questions_Ki1d65V3.yaml  with task_questions.py for details.


## Dependencies

None

## Impact

Make unit test for user easier