### PR TITLE
Keep the order of YAML configurations within run tasks

### DIFF
--- a/src/swell/tasks/run_jedi_variational_executable.py
+++ b/src/swell/tasks/run_jedi_variational_executable.py
@@ -124,8 +124,8 @@ class RunJediVariationalExecutable(taskBase):
             # Construct an OrderedDict from a YAML mapping
             return OrderedDict(loader.construct_pairs(node))
 
-        def dict_to_ordereddict(d):
         # Recursive conversion, dictionary to an OrderedDict
+        def dict_to_ordereddict(d):
             if isinstance(d, dict):
                 return OrderedDict((k, dict_to_ordereddict(v)) for k, v in d.items())
             elif isinstance(d, list):


### PR DESCRIPTION
In `Run..` tasks the configurations are put together by the `jedi_dictionary_iterator` method and gets reordered alphabetically. This PR fixes that, see #409 for more details.

This closes #409 for now. There could be better ways but @rtodling needs a quick solution.

I mentioned some other options here:
https://github.com/GEOS-ESM/swell/issues/409#issuecomment-2293740551
