### PR TITLE
MW (AllSky): Missing Surf Jacobian check

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
@@ -189,6 +189,22 @@ obs filters:
         err1:  [  5.0,  5.0,  5.0,  5.0,  5.0, 18.5,
                  20.0, 40.0, 20.0, 25.0, 30.0, 30.0,
                  30.0, 20.0]
+- filter: BlackList
+  filter variables:
+  - name: brightnessTemperature
+    channels: *amsr2_gcom-w1_available_channels
+  action:
+    name: inflate error
+    inflation variable:
+      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+      channels: *amsr2_gcom-w1_available_channels
+      options:
+        channels: *amsr2_gcom-w1_available_channels
+        sensor: *Sensor_ID
+        use_biasterm: true
+        test_biasterm: ObsBiasTerm
+        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 - filter: Background Check
   apply at iterations: 0, 1
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
@@ -189,22 +189,23 @@ obs filters:
         err1:  [  5.0,  5.0,  5.0,  5.0,  5.0, 18.5,
                  20.0, 40.0, 20.0, 25.0, 30.0, 30.0,
                  30.0, 20.0]
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *amsr2_gcom-w1_available_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
-      channels: *amsr2_gcom-w1_available_channels
-      options:
-        channels: *amsr2_gcom-w1_available_channels
-        sensor: *Sensor_ID
-        use_biasterm: true
-        test_biasterm: ObsBiasTerm
-        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
-        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
+# RT: Why does the following not work?
+#- filter: BlackList
+#  filter variables:
+#  - name: brightnessTemperature
+#    channels: *amsr2_gcom-w1_available_channels
+#  action:
+#    name: inflate error
+#    inflation variable:
+#      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+#      channels: *amsr2_gcom-w1_available_channels
+#      options:
+#        channels: *amsr2_gcom-w1_available_channels
+#        sensor: *Sensor_ID
+#        use_biasterm: true
+#        test_biasterm: ObsBiasTerm
+#        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+#        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 - filter: Background Check
   apply at iterations: 0, 1
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
@@ -110,19 +110,6 @@ obs filters:
   filter variables:
   - name: brightnessTemperature
     channels: *gmi_gpm_available_channels
-  where:
-  - variable:
-      name: MetaData/latitude
-    minvalue: -20.0
-    maxvalue: 0.0
-  - variable:
-      name: MetaData/longitude
-    minvalue: 25.0
-    maxvalue: 40.0
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *gmi_gpm_available_channels
   action:        
     name: inflate error  
     inflation variable:
@@ -135,6 +122,19 @@ obs filters:
         test_biasterm: ObsBiasTerm
         obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
         obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
+- filter: BlackList
+  filter variables:
+  - name: brightnessTemperature
+    channels: *gmi_gpm_available_channels
+  where:
+  - variable:
+      name: MetaData/latitude
+    minvalue: -20.0
+    maxvalue: 0.0
+  - variable:
+      name: MetaData/longitude
+    minvalue: 25.0
+    maxvalue: 40.0
 # Save CLW retrievals from ObsValue
 - filter: Variable Assignment
   assignments:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
@@ -119,6 +119,22 @@ obs filters:
       name: MetaData/longitude
     minvalue: 25.0
     maxvalue: 40.0
+- filter: BlackList
+  filter variables:
+  - name: brightnessTemperature
+    channels: *gmi_gpm_available_channels
+  action:        
+    name: inflate error  
+    inflation variable:
+      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+      channels: *gmi_gpm_available_channels
+      options:
+        channels: *gmi_gpm_available_channels
+        sensor: *Sensor_ID
+        use_biasterm: true
+        test_biasterm: ObsBiasTerm
+        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 # Save CLW retrievals from ObsValue
 - filter: Variable Assignment
   assignments:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
@@ -142,6 +142,23 @@ obs filters:
   - variable:
       name: GeoVaLs/average_surface_temperature_within_field_of_view
     maxvalue: 275
+# RT: Why does the following not work?
+#- filter: BlackList
+#  filter variables:
+#  - name: brightnessTemperature
+#    channels: *mhs_metop-b_available_channels
+#  action:
+#    name: inflate error
+#    inflation variable:
+#      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+#      channels: *mhs_metop-b_available_channels
+#      options:
+#        channels: *mhs_metop-b_available_channels
+#        sensor: *Sensor_ID
+#        use_biasterm: true
+#        test_biasterm: ObsBiasTerm
+#        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+#        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 - filter: BlackList
   filter variables:
   - name: brightnessTemperature
@@ -229,22 +246,6 @@ obs filters:
       channels: *mhs_metop-b_available_channels
       options:
         channels: *mhs_metop-b_available_channels
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *mhs_metop-b_available_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
-      channels: *mhs_metop-b_available_channels
-      options:
-        channels: *mhs_metop-b_available_channels
-        sensor: *Sensor_ID
-        use_biasterm: true
-        test_biasterm: ObsBiasTerm
-        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
-        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 #Gross check
 - filter: Background Check
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
@@ -229,6 +229,22 @@ obs filters:
       channels: *mhs_metop-b_available_channels
       options:
         channels: *mhs_metop-b_available_channels
+- filter: BlackList
+  filter variables:
+  - name: brightnessTemperature
+    channels: *mhs_metop-b_available_channels
+  action:
+    name: inflate error
+    inflation variable:
+      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+      channels: *mhs_metop-b_available_channels
+      options:
+        channels: *mhs_metop-b_available_channels
+        sensor: *Sensor_ID
+        use_biasterm: true
+        test_biasterm: ObsBiasTerm
+        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 #Gross check
 - filter: Background Check
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
@@ -142,6 +142,23 @@ obs filters:
   - variable:
       name: GeoVaLs/average_surface_temperature_within_field_of_view
     maxvalue: 275
+# RT: Why does the following not work?
+#- filter: BlackList
+#  filter variables:
+#  - name: brightnessTemperature
+#    channels: *mhs_metop-c_available_channels
+#  action:
+#    name: inflate error
+#    inflation variable:
+#      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+#      channels: *mhs_metop-c_available_channels
+#      options:
+#        channels: *mhs_metop-c_available_channels
+#        sensor: *Sensor_ID
+#        use_biasterm: true
+#        test_biasterm: ObsBiasTerm
+#        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+#        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 - filter: BlackList
   filter variables:
   - name: brightnessTemperature
@@ -229,22 +246,6 @@ obs filters:
       channels: *mhs_metop-c_available_channels
       options:
         channels: *mhs_metop-c_available_channels
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *mhs_metop-c_available_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
-      channels: *mhs_metop-c_available_channels
-      options:
-        channels: *mhs_metop-c_available_channels
-        sensor: *Sensor_ID
-        use_biasterm: true
-        test_biasterm: ObsBiasTerm
-        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
-        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 #Gross check
 - filter: Background Check
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
@@ -229,6 +229,22 @@ obs filters:
       channels: *mhs_metop-c_available_channels
       options:
         channels: *mhs_metop-c_available_channels
+- filter: BlackList
+  filter variables:
+  - name: brightnessTemperature
+    channels: *mhs_metop-c_available_channels
+  action:
+    name: inflate error
+    inflation variable:
+      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+      channels: *mhs_metop-c_available_channels
+      options:
+        channels: *mhs_metop-c_available_channels
+        sensor: *Sensor_ID
+        use_biasterm: true
+        test_biasterm: ObsBiasTerm
+        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 #Gross check
 - filter: Background Check
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
@@ -142,6 +142,23 @@ obs filters:
   - variable:
       name: GeoVaLs/average_surface_temperature_within_field_of_view
     maxvalue: 275
+# RT: Why does the following not work?
+#- filter: BlackList
+#  filter variables:
+#  - name: brightnessTemperature
+#    channels: *mhs_n19_available_channels
+#  action:
+#    name: inflate error
+#    inflation variable:
+#      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+#      channels: *mhs_n19_available_channels
+#      options:
+#        channels: *mhs_n19_available_channels
+#        sensor: *Sensor_ID
+#        use_biasterm: true
+#        test_biasterm: ObsBiasTerm
+#        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+#        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 - filter: BlackList
   filter variables:
   - name: brightnessTemperature
@@ -229,22 +246,6 @@ obs filters:
       channels: *mhs_n19_available_channels
       options:
         channels: *mhs_n19_available_channels
-- filter: BlackList
-  filter variables:
-  - name: brightnessTemperature
-    channels: *mhs_n19_available_channels
-  action:
-    name: inflate error
-    inflation variable:
-      name: ObsFunction/ObsErrorFactorSurfJacobianRad
-      channels: *mhs_n19_available_channels
-      options:
-        channels: *mhs_n19_available_channels
-        sensor: *Sensor_ID
-        use_biasterm: true
-        test_biasterm: ObsBiasTerm
-        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
-        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 #Gross check
 - filter: Background Check
   filter variables:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
@@ -229,6 +229,22 @@ obs filters:
       channels: *mhs_n19_available_channels
       options:
         channels: *mhs_n19_available_channels
+- filter: BlackList
+  filter variables:
+  - name: brightnessTemperature
+    channels: *mhs_n19_available_channels
+  action:
+    name: inflate error
+    inflation variable:
+      name: ObsFunction/ObsErrorFactorSurfJacobianRad
+      channels: *mhs_n19_available_channels
+      options:
+        channels: *mhs_n19_available_channels
+        sensor: *Sensor_ID
+        use_biasterm: true
+        test_biasterm: ObsBiasTerm
+        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
 #Gross check
 - filter: Background Check
   filter variables:


### PR DESCRIPTION
## Description

I believe these the surface Jacobian check is missing from the All-sky MW obs yam files.

I believe this should be on for all MW - including those treated as all-sky ... when I do it for GMI I have no problems and indeed see the increment of Ts (without modified any of the coeffs being contested in another PR) seem to get closer to GSI's  ... here is a fig of increments of Tskin differences w/ the GSI increment when JEDI does no include the surface Jac term (top) and when it does (bottom).

 
<img width="657" alt="gmi-sfcjac-incdiff" src="https://github.com/user-attachments/assets/b4a913af-6bb7-4e75-9e93-cd4bd897ad64" />

unfortunately, JEDI doesn't seem to like when this term is added to the MHS 

## Dependencies

None

## Impact

