### PR TITLE
Set tropopause pressure opt consistent w/ GSI

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/getvalues.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/getvalues.yaml
@@ -1,3 +1,4 @@
 variable change:
   variable change name: Model2GeoVaLs
   hydrometeor effective radii method: gsi
+  tropopause pressure method: gsi


### PR DESCRIPTION
## Description

This has been found sometime ago to be missing setting in SWELL. To be consistent w/ GSI we need to the Model2GeoVal to the formulation of GSI to calculate tropopause pressure.

## Dependencies

None

## Impact

None
