### PR TITLE
Revise obs space localization for LETKF

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setuptools.setup(
                'configuration/*/*/*',
                'configuration/*/*/*/*',
                'configuration/*/*/*/*/*',
+               'configuration/*/*/*/*/*/*',
                'utilities/pinned_versions/*.yaml'
              ],
     },

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/aircraft.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/aircraft.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/airs_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/airs_aqua.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsr2_gcom-w1.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_aqua.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_metop-b.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_metop-c.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_n15.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_n15.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_n18.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/amsua_n19.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/atms_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/atms_n20.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/atms_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/atms_npp.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/avhrr3_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/avhrr3_metop-b.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/avhrr3_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/avhrr3_n18.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/avhrr3_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/avhrr3_n19.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/cris-fsr_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/cris-fsr_n20.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/cris-fsr_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/cris-fsr_npp.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/gmi_gpm.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/gmi_gpm.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/gps.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/gps.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/iasi_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/iasi_metop-b.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/iasi_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/iasi_metop-c.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/mhs_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/mhs_metop-b.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/mhs_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/mhs_metop-c.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/mhs_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/mhs_n19.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/mls55_aura.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/mls55_aura.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/obsop_name_map.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/obsop_name_map.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/omi_aura.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/omi_aura.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/ompsnm_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/ompsnm_npp.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/pibal.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/pibal.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/satwind.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/satwind.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/scatwind.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/scatwind.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/sfc.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/sfcship.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/sfcship.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/sondes.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/sondes.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/ssmis_f17.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/localization/ssmis_f17.yaml
@@ -1,4 +1,4 @@
 obs localizations:
   localization method: Horizontal Gaspari-Cohn
-  lengthscale: 1000.e3
+  lengthscale: 500.e3
   max nobs: 100

--- a/src/swell/tasks/run_jedi_local_ensemble_da_executable.py
+++ b/src/swell/tasks/run_jedi_local_ensemble_da_executable.py
@@ -129,10 +129,10 @@ class RunJediLocalEnsembleDaExecutable(taskBase):
         # Prevent both 'local_ensemble_save_posterior_mean' and
         # 'local_ensemble_save_posterior_ensemble' from being true
         # --------------------------------------------------------
-        if not self.config.local_ensemble_save_posterior_mean() ^ \
+        if self.config.local_ensemble_save_posterior_mean() or \
            self.config.local_ensemble_save_posterior_ensemble():
-            raise ValueError("Only one of 'local_ensemble_save_posterior_mean' and\
-            'local_ensemble_save_posterior_ensemble' may be true at once!")
+            raise ValueError("'local_ensemble_save_posterior_mean' and\
+            'local_ensemble_save_posterior_ensemble' cannot be both true!")
 
         # Jedi configuration file
         # -----------------------
@@ -185,6 +185,14 @@ class RunJediLocalEnsembleDaExecutable(taskBase):
                 observer.update({'obs localizations': localization})
                 observer['obs space'].update(
                     {'distribution': {'name': 'Halo', 'halo size': 5000.e3}})
+
+        # bypass the writing of HofXs
+        # -------------------------------------------------------------------
+
+        bypass_HofXs = True
+        if bypass_HofXs:
+            for observer in jedi_config_dict['observations']['observers']:
+                del observer['obs space']['obsdataout']
 
         # Write the expanded dictionary to YAML file
         # ------------------------------------------

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -537,7 +537,7 @@ local_ensemble_inflation_rtps:
 
 local_ensemble_save_posterior_ensemble:
   ask_question: false
-  default_value: true
+  default_value: false
   models:
   - geos_atmosphere
   options:

--- a/src/swell/test/suite_tests/localensembleda-tier1.yaml
+++ b/src/swell/test/suite_tests/localensembleda-tier1.yaml
@@ -11,7 +11,7 @@ models:
 #    - T06
 #    - T12
 #    - T18
-    ensemble_num_members:  32
+    ensemble_num_members:  5
     skip_ensemble_hofx: true
     local_ensemble_solver: GETKF
     local_ensemble_use_linear_observer: true
@@ -21,38 +21,9 @@ models:
     path_to_ensemble: /discover/nobackup/projects/gmao/advda/SwellTestData/letk/ensemble/91/Y%Y/M%m/D%d/H%H/geos*%Y%m%d_%H%M%Sz.nc4
     observations:
     - aircraft
-    - airs_aqua
-    - amsr2_gcom-w1
-    - amsua_aqua
-    - amsua_metop-b
-    - amsua_metop-c
-    - amsua_n15
-    - amsua_n18
-    - amsua_n19
-    - atms_n20
-    - atms_npp
-    - avhrr3_metop-b
-    - avhrr3_n18
-    - avhrr3_n19
-    - cris-fsr_n20
-    - cris-fsr_npp
-    - gmi_gpm
-    - gps
-    - iasi_metop-b
-    - iasi_metop-c
-    - mhs_metop-b
-    - mhs_metop-c
-    - mhs_n19
-    - mls55_aura
-    - omi_aura
-    - ompsnm_npp
-    - pibal
-    - satwind
-    - scatwind
-    - sfcship
-    - sfc
     - sondes
-    - ssmis_f17
+    - gps
+    - amsua_metop-b
     background_experiment: x0048
     window_type: 3D
     clean_patterns:

--- a/src/swell/test/suite_tests/localensembleda-tier1.yaml
+++ b/src/swell/test/suite_tests/localensembleda-tier1.yaml
@@ -20,30 +20,39 @@ models:
     ensmean_only: false
     path_to_ensemble: /discover/nobackup/projects/gmao/advda/SwellTestData/letk/ensemble/91/Y%Y/M%m/D%d/H%H/geos*%Y%m%d_%H%M%Sz.nc4
     observations:
-    - sondes
+    - aircraft
+    - airs_aqua
+    - amsr2_gcom-w1
     - amsua_aqua
     - amsua_metop-b
-#    - amsua_metop-c
-#    - amsua_n15
-#    - amsua_n18
-#    - amsua_n19
-#    - amsr2_gcom-w1
-#    - atms_n20
-#    - atms_npp
-#    - avhrr3_metop-b
-#    - avhrr3_n18
-#    - avhrr3_n19
-#    - scatwind
-#    - sfcship
-#    - sfc
-#    - mhs_metop-b
-#    - mhs_metop-c
-#    - mhs_n19
-#    - mls55_aura
-#    - omi_aura
-#    - ompsnm_npp
-#    - pibal
-#    - ssmis_f17
+    - amsua_metop-c
+    - amsua_n15
+    - amsua_n18
+    - amsua_n19
+    - atms_n20
+    - atms_npp
+    - avhrr3_metop-b
+    - avhrr3_n18
+    - avhrr3_n19
+    - cris-fsr_n20
+    - cris-fsr_npp
+    - gmi_gpm
+    - gps
+    - iasi_metop-b
+    - iasi_metop-c
+    - mhs_metop-b
+    - mhs_metop-c
+    - mhs_n19
+    - mls55_aura
+    - omi_aura
+    - ompsnm_npp
+    - pibal
+    - satwind
+    - scatwind
+    - sfcship
+    - sfc
+    - sondes
+    - ssmis_f17
     background_experiment: x0048
     window_type: 3D
     clean_patterns:

--- a/src/swell/test/suite_tests/localensembleda-tier1.yaml
+++ b/src/swell/test/suite_tests/localensembleda-tier1.yaml
@@ -15,9 +15,11 @@ models:
     skip_ensemble_hofx: true
     local_ensemble_solver: GETKF
     local_ensemble_use_linear_observer: true
-    local_ensemble_save_posterior_mean: false
-    local_ensemble_save_posterior_ensemble_increments: true
     ensmean_only: false
+    local_ensemble_save_posterior_mean: false                 # default: false
+    local_ensemble_save_posterior_mean_increment: true        # default: true
+    local_ensemble_save_posterior_ensemble: false             # default: false
+    local_ensemble_save_posterior_ensemble_increments: false  # default: false
     path_to_ensemble: /discover/nobackup/projects/gmao/advda/SwellTestData/letk/ensemble/91/Y%Y/M%m/D%d/H%H/geos*%Y%m%d_%H%M%Sz.nc4
     observations:
     - aircraft


### PR DESCRIPTION
## Description

The original lenghscales were generating a completely noisy, unphysical, increment. 

I don't claim scientific correctness ... just reasonableness. Here is the T-500 increment original and after the revised scales:

<img width="659" alt="letkf_loc500" src="https://github.com/user-attachments/assets/23ef3fe4-c72d-46b8-8faf-c723455f3ba5">

Note these results use 32 members, at c90 resolution. I will suggest we change to more than 2 members for testing purposes in swell - in another PR - I don't think 2 members makes any sense.

## Dependencies

None

## Impact

None
