### PR TITLE
MW: Revised coeffs scalling emissivity term in surf Jacobian

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
@@ -147,7 +147,7 @@ obs post filters:
           sensor: *Sensor_ID
           use_biasterm: true
           test_biasterm: ObsBiasTerm
-          obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+          obserr_demisf: [0.050, 0.100, 0.075, 0.100, 0.200]
           obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 # Gross check
   - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
@@ -147,7 +147,7 @@ obs post filters:
           sensor: *Sensor_ID
           use_biasterm: true
           test_biasterm: ObsBiasTerm
-          obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+          obserr_demisf: [0.050, 0.100, 0.075, 0.100, 0.200]
           obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 # Gross check
   - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
@@ -147,7 +147,7 @@ obs post filters:
           sensor: *Sensor_ID
           use_biasterm: true
           test_biasterm: ObsBiasTerm
-          obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+          obserr_demisf: [0.050, 0.100, 0.075, 0.100, 0.200]
           obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 # Gross check
   - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
@@ -147,7 +147,7 @@ obs post filters:
           sensor: *Sensor_ID
           use_biasterm: true
           test_biasterm: ObsBiasTerm
-          obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+          obserr_demisf: [0.050, 0.100, 0.075, 0.100, 0.200]
           obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 # Gross check
   - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
@@ -147,7 +147,7 @@ obs post filters:
           sensor: *Sensor_ID
           use_biasterm: true
           test_biasterm: ObsBiasTerm
-          obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+          obserr_demisf: [0.050, 0.100, 0.075, 0.100, 0.200]
           obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 # Gross check
   - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
@@ -149,7 +149,7 @@ obs post filters:
           use_biasterm: true
           test_biasterm: ObsBiasTerm
           sensor: *Sensor_ID
-          obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+          obserr_demisf: [0.050, 0.100, 0.075, 0.100, 0.200]
           obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 # Gross check
   - filter: Background Check

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
@@ -149,7 +149,7 @@ obs post filters:
           use_biasterm: true
           test_biasterm: ObsBiasTerm
           sensor: *Sensor_ID
-          obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+          obserr_demisf: [0.050, 0.100, 0.075, 0.100, 0.200]
           obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 # Gross check
   - filter: Background Check


### PR DESCRIPTION
## Description

Though much less that for IR, the emissivity terms for the surface Jacobian for AMSUA and ATMS also seem to benefit from a revision -  all, expect mixed surfaces are multiplied by a factor of 5.

here is an illustration of 2 JEDI swell configurations (default; top)) and the one proposed here (bot) compared agains GSI - the figs are for Tskin increment differences w/ GSI.

 
<img width="659" alt="ts-dueAllMW-diff-gsiX2jedi" src="https://github.com/user-attachments/assets/b17c25f2-ed3e-42ac-8f6e-181db9a99496">

## Dependencies

None

## Impact

None
