### PR TITLE
All-sky MW linear op should have only water-temperature

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
@@ -24,7 +24,7 @@ obs operator:
   linear obs operator:
     Absorbers: [H2O,O3]
     Clouds: [Water,Ice,Rain,Snow]
-    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
+    Surfaces: [Water_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/amsr2_gcom-w1.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
@@ -23,7 +23,7 @@ obs operator:
   linear obs operator:
     Absorbers: [H2O,O3]
     Clouds: [Water,Ice,Rain,Snow]
-    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
+    Surfaces: [Water_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/gmi_gpm.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
@@ -23,7 +23,7 @@ obs operator:
   linear obs operator:
     Absorbers: [H2O,O3]
     Clouds: [Water, Ice, Rain, Snow]
-    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
+    Surfaces: [Water_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/mhs_metop-b.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
@@ -23,7 +23,7 @@ obs operator:
   linear obs operator:
     Absorbers: [H2O,O3]
     Clouds: [Water, Ice, Rain, Snow]
-    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
+    Surfaces: [Water_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/mhs_metop-c.{{background_time}}.satbias.nc4'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
@@ -23,7 +23,7 @@ obs operator:
   linear obs operator:
     Absorbers: [H2O,O3]
     Clouds: [Water, Ice, Rain, Snow]
-    Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
+    Surfaces: [Water_Temperature]
 
 obs bias:
   input file: '{{cycle_dir}}/mhs_n19.{{background_time}}.satbias.nc4'


### PR DESCRIPTION
## Description

This is to address issue #469 

## Dependencies

none

## Impact

none
