### PR TITLE
MHS QC associated w/ surface jacobian was missing

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
@@ -229,6 +229,23 @@ obs filters:
       channels: *mhs_metop-b_available_channels
       options:
         channels: *mhs_metop-b_available_channels
+# Surface Jacobian check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-b_available_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
+        channels: *mhs_metop-b_available_channels
+        options:
+          channels: *mhs_metop-b_available_channels
+          sensor: *Sensor_ID
+#         use_biasterm: true
+          test_biasterm: ObsBiasTerm   
+          obserr_demisf: [0.015, 0.090, 0.060, 0.060, 0.750]
+          obserr_dtempf: [0.500, 6.000, 3.000, 6.000, 15.00]
 #Gross check
 - filter: Background Check
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
@@ -229,6 +229,23 @@ obs filters:
       channels: *mhs_metop-c_available_channels
       options:
         channels: *mhs_metop-c_available_channels
+# Surface Jacobian check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_metop-c_available_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
+        channels: *mhs_metop-c_available_channels
+        options:
+          channels: *mhs_metop-c_available_channels
+          sensor: *Sensor_ID
+          use_biasterm: true
+#         test_biasterm: ObsBiasTerm
+          obserr_demisf: [0.015, 0.090, 0.060, 0.060, 0.750]
+          obserr_dtempf: [0.500, 6.000, 3.000, 6.000, 15.00]
 #Gross check
 - filter: Background Check
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
@@ -229,6 +229,23 @@ obs filters:
       channels: *mhs_n19_available_channels
       options:
         channels: *mhs_n19_available_channels
+# Surface Jacobian check
+  - filter: BlackList
+    filter variables:
+    - name: brightnessTemperature
+      channels: *mhs_n19_available_channels
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorSurfJacobianRad
+        channels: *mhs_n19_available_channels
+        options:
+          channels: *mhs_n19_available_channels
+          sensor: *Sensor_ID
+#         use_biasterm: true
+          test_biasterm: ObsBiasTerm
+          obserr_demisf: [0.015, 0.090, 0.060, 0.060, 0.750]
+          obserr_dtempf: [0.500, 6.000, 3.000, 6.000, 15.00]
 #Gross check
 - filter: Background Check
   filter variables:


### PR DESCRIPTION
## Description

Following what is in GSI, this filter associated w/ the surface Jacobians had been missing in yaml settings for MHS.

## Dependencies

None

## Impact

None