### PR TITLE
Platform for cascade lake nodes running sles15

### DIFF
--- a/docs/platforms/discover/configuring_cylc_discover.md
+++ b/docs/platforms/discover/configuring_cylc_discover.md
@@ -66,6 +66,10 @@ Create a file called `$HOME/.cylc/flow/global.cylc` and fill it with the followi
     job runner = slurm
     install target = localhost
     hosts = localhost
+  [[nccs_discover_cascade]]
+    job runner = slurm
+    install target = localhost
+    hosts = localhost
   [[nccs_discover_sles15]]
     job runner = slurm
     install target = localhost

--- a/src/swell/deployment/platforms/nccs_discover_cascade/__init__.py
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/__init__.py
@@ -1,0 +1,9 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+import os
+
+repo_directory = os.path.dirname(__file__)

--- a/src/swell/deployment/platforms/nccs_discover_cascade/modules
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/modules
@@ -1,0 +1,60 @@
+# Module initialization
+# ---------------------
+source /usr/share/lmod/lmod/init/bash
+
+# Purge modules
+# -------------
+module purge
+
+# Spack stack modules
+# -------------------
+module use /discover/swdev/jcsda/spack-stack/scu16/modulefiles
+module load ecflow/5.11.4
+module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.7.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
+module load stack-intel/2021.10.0
+module load stack-intel-oneapi-mpi/2021.10.0
+module load stack-python/3.10.13
+module load git-lfs/3.4.0
+module load py-pip/23.1.2
+module load jedi-fv3-env
+module load soca-env
+module load gmao-swell-env/1.0.0
+module unload gsibec crtm fms
+module load fms/2023.04
+
+# JEDI Python Path
+# ----------------
+PYTHONPATH={{experiment_root}}/{{experiment_id}}/jedi_bundle/build/lib/python{{python_majmin}}:$PYTHONPATH
+
+# Aircraft Bias Python Path
+# -------------------------
+PYTHONPATH={{experiment_root}}/{{experiment_id}}/jedi_bundle/source/iodaconv/src/gsi_varbc:$PYTHONPATH
+
+# Load GEOS modules
+# -----------------
+module use -a /discover/swdev/gmao_SIteam/modulefiles-SLES15
+module load other/mepo
+
+# Load r2d2 modules
+# -----------------
+module use -a /discover/nobackup/projects/gmao/advda/JediOpt/modulefiles/core
+module load solo/sles15_skylab7
+module load py-boto3
+module load r2d2/sles15_skylab7
+
+# Load eva and jedi_bundle
+# ------------------------
+module load eva/sles15_1.6.1
+module load jedi_bundle/sles15_skylab7
+
+# Set the swell paths
+# -------------------
+PATH={{swell_bin_path}}:$PATH
+PYTHONPATH={{swell_lib_path}}:$PYTHONPATH
+
+# Unlimited Stacksize
+# -------------------
+ulimit -S -s unlimited
+ulimit -S -v unlimited
+umask 022
+

--- a/src/swell/deployment/platforms/nccs_discover_cascade/modules
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/modules
@@ -8,9 +8,9 @@ module purge
 
 # Spack stack modules
 # -------------------
-module use /discover/swdev/jcsda/spack-stack/scu16/modulefiles
+module use /discover/swdev/jcsda/spack-stack/scu17/modulefiles
 module load ecflow/5.11.4
-module use /gpfsm/dswdev/jcsda/spack-stack/scu16/spack-stack-1.7.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
+module use /gpfsm/dswdev/jcsda/spack-stack/scu17/spack-stack-1.7.0/envs/ue-intel-2021.10.0/install/modulefiles/Core
 module load stack-intel/2021.10.0
 module load stack-intel-oneapi-mpi/2021.10.0
 module load stack-python/3.10.13

--- a/src/swell/deployment/platforms/nccs_discover_cascade/properties.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/properties.yaml
@@ -1,0 +1,3 @@
+hostname:
+  login: discover
+  compute: borg

--- a/src/swell/deployment/platforms/nccs_discover_cascade/r2d2_config.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/r2d2_config.yaml
@@ -1,0 +1,22 @@
+databases:
+
+  ${USER}:
+    class: LocalDB
+    root: {{r2d2_local_path}}
+    cache_fetch: false
+
+  gmao-shared:
+    class: LocalDB
+    root: /discover/nobackup/projects/gmao/advda/R2D2DataStore/Shared
+    cache_fetch: false
+
+# when fetching data, in which order should the databases accessed?
+fetch_order:
+  - ${USER}
+  - gmao-shared
+
+# when storing data, in which order should the databases accessed?
+store_order:
+  - ${USER}
+
+cache_name: ${USER}

--- a/src/swell/deployment/platforms/nccs_discover_cascade/slurm.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/slurm.yaml
@@ -1,0 +1,6 @@
+qos: allnccs
+nodes: 1
+ntasks-per-node: 24
+reservation: sles15_cas
+constraint: cas
+no-requeue: ''

--- a/src/swell/deployment/platforms/nccs_discover_cascade/suite_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/suite_questions.yaml
@@ -1,0 +1,2 @@
+experiment_root:
+  default_value: /discover/nobackup/${USER}/SwellExperiments

--- a/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
@@ -1,0 +1,33 @@
+crtm_coeff_dir:
+  default_value: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1/
+
+existing_geos_gcm_build_path:
+  default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.6.0/install-SLES15
+
+existing_geos_gcm_source_path:
+  default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.6.0/
+
+existing_jedi_build_directory:
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15/build-intel-release
+
+existing_jedi_build_directory_pinned:
+  default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/build/
+
+existing_jedi_source_directory:
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15
+
+existing_jedi_source_directory_pinned:
+  default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles/current_pinned_jedi_bundle/source/
+
+geos_experiment_directory:
+  default_value: 5deg_v11
+
+geos_restarts_directory:
+  default_value: restarts_20210601_030000
+
+r2d2_local_path:
+  default_value: /discover/nobackup/${USER}/R2D2DataStore/Local
+
+swell_static_files:
+  default_value: /discover/nobackup/projects/gmao/advda/SwellStaticFiles
+

--- a/src/swell/test/code_tests/slurm_test.py
+++ b/src/swell/test/code_tests/slurm_test.py
@@ -56,6 +56,10 @@ class SLURMConfigTest(unittest.TestCase):
         self.assertEqual(sd_discover["RunJediVariationalExecutable"]["directives"]["all"]
                          ["constraint"], "cas|sky")
 
+        with self.assertRaises(AssertionError):
+            prepare_scheduling_dict(logger, experiment_dict,
+                                    platform="nccs_discover_sles15")
+
         platform_mocked.return_value = "Linux-5.14.21"
         sd_discover_sles15 = prepare_scheduling_dict(logger, experiment_dict,
                                                      platform="nccs_discover_sles15")
@@ -63,10 +67,6 @@ class SLURMConfigTest(unittest.TestCase):
                          ["all"]["constraint"], "mil")
         self.assertEqual(sd_discover_sles15["RunJediVariationalExecutable"]["directives"]
                          ["all"]["qos"], "dastest")
-
-        with self.assertRaises(AssertionError):
-            prepare_scheduling_dict(logger, experiment_dict,
-                                    platform="nccs_discover")
 
         # Platform generic tests
         for sd in [sd_discover, sd_discover_sles15]:

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -58,9 +58,9 @@ def prepare_scheduling_dict(
     user_globals = slurm_global_defaults(logger)
 
     # Check if platform contains Linux-5.14.21, which indicates platform is SLES15
-    if 'Linux-5.14.21' in pltfrm.platform():
-        assert platform == "nccs_discover_sles15", (
-            "'Linux-5.14.21' detected, which implies platform 'nccs_discover_sles15. " +
+    if 'Linux-4.12.14' in pltfrm.platform():
+        assert platform == "nccs_discover", (
+            "'Linux-4.12.14' detected, which implies platform 'nccs_discover. " +
             f"That is inconsistent with user-specified platform '{platform}'."
         )
 


### PR DESCRIPTION

This PR adds a platform for cascade lake nodes on Discover running sles15 (#487). I had to adjust the code tests since the convention that ‘sles15=milan node’ is no longer applicable. We probably need to figure out a better way to better distinguish milan and cascade nodes in the future. I tested various methods in the python `platform` package and I couldn’t find one that reports the microarchitecture, they all just report “x68_64”. For now I just changed the platform test so that it asserts that `sles4.12=nccs_discover`