### PR TITLE
Remove hardcoded /tmp from code_tests, and fix GEOS_mksi test

### DIFF
--- a/docs/code_tests/code_tests.md
+++ b/docs/code_tests/code_tests.md
@@ -4,6 +4,8 @@ Here are a few steps the CI test will run online after your PR, but it can be ea
 
 - Python coding norms: run `python pycodestyle_run.py` at your swell root directory and resolve potential code style issues
 
-- Code test:  run `swell test code_tests`. The `swell/test/code_tests/code_tests.py` will test unused variables. 
-  - If you get `assert tq_dicts_rc == 0; AssertionError`, that means your `tasks/task_questions.yaml` source code needs to be updated with the regenerated ymal file, e.g., named '/tmp/task_questions_RKznhVXN.yaml'.  If you do not see the print-out information following the error code, check
-Line 28 of `swell/test/code_tests/code_tests.py`, which may read `os.environ["LOG_INFO"] = "0"  # Set this to 1 when errors are being debugged `.  Set its value to `1`, rebuild swell, and run again `swell test  code_tests`.
+- Code test:  run `swell test code_tests`.
+  - The `swell/test/code_tests/code_tests.py` will test unused variables.
+  - If you get `assert tq_dicts_rc == 0; AssertionError`, that means your `tasks/task_questions.yaml` source code needs to be updated with the regenerated yaml file, e.g., named `/tmp/task_questions_RKznhVXN.yaml` (see NOTE).  If you do not see the print-out information following the error code, check
+Line 28 of `swell/test/code_tests/code_tests.py`, which may read `os.environ["LOG_INFO"] = "0"  # Set this to 1 when errors are being debugged `.  Set its value to `1`, rebuild swell, and run again `swell test code_tests`.
+    - NOTE: `/tmp` here will be different depending on your environment, following the semantics of Python's [`tempfile.gettempdir()`](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir)

--- a/src/swell/test/code_tests/question_dictionary_comparison_test.py
+++ b/src/swell/test/code_tests/question_dictionary_comparison_test.py
@@ -9,9 +9,11 @@
 
 
 import unittest
+import tempfile
+import shutil
 
-from swell.utilities.scripts.task_question_dicts import main as tq_dicts
-from swell.utilities.scripts.task_question_dicts_defaults import main as tq_dicts_defaults
+from swell.utilities.scripts.task_question_dicts import tq_dicts
+from swell.utilities.scripts.task_question_dicts_defaults import tq_dicts_defaults
 
 
 # --------------------------------------------------------------------------------------------------
@@ -22,12 +24,17 @@ class QuestionDictionaryTest(unittest.TestCase):
     def test_dictionary_comparison(self):
 
         # Run main task question dictionary generation
-        tq_dicts_rc = tq_dicts()
+        tempdir = tempfile.mkdtemp()
+        tq_dicts_rc = tq_dicts(tempdir)
         assert tq_dicts_rc == 0
 
         # Run generation for defaults
-        tq_dicts_defaults_rc = tq_dicts_defaults()
+        tq_dicts_defaults_rc = tq_dicts_defaults(tempdir)
         assert tq_dicts_defaults_rc == 0
+
+        # If we got this far without errors, we can remove the temporary
+        # directory (otherwise, it will persist).
+        shutil.rmtree(tempdir)
 
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/test/code_tests/test_generate_observing_system.py
+++ b/src/swell/test/code_tests/test_generate_observing_system.py
@@ -8,16 +8,19 @@ from swell.test.code_tests.testing_utilities import suppress_stdout
 from swell.utilities.observing_system_records import ObservingSystemRecords
 
 
-def setup_geos_mksi(branch):
+def setup_geos_mksi(reference: str):
+    """
+    Clone GEOS-mksi and checkout a branch or commit specified by `reference`.
+    """
     url = "https://github.com/GEOS-ESM/GEOS_mksi.git"
     # Clone repo if not already cloned
     if not os.path.exists("GEOS_mksi"):
-        git_clone_cmd = ["git", "clone", "-b", branch, url, "GEOS_mksi"]
+        git_clone_cmd = ["git", "clone", url, "GEOS_mksi"]
         subprocess.run(git_clone_cmd, stderr=subprocess.DEVNULL)
-    else:
-        git_checkout_cmd = ["git", "checkout", branch]
-        subprocess.run(git_checkout_cmd, cwd="./GEOS_mksi", stdout=subprocess.DEVNULL,
-                       stderr=subprocess.DEVNULL)
+
+    git_checkout_cmd = ["git", "checkout", reference]
+    subprocess.run(git_checkout_cmd, cwd="./GEOS_mksi", stdout=subprocess.DEVNULL,
+                   stderr=subprocess.DEVNULL)
 
 
 class GenerateObservingSystemTest(unittest.TestCase):
@@ -29,13 +32,14 @@ class GenerateObservingSystemTest(unittest.TestCase):
         cls.dt_cycle_time = dt.strptime("20211212T000000Z", "%Y%m%dT%H%M%SZ")
         cls.path_to_gsi_records = os.path.join("GEOS_mksi/", "sidb")
 
-    def test_geos_mksi_main(self):
+    def test_geos_mksi_broken(self):
 
-        """ Testing abort for if on main branch for GEOS_mksi  """
+        """ Testing abort if on a known bad commit of GEOS_mksi  """
+        bad_reference = "bb332daf362891260f87bfa73075615461848325"
 
         # Clone Geos_mksi (main branch) and parse yamls
         observations = ["cris-fsr_npp"]
-        setup_geos_mksi("main")
+        setup_geos_mksi(bad_reference)
         sat_records = ObservingSystemRecords("channel")
         sat_records.parse_records(self.path_to_gsi_records)
         sat_records.save_yamls(self.observing_system_records_path, observations)

--- a/src/swell/utilities/scripts/task_question_dicts.py
+++ b/src/swell/utilities/scripts/task_question_dicts.py
@@ -23,7 +23,7 @@ from swell.utilities.case_switching import snake_case_to_camel_case
 # --------------------------------------------------------------------------------------------------
 
 
-def main():
+def tq_dicts(tempdir: str):
 
     # Create a logger
     logger = Logger('ListOfTaskQuestions')
@@ -141,7 +141,7 @@ def main():
 
         # Write the new dictionary to a temporary file
         random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=8))
-        destination_yaml_temp = os.path.join('/tmp', f'task_questions_{random_string}.yaml')
+        destination_yaml_temp = os.path.join(tempdir, f'task_questions_{random_string}.yaml')
 
         with open(destination_yaml_temp, 'w') as file:
             file.write(dict_to_write_str)

--- a/src/swell/utilities/scripts/task_question_dicts_defaults.py
+++ b/src/swell/utilities/scripts/task_question_dicts_defaults.py
@@ -135,7 +135,7 @@ def create_platform_tq_dicts(
 # --------------------------------------------------------------------------------------------------
 
 
-def main() -> int:
+def tq_dicts_defaults(tempdir: str) -> int:
 
     # Create a logger
     logger = Logger('ListOfTaskQuestions')
@@ -213,7 +213,7 @@ def main() -> int:
             # Write the new dictionary to a temporary file
             random_string = ''.join(random.choices(string.ascii_letters + string.digits, k=8))
             temp_tq_file_name = f'{tq_dicts_name}_task_questions_{random_string}.yaml'
-            destination_yaml_temp = os.path.join('/tmp', temp_tq_file_name)
+            destination_yaml_temp = os.path.join(tempdir, temp_tq_file_name)
 
             with open(destination_yaml_temp, 'w') as file:
                 file.write(tq_dicts_str)


### PR DESCRIPTION
See #432

Also, fixes an issue with the `GEOS_mksi` test now that `GEOS_mksi@develop` has been merged into `main` (https://github.com/GEOS-ESM/GEOS_mksi/pull/2).
