### PR TITLE
Updates for the SOCA config for updating pinned JEDI build

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_diffusion_vt.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_diffusion_vt.yaml
@@ -1,0 +1,5 @@
+date: '{{local_background_time_iso}}'
+read_from_file: 1
+basename: './'
+ocn_filename: 'MOM6.res.{{local_background_time}}.nc'
+state variables: [tocn]

--- a/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error.yaml
@@ -6,7 +6,7 @@ saber central block:
     groups:
     - variables: [tocn, socn]
       horizontal:
-        filepath: 'background_error_model/hz_rossby'
+        filepath: 'background_error_model/hz_rossby_1p5'
       vertical:
         levels: {{vertical_resolution}}
         filepath: 'background_error_model/vt.{{local_background_time}}'
@@ -17,7 +17,7 @@ saber central block:
 date: '{{local_background_time_iso}}'
 
 saber outer blocks:
-  - linear variable change name: SOCABkgErrFilt
+  - saber block name: SOCABkgErrFilt
     ocean_depth_min: 100 # [m]
     rescale_bkgerr: 1.0
     efold_z: 2500.0       # [m]

--- a/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error.yaml
@@ -1,38 +1,31 @@
 covariance model: SABER
 saber central block:
-  saber block name: EXPLICIT_DIFFUSION
+  saber block name: diffusion
   active variables: [tocn, socn, ssh]
-  geometry:
-    mom6_input_nml: 'soca/input.nml'
-    fields metadata: 'soca/fields_metadata.yaml'
-    geom_grid_file: 'INPUT/soca_gridspec.nc'
-  group mapping:
-  - name: ocn_3d
-    variables: [tocn, socn]
-  - name: ocn_2d
-    variables: [ssh]
   read:
     groups:
-    - name: ocn_3d
+    - variables: [tocn, socn]
       horizontal:
-        filename: 'background_error_model/hz_rossby.nc'
+        filepath: 'background_error_model/hz_rossby'
       vertical:
-        filename: 'background_error_model/vt.{{local_background_time}}.nc'
-    - name: ocn_2d
+        levels: {{vertical_resolution}}
+        filepath: 'background_error_model/vt.{{local_background_time}}'
+    - variables: [ssh]
       horizontal:
-        filename: 'background_error_model/hz_rossby_1p5.nc'
+        filepath: 'background_error_model/hz_rossby_1p5'
 
 date: '{{local_background_time_iso}}'
+
+saber outer blocks:
+  - linear variable change name: SOCABkgErrFilt
+    ocean_depth_min: 100 # [m]
+    rescale_bkgerr: 1.0
+    efold_z: 2500.0       # [m]
 
 linear variable change:
   input variables: {{analysis_variables}}
   output variables: {{analysis_variables}}
   linear variable changes:
-  - linear variable change name: BkgErrFILT
-    ocean_depth_min: 100 # [m]
-    rescale_bkgerr: 1.0
-    efold_z: 2500.0       # [m]
-
   - linear variable change name: BkgErrGODAS
     sst_bgerr_file: '{{cycle_dir}}/soca/godas_sst_bgerr.nc'
     t_min: 0.1
@@ -48,12 +41,11 @@ linear variable change:
     cicen_max: 0.5
     hicen_min: 10.0
     hicen_max: 100.0
-
   - linear variable change name: BalanceSOCA
-    kst:
-      dsdtmax: 0.1
-      dsdzmin: 3.0e-6
-      dtdzmin: 1.0e-6
-      nlayers: 2
+    # kst:
+    #   dsdtmax: 0.1
+    #   dsdzmin: 3.0e-6
+    #   dtdzmin: 1.0e-6
+    #   nlayers: 2
     ksshts:
       nlayers: 2

--- a/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error_diffusion_vt.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error_diffusion_vt.yaml
@@ -8,10 +8,12 @@
         iterations: 1000
 
       groups:
-      - name: vt
+      - name: diffusion_vt
         vertical:
-          from file:
-            filename: '{{cycle_dir}}/calculated_scales.nc'
-            variable name: tocn
+          model file:
+            date: '{{local_background_time_iso}}'
+            basename: './'
+            ocn_filename: 'calculated_scales.nc'
+          model variable: tocn
         write:
-          filename: 'background_error_model/vt.{{local_background_time}}.nc'
+          filepath: 'background_error_model/vt.{{local_background_time}}'

--- a/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error_diffusion_vt.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error_diffusion_vt.yaml
@@ -1,10 +1,6 @@
   covariance model: SABER
   saber central block:
-    saber block name: EXPLICIT_DIFFUSION
-    geometry:
-      mom6_input_nml: 'soca/input.nml'
-      fields metadata: 'soca/fields_metadata.yaml'
-      geom_grid_file: 'INPUT/soca_gridspec.nc'
+    saber block name: diffusion
     calibration:
       normalization:
         # NOTE, not actually used here, since the normalization spec is only used for hz
@@ -16,6 +12,6 @@
         vertical:
           from file:
             filename: '{{cycle_dir}}/calculated_scales.nc'
-            variable name: vt
+            variable name: tocn
         write:
           filename: 'background_error_model/vt.{{local_background_time}}.nc'

--- a/src/swell/configuration/jedi/oops/calc_scales.yaml
+++ b/src/swell/configuration/jedi/oops/calc_scales.yaml
@@ -2,8 +2,10 @@ gridspec_filename: 'INPUT/soca_gridspec.nc'
 restart_filename: 'MOM6.res.{{local_background_time}}.nc'
 mld_filename: 'MOM6.res.{{local_background_time}}.nc'
 output_filename: '{{cycle_dir}}/calculated_scales.nc'
-output_variable_vt: 'vt'
-output_variable_hz: 'hz'
+
+# These names should match the model variables for now
+output_variable_vt: 'tocn'
+output_variable_hz: 'ave_ssh'
 
 # Parameters for the vertical scale
 VT_MIN: 1.5

--- a/src/swell/configuration/jedi/oops/calc_scales.yaml
+++ b/src/swell/configuration/jedi/oops/calc_scales.yaml
@@ -4,7 +4,7 @@ mld_filename: 'MOM6.res.{{local_background_time}}.nc'
 output_filename: '{{cycle_dir}}/calculated_scales.nc'
 
 # These names should match the model variables for now
-output_variable_vt: 'tocn'
+output_variable_vt: 'Temp'
 output_variable_hz: 'ave_ssh'
 
 # Parameters for the vertical scale

--- a/src/swell/configuration/jedi/oops/parameters_diffusion_vt.yaml
+++ b/src/swell/configuration/jedi/oops/parameters_diffusion_vt.yaml
@@ -2,7 +2,7 @@ geometry:
   TASKFILLgeometry
 
 background:
-  TASKFILLbackground
+  TASKFILLbackground_diffusion_vt
 
 background error:
   TASKFILLbackground_error_diffusion_vt


### PR DESCRIPTION
Following some SABER updates, configuration for SOCA needs to be updated to use JEDI builds past Aug 3rd.

`Explicit_diffusion` became generic (i.e., it can be shared with other models). For SOCA, it has to use the model interface and that introduces some quirks. The correlation scales need to be named as ocean model variables (instead of `hz` or `vt`, `tocn` and `ssh`). And the `state_variable` in `background_diffusion_vt.yaml` has to only contain the correlation scale variable (`tocn` in this case). Hopefully this will be fixed in a future update.

## Dependencies:

- [x] ~Requires a new build, which I already did for August 31st and works for that. So we should first wait for https://github.com/GEOS-ESM/swell/pull/429~

@rtodling tested with an August 31st JEDI build and results are practically identical.

- [x] ~Requires Static file changes which are currently located in my local folder.~