### PR TITLE
Revise emis coeffs in light of troubled JEDI

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
@@ -241,7 +241,9 @@ obs post filters:
       options:
         channels: *airs_aqua_channels
         sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#       obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#   Todling: return to compensate for unknown IR emis issue
+        obserr_demisf: [0.20, 0.40, 0.45, 0.40, 0.45]
         obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
 #  Gross check
 - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-b.yaml
@@ -178,7 +178,9 @@ obs post filters:
       options:
         channels: *avhrr3_metop-b_channels
         sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#       obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#   Todling: return to compensate for unknown IR emis issue
+        obserr_demisf: [0.20, 0.40, 0.45, 0.40, 0.45] 
         obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
 # Gross check
 - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n18.yaml
@@ -178,7 +178,9 @@ obs post filters:
       options:
         channels: *avhrr3_n18_channels
         sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#       obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#   Todling: return to compensate for unknown IR emis issue
+        obserr_demisf: [0.20, 0.40, 0.45, 0.40, 0.45] 
         obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
 # Gross check
 - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
@@ -178,7 +178,9 @@ obs post filters:
       options:
         channels: *avhrr3_n19_channels
         sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#       obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#   Todling: return to compensate for unknown IR emis issue
+        obserr_demisf: [0.20, 0.40, 0.45, 0.40, 0.45]
         obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
 # Gross check
 - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
@@ -282,7 +282,9 @@ obs post filters:
       options:
         channels: *cris-fsr_n20_channels
         sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#       obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#   Todling: return to compensate for unknown IR emis issue
+        obserr_demisf: [0.20, 0.40, 0.45, 0.40, 0.45] 
         obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
 # Gross check
 - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
@@ -284,7 +284,7 @@ obs post filters:
         sensor: *Sensor_ID
 #       obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
 #   Todling: return to compensate for unknown IR emis issue
-        obserr_demisf: [0.20, 0.40, 0.45, 0.40, 0.45] 
+        obserr_demisf: [0.05, 0.10, 0.15, 0.10, 0.15] 
         obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
 # Gross check
 - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
@@ -284,7 +284,7 @@ obs post filters:
         sensor: *Sensor_ID
 #       obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
 #   Todling: return to compensate for unknown IR emis issue
-        obserr_demisf: [0.20, 0.40, 0.45, 0.40, 0.45] 
+        obserr_demisf: [0.05, 0.10, 0.15, 0.10, 0.15] 
         obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
 # Gross check
 - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
@@ -282,7 +282,9 @@ obs post filters:
       options:
         channels: *cris-fsr_npp_channels
         sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#       obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#   Todling: return to compensate for unknown IR emis issue
+        obserr_demisf: [0.20, 0.40, 0.45, 0.40, 0.45] 
         obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
 # Gross check
 - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
@@ -309,7 +309,9 @@ obs post filters:
       options:
         channels: *iasi_metop-b_channels
         sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#       obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#   Todling: return to compensate for unknown IR emis issue
+        obserr_demisf: [0.20, 0.40, 0.45, 0.40, 0.45] 
         obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
 # Gross check
 - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
@@ -309,7 +309,9 @@ obs post filters:
       options:
         channels: *iasi_metop-c_channels
         sensor: *Sensor_ID
-        obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#       obserr_demisf: [0.01, 0.02, 0.03, 0.02, 0.03]
+#   Todling: return to compensate for unknown IR emis issue
+        obserr_demisf: [0.20, 0.40, 0.45, 0.40, 0.45] 
         obserr_dtempf: [0.50, 2.00, 4.00, 2.00, 4.00]
 # Gross check
 - filter: Background Check


### PR DESCRIPTION
## Description

After considerable looking I find that a temporary solution to the issue associated with the very large increments of T-skin obtained from IR instruments in JEDI can be alleviated by rescaling the emissivity coeffs in the surface Jacobian filter as indicated here.

I have long discussions in the SWELL issue:

- issue #426 

and also - even more extensive here: https://github.com/orgs/JCSDA-internal/discussions/156

The palliative being put forward here meant to allow GMAO to run with a JEDI configuration with known issues minimized as much as possible. 

It is still necessary to look more carefully at this and figure try to figure out why JEDI gets  such large IR emissivities to begin with.   

## Dependencies

None

## Impact

Much more reasonable results.
