### PR TITLE
Add missing surface type to linear obs op of MW

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
@@ -20,7 +20,7 @@ obs operator:
     CoefficientPath: '{{crtm_coeff_dir}}/'
   linear obs operator:
     Absorbers: [H2O,O3]
-    Surfaces: [Water_Temperature]
+    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_aqua.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
@@ -20,7 +20,7 @@ obs operator:
     CoefficientPath: '{{crtm_coeff_dir}}/'
   linear obs operator:
     Absorbers: [H2O,O3]
-    Surfaces: [Water_Temperature]
+    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_metop-b.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
@@ -20,7 +20,7 @@ obs operator:
     CoefficientPath: '{{crtm_coeff_dir}}/'
   linear obs operator:
     Absorbers: [H2O,O3]
-    Surfaces: [Water_Temperature]
+    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_metop-c.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
@@ -20,7 +20,7 @@ obs operator:
     CoefficientPath: '{{crtm_coeff_dir}}/'
   linear obs operator:
     Absorbers: [H2O,O3]
-    Surfaces: [Water_Temperature]
+    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_n15.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
@@ -20,7 +20,7 @@ obs operator:
     CoefficientPath: '{{crtm_coeff_dir}}/'
   linear obs operator:
     Absorbers: [H2O,O3]
-    Surfaces: [Water_Temperature]
+    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_n18.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
@@ -20,7 +20,7 @@ obs operator:
     CoefficientPath: '{{crtm_coeff_dir}}/'
   linear obs operator:
     Absorbers: [H2O,O3]
-    Surfaces: [Water_Temperature]
+    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/amsua_n19.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
@@ -20,7 +20,7 @@ obs operator:
     CoefficientPath: '{{crtm_coeff_dir}}/'
   linear obs operator:
     Absorbers: [H2O,O3]
-    Surfaces: [Water_Temperature]
+    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/atms_n20.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
@@ -20,7 +20,7 @@ obs operator:
     CoefficientPath: '{{crtm_coeff_dir}}/'
   linear obs operator:
     Absorbers: [H2O,O3]
-    Surfaces: [Water_Temperature]
+    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/atms_npp.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ssmis_f17.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ssmis_f17.yaml
@@ -3,7 +3,7 @@
     Absorbers: [H2O,O3,CO2]
     linear obs operator:
       Absorbers: [H2O,O3]
-      Surfaces: [Water_Temperature]
+      Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
     obs options:
       Sensor_ID: &Sensor_ID ssmis_f17
       EndianType: little_endian


### PR DESCRIPTION
## Description

This  add the missing surface types to the linear obs operators of the  MW instruments.

See issue #462 

## Dependencies

NONE

## Impact

NONE