### PR TITLE
Oct 2024 Variable Change Sprint

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
@@ -10,12 +10,20 @@ saber central block:
     debugging mode: false
 saber outer blocks:
 - saber block name: gsi interpolation to model grid
-  state variables to inverse: &bvars [eastward_wind,northward_wind,air_temperature,surface_pressure,
-                                      specific_humidity,cloud_liquid_ice,cloud_liquid_water,
-                                      rain_water,snow_water,
+  state variables to inverse: &bvars [eastward_wind,
+                                      northward_wind,air_temperature,
+                                      air_pressure_at_surface,
+                                      water_vapor_mixing_ratio_wrt_moist_air,
+                                      cloud_liquid_ice,
+                                      cloud_liquid_water,
+                                      rain_water,
+                                      snow_water,
                                       mole_fraction_of_ozone_in_air,
-                                      fraction_of_ocean,fraction_of_lake,fraction_of_ice,
-                                      sfc_geopotential_height_times_grav]
+                                      fraction_of_ocean,
+                                      fraction_of_lake,
+                                      fraction_of_ice,
+                                      geopotential_height_times_gravity_at_surface,
+                                      skin_temperature_at_surface]
   gsi akbk: './fv3-jedi/fv3files/akbk{{vertical_resolution}}.nc4'
   gsi error covariance file: './fv3-jedi/gsibec/gsibec_coefficients_c{{horizontal_resolution}}.nc4'
   gsi berror namelist file: './fv3-jedi/gsibec/{{gsibec_configuration}}_c{{horizontal_resolution}}.nml'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/aircraft.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/aircraft.yaml
@@ -121,14 +121,14 @@ obs post filters:
         - name: MetaData/stationIdentification
           method: exact
   defer to post: true
-# Reassign any ascent predictor to zero where  MetaData/windUpward >50.
+# Reassign any ascent predictor to zero where  MetaData/instantaneousAltitudeRate >50.
 - filter: Variable Assignment
   where:
   - variable:
-      name: MetaData/windUpward
+      name: MetaData/instantaneousAltitudeRate
     minvalue: 50.
   assignments:
-  - name: MetaData/windUpward
+  - name: MetaData/instantaneousAltitudeRate
     value: 0.
 # Compute the BiasCorrectionTerm/ascentPredictor as
 # coefficient * predictor (order=1)
@@ -140,7 +140,7 @@ obs post filters:
       name: ObsFunction/AircraftBiasCorrectionTerm
       options:
         coeff_grpvarname: BiasCoefficientValue/ascentPredictor
-        predi_grpvarname: MetaData/windUpward
+        predi_grpvarname: MetaData/instantaneousAltitudeRate
         predi_order: 1.
   defer to post: true
 # Compute the BiasCorrectionTerm/ascentSquaredPredictor as
@@ -153,7 +153,7 @@ obs post filters:
       name: ObsFunction/AircraftBiasCorrectionTerm
       options:
         coeff_grpvarname: BiasCoefficientValue/ascentSquaredPredictor
-        predi_grpvarname: MetaData/windUpward
+        predi_grpvarname: MetaData/instantaneousAltitudeRate
         predi_order: 2.
   defer to post: true
 # Use ObsFunction/LinearCombination to combine ObsValue/airTemperature with the

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/aircraft.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/aircraft.yaml
@@ -355,7 +355,7 @@ obs post filters:
         inflation factor: 8.0
         surface_obs: false
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
   defer to post: true
 
 # inflate error for tails with uninitialized bias coefficients (i.e. all coefficients equal to zero)
@@ -672,7 +672,7 @@ obs post filters:
         inflation factor: 4.0
         surface_obs: false
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
   defer to post: true
 
 # Error inflation based on pressure check
@@ -688,7 +688,7 @@ obs post filters:
         inflation factor: 4.0
         surface_obs: false
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
   defer to post: true
 
   # Gross Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
@@ -77,10 +77,10 @@ obs filters:
       name: GeoVaLs/water_area_fraction
     minvalue: 0.999
   - variable:
-      name: GeoVaLs/surface_temperature_where_sea
+      name: GeoVaLs/skin_temperature_at_surface_where_sea
     minvalue: 275
   - variable:
-      name: GeoVaLs/surface_wind_speed
+      name: GeoVaLs/wind_speed_at_surface
     maxvalue: 12
   - variable:
       name: MetaData/latitude

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
@@ -249,9 +249,9 @@ obs post filters:
   - variable:
       name: GeoVaLs/water_area_fraction
     maxvalue: 0.99
-  test variables:
-  - name: ObsDiag/brightness_temperature_jacobian_surface_temperature
-    channels: *cris-fsr_n20_channels
+# test variables:
+# - name: ObsDiag/brightness_temperature_jacobian_surface_temperature
+#   channels: *cris-fsr_n20_channels
   maxvalue: 0.2
 # NSST Retrieval Check
 - filter: Bounds Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
@@ -249,9 +249,9 @@ obs post filters:
   - variable:
       name: GeoVaLs/water_area_fraction
     maxvalue: 0.99
-  test variables:
-  - name: ObsDiag/brightness_temperature_jacobian_surface_temperature
-    channels: *cris-fsr_npp_channels
+# test variables:
+# - name: ObsDiag/brightness_temperature_jacobian_surface_temperature
+#   channels: *cris-fsr_npp_channels
   maxvalue: 0.2
 #  NSST Retrieval Check
 - filter: Bounds Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/obsop_name_map.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/obsop_name_map.yaml
@@ -33,6 +33,14 @@ variable maps:
     alias: mole_fraction_of_ozone_in_air
   - name: ozoneTotal
     alias: integrated_layer_ozone_in_air
+  - name: cloudAmount
+    alias: cloud_layer
+  - name: height
+    alias: height_above_mean_sea_level
+  - name: height_levels
+    alias: height_above_mean_sea_level_levels
+  - name: height_levels_minus_one
+    alias: height_above_mean_sea_level_levels_minus_one
   # This came from fv3-jedi but not sure it is needed and it seems to be the same maping as
   # ozoneLayer
   #- name: ozoneProfile

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/obsop_name_map.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/obsop_name_map.yaml
@@ -6,7 +6,7 @@ variable maps:
   - name: windNorthward
     alias: northward_wind
   - name: specificHumidity
-    alias: specific_humidity
+    alias: water_vapor_mixing_ratio_wrt_moist_air
   - name: relativeHumidity
     alias: relative_humidity
   - name: pressure
@@ -14,13 +14,13 @@ variable maps:
   - name: virtualTemperature
     alias: virtual_temperature
   - name: stationPressure
-    alias: surface_pressure
+    alias: air_pressure_at_surface
   - name: depthBelowWaterSurface
     alias: ocean_depth
   - name: waterTemperature
     alias: ocean_temperature
   - name: surfacePressure
-    alias: surface_pressure
+    alias: air_pressure_at_surface
   - name: seaSurfaceTemperature
     alias: sea_surface_temperature
   - name: equivalentReflectivityFactor
@@ -28,8 +28,8 @@ variable maps:
   - name: salinity
     alias: sea_water_salinity
   - name: seaSurfaceTemperature
-    alias: sea_surface_temperature
-  - name: ozoneLayer
+    alias: skin_temperature_at_surface
+  - name: ozoneProfile
     alias: mole_fraction_of_ozone_in_air
   - name: ozoneTotal
     alias: integrated_layer_ozone_in_air

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pibal.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pibal.yaml
@@ -181,7 +181,7 @@ obs post filters:
         variable: windEastward
         inflation factor: 4.0
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
 - filter: Perform Action
   filter variables:
   - name: windNorthward
@@ -197,7 +197,7 @@ obs post filters:
         variable: windNorthward
         inflation factor: 4.0
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
   # Gross Check
 - filter: Background Check
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/satwind.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/satwind.yaml
@@ -244,7 +244,7 @@ obs post filters:
   filter variables:
   - name: windEastward
   - name: windNorthward
-  reference: GeoVaLs/surface_pressure
+  reference: GeoVaLs/air_pressure_at_surface
   value: MetaData/pressure
   maxvalue: -11000
   where:
@@ -259,7 +259,7 @@ obs post filters:
   filter variables:
   - name: windEastward
   - name: windNorthward
-  reference: GeoVaLs/surface_pressure
+  reference: GeoVaLs/air_pressure_at_surface
   value: MetaData/pressure
   maxvalue: -20000
   where:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/satwind.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/satwind.yaml
@@ -315,7 +315,7 @@ obs post filters:
         variable: windEastward
         inflation factor: 4
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
 
 - filter: BlackList
   filter variables:
@@ -332,7 +332,7 @@ obs post filters:
         variable: windNorthward
         inflation factor: 4
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
 
 # Gross Check
 - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/scatwind.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/scatwind.yaml
@@ -114,7 +114,7 @@ obs post filters:
         variable: windEastward
         inflation factor: 4.0
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
 #
 - filter: BlackList
   filter variables:
@@ -131,7 +131,7 @@ obs post filters:
         variable: windNorthward
         inflation factor: 4.0
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
 #
 - filter: Bounds Check
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
@@ -41,7 +41,7 @@ obs operator:
      - name: stationPressure
      da_psfc_scheme: GSI
      geovar_geomz: geopotential_height
-     geovar_sfc_geomz: surface_geometric_height
+     geovar_sfc_geomz: height_above_mean_sea_level_at_surface
      station_altitude: height
 
    # Specific humidity is using the lowest model level (identity)
@@ -172,7 +172,7 @@ obs post filters:
       name: ObsFunction/ObsErrorFactorSfcPressure
       options:
         geovar_geomz: geopotential_height
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
         station_altitude: height
 # assign TempObsErrorData/stationPressure <--- ObsErrorData before changing its Min and Max
 - filter: Variable Assignment

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfcship.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfcship.yaml
@@ -39,7 +39,7 @@ obs operator:
      - name: stationPressure
      da_psfc_scheme: GSI
      geovar_geomz: geopotential_height
-     geovar_sfc_geomz: surface_geometric_height
+     geovar_sfc_geomz: height_above_mean_sea_level_at_surface
      station_altitude: height
 
    # Specific humidity is using the lowest model level (identity)
@@ -165,7 +165,7 @@ obs post filters:
       name: ObsFunction/ObsErrorFactorSfcPressure
       options:
         geovar_geomz: geopotential_height
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
         station_altitude: height
 # assign TempObsErrorData/stationPressure <--- ObsErrorData before changing its Min and Max
 - filter: Variable Assignment
@@ -363,7 +363,7 @@ obs post filters:
       options:
         variable: airTemperature
         inflation factor: 8.0
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
   defer to post: true
 # assign TempObsErrorData/airTemperature  <--- ObsErrorData before changing its Min and Max
 - filter: Variable Assignment
@@ -568,7 +568,7 @@ obs post filters:
       options:
         variable: virtualTemperature
         inflation factor: 8.0
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
   defer to post: true
 
 # assign TempObsErrorData/virtualTemperature  <--- ObsErrorData before changing its Min and Max
@@ -734,7 +734,7 @@ obs post filters:
         variable: specificHumidity
         inflation factor: 8
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
 
 # Background  check
 # ratio threshold 8.0 PreQC /= 3
@@ -850,7 +850,7 @@ obs post filters:
         variable: windEastward
         inflation factor: 4.0
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
 
 # Pressure check
 - filter: BlackList
@@ -864,7 +864,7 @@ obs post filters:
         variable: windNorthward
         inflation factor: 4.0
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
 
 # Background  check
 # ratio threshold 6.0 if PreQC /= 3

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sondes.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sondes.yaml
@@ -39,7 +39,7 @@ obs operator:
     - name: stationPressure
     da_psfc_scheme: GSI
     geovar_geomz: geopotential_height
-    geovar_sfc_geomz: surface_geometric_height
+    geovar_sfc_geomz: height_above_mean_sea_level_at_surface
     station_altitude: height
 
 linear obs operator:
@@ -127,7 +127,7 @@ obs post filters:
       name: ObsFunction/ObsErrorFactorSfcPressure
       options:
         geovar_geomz: geopotential_height
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
         station_altitude: height
 
 # Note: Obs Erorr should between [min ~ max] for gross error checks.
@@ -259,7 +259,7 @@ obs post filters:
         variable: specificHumidity
         inflation factor: 8.0
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
   defer to post: true
 # assign TempObsErrorData/stationPressure <--- ObsErrorData
 - filter: Variable Assignment
@@ -366,7 +366,7 @@ obs post filters:
       options:
         variable: airTemperature
         inflation factor: 8.0
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
   defer to post: true
 # assign TempObsErrorData/airTemperature  <--- ObsErrorData before changing its Min and Max
 - filter: Variable Assignment
@@ -548,7 +548,7 @@ obs post filters:
       options:
         variable: virtualTemperature
         inflation factor: 8.0
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
   defer to post: true
 
 # assign TempObsErrorData/virtualTemperature  <--- ObsErrorData before changing its Min and Max
@@ -731,7 +731,7 @@ obs post filters:
         variable: windEastward
         inflation factor: 4.0
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
 
 - filter: Perform Action
   filter variables:
@@ -748,7 +748,7 @@ obs post filters:
         variable: windNorthward
         inflation factor: 4.0
         adjusted_error_name: GsiAdjustObsError
-        geovar_sfc_geomz: surface_geometric_height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
 
 # Gross Check
 - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ssmis_f17.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ssmis_f17.yaml
@@ -99,7 +99,7 @@
       channels: *ssmis_f17_channels
     where:
     - variable:
-        name: GeoVaLs/surface_geopotential_height
+        name: GeoVaLs/geopotential_height_at_surface
       minvalue: 2000.0
       min_exclusive: true
     - variable:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -154,7 +154,7 @@ number_of_iterations:
   - 5
 
 obs_experiment:
-  default_value: x0048v2
+  default_value: x0048v3
 
 obs_provider:
   default_value: ncdiag

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -82,7 +82,7 @@ ensemble_num_members:
   options: None
 
 geovals_experiment:
-  default_value: x0048-geovals
+  default_value: x0048v3-geovals
 
 geovals_provider:
   default_value: ncdiag
@@ -154,7 +154,7 @@ number_of_iterations:
   - 5
 
 obs_experiment:
-  default_value: x0048
+  default_value: x0048v2
 
 obs_provider:
   default_value: ncdiag

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -19,6 +19,7 @@ analysis_variables:
   - frocean
   - frlake
   - frseaice
+  - ts
   options:
   - ua
   - va
@@ -34,6 +35,7 @@ analysis_variables:
   - frocean
   - frlake
   - frseaice
+  - ts
 
 background_error_model:
   default_value: GSIbec

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/background.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/background.yaml
@@ -5,4 +5,13 @@ ocn_filename: 'MOM6.res.{{local_background_time}}.nc'
 {% if 'cice6' in marine_models %}
 ice_filename: 'cice.res.{{local_background_time}}.nc'
 {% endif %}
-state variables: [cicen, hicen, hsnon, socn, tocn, ssh, hocn, mld, layer_depth]
+state variables:
+  - sea_ice_area_fraction
+  - sea_ice_thickness
+  - sea_ice_snow_thickness
+  - sea_water_salinity
+  - sea_water_potential_temperature
+  - sea_surface_height_above_geoid
+  - sea_water_cell_thickness
+  - ocean_mixed_layer_thickness
+  - sea_water_depth

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/background_diffusion_vt.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/background_diffusion_vt.yaml
@@ -5,4 +5,4 @@ ocn_filename: 'MOM6.res.{{local_background_time}}.nc'
 {% if 'cice6' in marine_models %}
 ice_filename: 'cice.res.{{local_background_time}}.nc'
 {% endif %}
-state variables: [tocn]
+state variables: [sea_water_potential_temperature]

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/background_error.yaml
@@ -1,16 +1,26 @@
 covariance model: SABER
 saber central block:
   saber block name: diffusion
-  active variables: [cicen, hicen, hsnon, tocn, socn, ssh]
+  active variables:
+    - sea_ice_area_fraction
+    - sea_ice_thickness
+    - sea_ice_snow_thickness
+    - sea_water_potential_temperature
+    - sea_water_salinity
+    - sea_surface_height_above_geoid
   read:
     groups:
-    - variables: [tocn, socn]
+    - variables: [sea_water_potential_temperature, sea_water_salinity]
       horizontal:
         filepath: 'background_error_model/hz_rossby'
       vertical:
         levels: {{vertical_resolution}}
         filepath: 'background_error_model/vt.{{local_background_time}}'
-    - variables: [ssh, cicen, hicen, hsnon]
+    - variables:
+      - sea_surface_height_above_geoid
+      - sea_ice_area_fraction
+      - sea_ice_thickness
+      - sea_ice_snow_thickness
       horizontal:
         filepath: 'background_error_model/hz_rossby_1p5'
 
@@ -22,27 +32,18 @@ saber outer blocks:
     rescale_bkgerr: 1.0
     efold_z: 2500.0       # [m]
 
+  - saber block name: SOCAParametricOceanStdDev
+    temperature:  # use defaults other than SST input file
+      sst:
+        filepath: '{{cycle_dir}}/soca/godas_sst_bgerr.nc'
+        variable: sst_bgerr
+    unbalanced salinity: {} # use default values
+    unbalanced ssh: {} # use default values
+
 linear variable change:
   input variables: {{analysis_variables}}
   output variables: {{analysis_variables}}
   linear variable changes:
-  - linear variable change name: BkgErrGODAS
-    sst_bgerr_file: '{{cycle_dir}}/soca/godas_sst_bgerr.nc'
-    # output:
-    #   filename: '{{cycle_dir}}/bkgerrgodas.nc'
-    t_min: 0.1
-    t_max: 2.0
-    t_dz:  20.0
-    t_efold: 500.0
-    s_min: 0.0
-    s_max: 0.25
-    ssh_min: 0.0   # value at EQ
-    ssh_max: 0.1   # value in Extratropics
-    ssh_phi_ex: 20 # lat of transition from extratropics
-    cicen_min: 0.1
-    cicen_max: 0.5
-    hicen_min: 10.0
-    hicen_max: 100.0
   - linear variable change name: BalanceSOCA
     ksshts:
       nlayers: 2

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/background_error_diffusion_vt.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/background_error_diffusion_vt.yaml
@@ -14,6 +14,6 @@
             date: '{{local_background_time_iso}}'
             basename: './'
             ocn_filename: 'calculated_scales.nc'
-          model variable: tocn
+          model variable: sea_water_potential_temperature
         write:
           filepath: 'background_error_model/vt.{{local_background_time}}'

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/background_error_init.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/background_error_init.yaml
@@ -16,7 +16,14 @@ correlation:
 - name: 'ocn'
   base value: 840336.134453782
   rossby mult: 0.280112045
-  variables: [socn, tocn, ssh, hocn]
+  variables:
+    - sea_water_salinity
+    - sea_water_potential_temperature
+    - sea_surface_height_above_geoid
+    - sea_water_cell_thickness
 - name: 'ice'
   base value: 560224.089635854
-  variables: [cicen, hicen, hsnon]
+  variables:
+    - sea_ice_area_fraction
+    - sea_ice_thickness
+    - sea_ice_snow_thickness

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/states.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/states.yaml
@@ -6,7 +6,13 @@
     ice_filename: ice.{{experiment_id}}.an.{{analysis_time_iso}}.nc
     {% endif %}
     date: '{{analysis_time_iso}}'
-    state variables: [tocn, socn, hocn, cicen, hicen, hsnon]
+    state variables:
+      - sea_water_potential_temperature
+      - sea_water_salinity
+      - sea_water_cell_thickness
+      - sea_ice_area_fraction
+      - sea_ice_thickness
+      - sea_ice_snow_thickness
   output:
     datadir: ./
     exp: {{experiment_id}}

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/variable_change_soca2cice.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/variable_change_soca2cice.yaml
@@ -10,9 +10,15 @@ domain: {{cice6_domain}}
 cice background state:
   restart: 'iced.res.{{local_background_time}}.nc'
   ncat: 5
-  ice_lev: 4
+  ice_lev: 7
   sno_lev: 1
   tstep: PT1H
 cice output:
   restart: 'iced.res.{{local_background_time}}.nc'
-output variables: [tocn, socn, hocn, cicen, hicen, hsnon]
+output variables:
+  - sea_water_potential_temperature
+  - sea_water_salinity
+  - sea_water_cell_thickness
+  - sea_ice_area_fraction
+  - sea_ice_thickness
+  - sea_ice_snow_thickness

--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/obsop_name_map.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/obsop_name_map.yaml
@@ -2,7 +2,7 @@ variable maps:
   - name: depthBelowWaterSurface
     alias: ocean_depth
   - name: waterTemperature
-    alias: ocean_temperature
+    alias: sea_water_temperature
   - name: seaSurfaceTemperature
     alias: sea_surface_temperature
   - name: salinity

--- a/src/swell/configuration/jedi/interfaces/geos_marine/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/task_questions.yaml
@@ -5,15 +5,15 @@ analysis_forecast_window_offset:
 
 analysis_variables:
   default_value:
-  - socn
-  - tocn
-  - ssh
-  - hocn
+  - sea_water_salinity
+  - sea_water_potential_temperature
+  - sea_surface_height_above_geoid
+  - sea_water_cell_thickness
   options:
-  - socn
-  - tocn
-  - ssh
-  - hocn
+  - sea_water_salinity
+  - sea_water_potential_temperature
+  - sea_surface_height_above_geoid
+  - sea_water_cell_thickness
 
 background_error_model:
   default_value: explicit_diffusion

--- a/src/swell/configuration/jedi/interfaces/geos_ocean/model/background.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/model/background.yaml
@@ -2,4 +2,10 @@ date: '{{local_background_time_iso}}'
 read_from_file: 1
 basename: './'
 ocn_filename: 'MOM6.res.{{local_background_time}}.nc'
-state variables: [socn, tocn, ssh, hocn, mld, layer_depth]
+state variables:
+  - sea_water_salinity
+  - sea_water_potential_temperature
+  - sea_surface_height_above_geoid
+  - sea_water_cell_thickness
+  - ocean_mixed_layer_thickness
+  - sea_water_depth

--- a/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_diffusion_vt.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_diffusion_vt.yaml
@@ -2,4 +2,4 @@ date: '{{local_background_time_iso}}'
 read_from_file: 1
 basename: './'
 ocn_filename: 'MOM6.res.{{local_background_time}}.nc'
-state variables: [tocn]
+state variables: [sea_water_potential_temperature]

--- a/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error.yaml
@@ -1,16 +1,19 @@
 covariance model: SABER
 saber central block:
   saber block name: diffusion
-  active variables: [tocn, socn, ssh]
+  active variables:
+    - sea_water_potential_temperature
+    - sea_water_salinity
+    - sea_surface_height_above_geoid
   read:
     groups:
-    - variables: [tocn, socn]
+    - variables: [sea_water_potential_temperature, sea_water_salinity]
       horizontal:
         filepath: 'background_error_model/hz_rossby_1p5'
       vertical:
         levels: {{vertical_resolution}}
         filepath: 'background_error_model/vt.{{local_background_time}}'
-    - variables: [ssh]
+    - variables: [sea_surface_height_above_geoid]
       horizontal:
         filepath: 'background_error_model/hz_rossby_1p5'
 
@@ -22,25 +25,18 @@ saber outer blocks:
     rescale_bkgerr: 1.0
     efold_z: 2500.0       # [m]
 
+  - saber block name: SOCAParametricOceanStdDev
+    temperature:  # use defaults other than SST input file
+      sst:
+        filepath: '{{cycle_dir}}/soca/godas_sst_bgerr.nc'
+        variable: sst_bgerr
+    unbalanced salinity: {} # use default values
+    unbalanced ssh: {} # use default values
+
 linear variable change:
   input variables: {{analysis_variables}}
   output variables: {{analysis_variables}}
   linear variable changes:
-  - linear variable change name: BkgErrGODAS
-    sst_bgerr_file: '{{cycle_dir}}/soca/godas_sst_bgerr.nc'
-    t_min: 0.1
-    t_max: 2.0
-    t_dz:  20.0
-    t_efold: 500.0
-    s_min: 0.0
-    s_max: 0.25
-    ssh_min: 0.0   # value at EQ
-    ssh_max: 0.1   # value in Extratropics
-    ssh_phi_ex: 20 # lat of transition from extratropics
-    cicen_min: 0.1
-    cicen_max: 0.5
-    hicen_min: 10.0
-    hicen_max: 100.0
   - linear variable change name: BalanceSOCA
     ksshts:
       nlayers: 2

--- a/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error_diffusion_vt.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/model/background_error_diffusion_vt.yaml
@@ -14,6 +14,6 @@
             date: '{{local_background_time_iso}}'
             basename: './'
             ocn_filename: 'calculated_scales.nc'
-          model variable: tocn
+          model variable: sea_water_potential_temperature
         write:
           filepath: 'background_error_model/vt.{{local_background_time}}'

--- a/src/swell/configuration/jedi/interfaces/geos_ocean/observations/obsop_name_map.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/observations/obsop_name_map.yaml
@@ -2,7 +2,7 @@ variable maps:
   - name: depthBelowWaterSurface
     alias: ocean_depth
   - name: waterTemperature
-    alias: ocean_temperature
+    alias: sea_water_temperature
   - name: seaSurfaceTemperature
     alias: sea_surface_temperature
   - name: salinity

--- a/src/swell/configuration/jedi/interfaces/geos_ocean/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/task_questions.yaml
@@ -6,15 +6,15 @@ analysis_forecast_window_offset:
 
 analysis_variables:
   default_value:
-  - socn
-  - tocn
-  - ssh
-  - hocn
+  - sea_water_salinity
+  - sea_water_potential_temperature
+  - sea_surface_height_above_geoid
+  - sea_water_cell_thickness
   options:
-  - socn
-  - tocn
-  - ssh
-  - hocn
+  - sea_water_salinity
+  - sea_water_potential_temperature
+  - sea_surface_height_above_geoid
+  - sea_water_cell_thickness
 
 background_error_model:
   default_value: explicit_diffusion
@@ -117,4 +117,3 @@ window_offset:
 
 window_type:
   default_value: 3D
-

--- a/src/swell/configuration/jedi/interfaces/geos_ocean/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_ocean/task_questions.yaml
@@ -117,3 +117,4 @@ window_offset:
 
 window_type:
   default_value: 3D
+

--- a/src/swell/suites/3dfgat_cycle/eva/increment-geos_marine.yaml
+++ b/src/swell/suites/3dfgat_cycle/eva/increment-geos_marine.yaml
@@ -12,7 +12,7 @@ datasets:
     type: SocaRestart
     soca_filenames: {{ice_increment_file_path}}
     geometry_file: {{cycle_dir}}/INPUT/soca_gridspec.nc
-    variables: [aicen]
+    variables: [aice_h]
     coordinate variables: [lon, lat]
 {% endif %}
 
@@ -112,7 +112,7 @@ graphics:
 
 {% if 'cice6' in marine_models %}
   - batch figure:
-      variables: [aicen]
+      variables: [aice_h]
     figure:
       figure size: [20,10]
       layout: [1,1]
@@ -133,14 +133,14 @@ graphics:
           latitude:
             variable: seaice_increment::SOCAgrid::lat
           data:
-            variable: seaice_increment::SOCAVars::aicen
+            variable: seaice_increment::SOCAVars::aice_h
           label: Sea ice concentration increment
           colorbar: true
           cmap: 'bwr'
           vmin: -1
           vmax: 1
   - batch figure:
-      variables: [aicen]
+      variables: [aice_h]
     figure:
       figure size: [20,10]
       layout: [1,1]
@@ -161,7 +161,7 @@ graphics:
           latitude:
             variable: seaice_increment::SOCAgrid::lat
           data:
-            variable: seaice_increment::SOCAVars::aicen
+            variable: seaice_increment::SOCAVars::aice_h
           label: Sea-ice concentration increment
           colorbar: true
           cmap: 'bwr'

--- a/src/swell/suites/3dvar_cycle/eva/increment-geos_marine.yaml
+++ b/src/swell/suites/3dvar_cycle/eva/increment-geos_marine.yaml
@@ -11,7 +11,7 @@ datasets:
     type: SocaRestart
     soca_filenames: {{ice_increment_file_path}}
     geometry_file: {{cycle_dir}}/INPUT/soca_gridspec.nc
-    variables: [aicen]
+    variables: [aice_h]
     coordinate variables: [lon, lat]
 
 graphics:
@@ -109,7 +109,7 @@ graphics:
           vmax: 1
 
   - batch figure:
-      variables: [aicen]
+      variables: [aice_h]
     figure:
       figure size: [20,10]
       layout: [1,1]
@@ -130,14 +130,14 @@ graphics:
           latitude:
             variable: seaice_increment::SOCAgrid::lat
           data:
-            variable: seaice_increment::SOCAVars::aicen
+            variable: seaice_increment::SOCAVars::aice_h
           label: Sea ice concentration increment
           colorbar: true
           cmap: 'bwr'
           vmin: -1
           vmax: 1
   - batch figure:
-      variables: [aicen]
+      variables: [aice_h]
     figure:
       figure size: [20,10]
       layout: [1,1]
@@ -158,7 +158,7 @@ graphics:
           latitude:
             variable: seaice_increment::SOCAgrid::lat
           data:
-            variable: seaice_increment::SOCAVars::aicen
+            variable: seaice_increment::SOCAVars::aice_h
           label: Sea-ice concentration increment
           colorbar: true
           cmap: 'bwr'

--- a/src/swell/tasks/link_geos_output.py
+++ b/src/swell/tasks/link_geos_output.py
@@ -195,7 +195,7 @@ class LinkGeosOutput(taskBase):
 
         # rename the dimensions to xaxis_1 and yaxis_1 and rename the variables
         ds = ds.rename({'ni': 'xaxis_1', 'nj': 'yaxis_1'})
-        ds = ds.rename({'aice': 'aicen', 'hi': 'hicen', 'hs': 'hsnon'})
+        ds = ds.rename({'aice': 'aice_h', 'hi': 'hi_h', 'hs': 'hs_h'})
 
         # Save as a new file
         ds.to_netcdf(dst_history, mode='w')
@@ -207,9 +207,9 @@ class LinkGeosOutput(taskBase):
         # time dimension added to the dataset.
         # SOCA needs icea area (aicen), ice volume (vicen), and snow area (vsnon)
         # --------------------------------------------------------------------
-        soca2cice_vars = {'aicen': 'aicen',
-                          'hicen': 'vicen',
-                          'hsnon': 'vsnon'}
+        soca2cice_vars = {'aice_h': 'aicen',
+                          'hi_h': 'vicen',
+                          'hs_h': 'vsnon'}
 
         # read CICE6 restart
         # -----------------

--- a/src/swell/tasks/run_jedi_hofx_executable.py
+++ b/src/swell/tasks/run_jedi_hofx_executable.py
@@ -127,8 +127,8 @@ class RunJediHofxExecutable(taskBase):
                     }
 
             # Update config filters to save the GeoVaLs from the model interface.
-            # Add GOMsaver to either obs filters OR obs post filters, if neither
-            # exists then create obs post filters and add GOMsaver
+            # Add GOMsaver to either obs filters OR obs prior filters, if neither
+            # exists then create obs prior filters and add GOMsaver
             # ------------------------------------------------------------------
             if save_geovals:
                 self.append_gomsaver(observations, jedi_config_dict, window_begin)
@@ -175,7 +175,8 @@ class RunJediHofxExecutable(taskBase):
 
                     # Assert that there are np files
                     self.logger.assert_abort(len(geovals_files) == np, f'Number of GeoVaLs' +
-                                             f' files does not match number of processors:\n' +
+                                             f' for observtion type {observation}:\n' +
+                                             f' does not match number of processors:\n' +
                                              f' np={np}, len(geovals_files) = {len(geovals_files)}')
 
                     # Write the concatenated dataset to a new file
@@ -231,8 +232,8 @@ class RunJediHofxExecutable(taskBase):
                         outfile.replace('.nc4', f'_{mem:02}.nc4')
 
                 # Update config filters to save the GeoVaLs from the model interface.
-                # Add GOMsaver to either obs filters OR obs post filters, if neither
-                # exists then create obs post filters and add GOMsaver
+                # Add GOMsaver to either obs filters OR obs prior filters, if neither
+                # exists then create obs prior filters and add GOMsaver
                 # ------------------------------------------------------------------
                 if save_geovals:
                     self.append_gomsaver(observations, jedi_config_dict, window_begin, mem=mem)
@@ -274,12 +275,12 @@ class RunJediHofxExecutable(taskBase):
             # Check if observer has obs filters and if so add them to the jedi_config_dict
             if 'obs filters' in observer:
                 filter_dict = 'obs filters'
-            elif 'obs post filters' in observer:
-                filter_dict = 'obs post filters'
+            elif 'obs prior filters' in observer:
+                filter_dict = 'obs prior filters'
             else:
-                # Create some post filters
-                observer['obs post filters'] = []
-                filter_dict = 'obs post filters'
+                # Create some prior filters
+                observer['obs prior filters'] = []
+                filter_dict = 'obs prior filters'
 
             # Append the GOMsaver dictionary to the observer filters
             observer[filter_dict].append(gom_saver_dict)

--- a/src/swell/test/code_tests/missing_obs_test/experiment/configuration/jedi/interfaces/geos_atmosphere/observations/satwind.yaml
+++ b/src/swell/test/code_tests/missing_obs_test/experiment/configuration/jedi/interfaces/geos_atmosphere/observations/satwind.yaml
@@ -238,7 +238,7 @@ obs post filters:
   filter variables:
   - name: windEastward
   - name: windNorthward
-  reference: GeoVaLs/surface_pressure
+  reference: GeoVaLs/air_pressure_at_surface
   value: MetaData/pressure
   maxvalue: -11000
   where:
@@ -253,7 +253,7 @@ obs post filters:
   filter variables:
   - name: windEastward
   - name: windNorthward
-  reference: GeoVaLs/surface_pressure
+  reference: GeoVaLs/air_pressure_at_surface
   value: MetaData/pressure
   maxvalue: -20000
   where:

--- a/src/swell/test/suite_tests/3dfgat_atmos-tier1.yaml
+++ b/src/swell/test/suite_tests/3dfgat_atmos-tier1.yaml
@@ -47,7 +47,7 @@ models:
     gradient_norm_reduction: 1e-3
     number_of_iterations:
     - 10
-    obs_experiment: x0048v2
+    obs_experiment: x0048v3
     geovals_experiment: x0048v3-geovals
     clean_patterns:
     - '*.txt'

--- a/src/swell/test/suite_tests/3dfgat_atmos-tier1.yaml
+++ b/src/swell/test/suite_tests/3dfgat_atmos-tier1.yaml
@@ -48,7 +48,7 @@ models:
     number_of_iterations:
     - 10
     obs_experiment: x0048v2
-    geovals_experiment: x0048v2-geovals
+    geovals_experiment: x0048v3-geovals
     clean_patterns:
     - '*.txt'
     - '*.csv'

--- a/src/swell/test/suite_tests/3dfgat_atmos-tier1.yaml
+++ b/src/swell/test/suite_tests/3dfgat_atmos-tier1.yaml
@@ -47,8 +47,6 @@ models:
     gradient_norm_reduction: 1e-3
     number_of_iterations:
     - 10
-    obs_experiment: x0048v2
-    geovals_experiment: x0048v3-geovals
     clean_patterns:
     - '*.txt'
     - '*.csv'

--- a/src/swell/test/suite_tests/3dvar_atmos-tier1.yaml
+++ b/src/swell/test/suite_tests/3dvar_atmos-tier1.yaml
@@ -50,8 +50,6 @@ models:
     - sfc
     - sondes
     - ssmis_f17
-    obs_experiment: x0048v2
-    geovals_experiment: x0048v3-geovals
     clean_patterns:
     - '*.txt'
     - '*.csv'

--- a/src/swell/test/suite_tests/3dvar_atmos-tier1.yaml
+++ b/src/swell/test/suite_tests/3dvar_atmos-tier1.yaml
@@ -51,7 +51,7 @@ models:
     - sondes
     - ssmis_f17
     obs_experiment: x0048v2
-    geovals_experiment: x0048v2-geovals
+    geovals_experiment: x0048v3-geovals
     clean_patterns:
     - '*.txt'
     - '*.csv'

--- a/src/swell/test/suite_tests/3dvar_atmos-tier1.yaml
+++ b/src/swell/test/suite_tests/3dvar_atmos-tier1.yaml
@@ -50,7 +50,7 @@ models:
     - sfc
     - sondes
     - ssmis_f17
-    obs_experiment: x0048v2
+    obs_experiment: x0048v3
     geovals_experiment: x0048v3-geovals
     clean_patterns:
     - '*.txt'

--- a/src/swell/test/suite_tests/hofx-tier1.yaml
+++ b/src/swell/test/suite_tests/hofx-tier1.yaml
@@ -41,7 +41,7 @@ models:
     - sondes
     - ssmis_f17
     obs_experiment: x0048v2
-    geovals_experiment: x0048v2-geovals
+    geovals_experiment: x0048v3-geovals
     clean_patterns: []
   geos_ocean:
     obs_experiment: s2s_v1

--- a/src/swell/test/suite_tests/hofx-tier1.yaml
+++ b/src/swell/test/suite_tests/hofx-tier1.yaml
@@ -40,7 +40,7 @@ models:
     - sfc
     - sondes
     - ssmis_f17
-    obs_experiment: x0048v2
+    obs_experiment: x0048v3
     geovals_experiment: x0048v3-geovals
     clean_patterns: []
   geos_ocean:

--- a/src/swell/test/suite_tests/hofx-tier1.yaml
+++ b/src/swell/test/suite_tests/hofx-tier1.yaml
@@ -40,8 +40,6 @@ models:
     - sfc
     - sondes
     - ssmis_f17
-    obs_experiment: x0048v2
-    geovals_experiment: x0048v3-geovals
     clean_patterns: []
   geos_ocean:
     obs_experiment: s2s_v1

--- a/src/swell/test/suite_tests/localensembleda-tier1.yaml
+++ b/src/swell/test/suite_tests/localensembleda-tier1.yaml
@@ -22,7 +22,7 @@ models:
     observations:
     - sondes
     - amsua_metop-b
-    obs_experiment: x0048v2
+    obs_experiment: x0048v3
     background_experiment: x0048
     window_type: 3D
     clean_patterns:

--- a/src/swell/test/suite_tests/localensembleda-tier1.yaml
+++ b/src/swell/test/suite_tests/localensembleda-tier1.yaml
@@ -22,7 +22,6 @@ models:
     observations:
     - sondes
     - amsua_metop-b
-    obs_experiment: x0048v2
     background_experiment: x0048
     window_type: 3D
     clean_patterns:

--- a/src/swell/test/suite_tests/ufo_testing-tier1.yaml
+++ b/src/swell/test/suite_tests/ufo_testing-tier1.yaml
@@ -55,5 +55,3 @@ models:
     - gsi_ncdiags/aircraft
     - gsi_ncdiags
     path_to_gsi_nc_diags: /discover/nobackup/projects/gmao/advda/SwellTestData/ufo_testing/ncdiagv2/%Y%m%d%H
-    obs_experiment: x0048v3
-    geovals_experiment: x0048v3-geovals

--- a/src/swell/test/suite_tests/ufo_testing-tier1.yaml
+++ b/src/swell/test/suite_tests/ufo_testing-tier1.yaml
@@ -55,5 +55,5 @@ models:
     - gsi_ncdiags/aircraft
     - gsi_ncdiags
     path_to_gsi_nc_diags: /discover/nobackup/projects/gmao/advda/SwellTestData/ufo_testing/ncdiagv2/%Y%m%d%H
-    obs_experiment: x0048v2
+    obs_experiment: x0048v3
     geovals_experiment: x0048v3-geovals

--- a/src/swell/test/suite_tests/ufo_testing-tier1.yaml
+++ b/src/swell/test/suite_tests/ufo_testing-tier1.yaml
@@ -56,4 +56,4 @@ models:
     - gsi_ncdiags
     path_to_gsi_nc_diags: /discover/nobackup/projects/gmao/advda/SwellTestData/ufo_testing/ncdiagv2/%Y%m%d%H
     obs_experiment: x0048v2
-    geovals_experiment: x0048v2-geovals
+    geovals_experiment: x0048v3-geovals


### PR DESCRIPTION
## Description

**All this is using JEDI from 19Nov2024. So this is following JEDI build update to November 19th**

Working to address changes from October 2024 Variable Change Sprint. 

- Geoval names were updated and relevant R2D2 files and folders were updated to handle this change. Now new folders are named v3 and set as the default
- Erased some of the overwrites in Tier 1 tests to prevent confusion
- `fields_metadata.yaml` changed for SOCA
- Sea-ice variable names changed. 
 
These now work for all of the atmospheric obs systems:

However, in the SSMI case, I am seeing the Jo got down to negative numbers ... this means something is odd somewhere - bias correction, or something. I am not sure whether this was the case in the original code (before all these changes) ... I am currently checking on that.

# SOCA notes:

There are major changes in terms of what internal variable names SOCA would be using and hence the configuration yamls needed to be updated. In terms of MOM6 outputs or obs files, there are no changes. See more details in https://github.com/JCSDA-internal/soca/pull/1082. For instance instead of `tocn` we set `sea_water_potential_temperature`.

It also conforms with https://github.com/JCSDA-internal/soca/pull/1085, `BkgErrGODAS` is moved out to the generic block. Most of the default balance values were what we have been using but there is an additional `OceanSmoother` that we should be careful about.