### PR TITLE
A prototype for alternative task and suite questions

### DIFF
--- a/src/swell/deployment/prepare_config_and_suite/prepare_config_and_suite.py
+++ b/src/swell/deployment/prepare_config_and_suite/prepare_config_and_suite.py
@@ -11,6 +11,8 @@
 import copy
 import os
 import yaml
+import importlib
+from dataclasses import asdict
 from typing import Union, Tuple, Optional
 
 from swell.swell_path import get_swell_path
@@ -60,6 +62,7 @@ class PrepareExperimentConfigAndSuite:
         # Store local copy of the inputs
         self.logger = logger
         self.suite = suite
+        self.suite_ind = ('_' if suite[0].isdigit() else '') + suite
         self.platform = platform
         self.override = override
 
@@ -82,6 +85,10 @@ class PrepareExperimentConfigAndSuite:
         suite_file = os.path.join(get_swell_path(), 'suites', self.suite, 'flow.cylc')
         with open(suite_file, 'r') as suite_file_open:
             self.suite_str = suite_file_open.read()
+
+        # Get a list of model-independent and dependent questions
+        self.model_ind_tasks = self.get_suite_task_list_model_ind(self.suite_str)
+        self.model_dep_tasks = self.get_suite_task_list_model_dep(self.suite_str)
 
         # Perform the assembly of the dictionaries that contain all the questions that can possibly
         # be asked. This
@@ -122,15 +129,41 @@ class PrepareExperimentConfigAndSuite:
             prompt: ...
         """
 
-        # Read suite questions into a dictionary
-        suite_questions_file = os.path.join(get_swell_path(), 'suites', 'suite_questions.yaml')
-        with open(suite_questions_file, 'r') as ymlfile:
-            question_dictionary = yaml.safe_load(ymlfile)
+        # Create a dictionary of all suite questions
+        question_dictionary = {}
 
-        # Read task questions into a dictionary
-        task_questions_file = os.path.join(get_swell_path(), 'tasks', 'task_questions.yaml')
-        with open(task_questions_file, 'r') as ymlfile:
-            question_dictionary_tasks = yaml.safe_load(ymlfile)
+        question_list_module = importlib.import_module('swell.suites.suite_question_list')
+        suite_question_list = getattr(question_list_module, 'all_suites').get('questions')
+
+        if hasattr(question_list_module, self.suite_ind):
+            suite_question_list.extend(
+                    getattr(question_list_module, self.suite_ind).get('questions'))
+
+        if suite_question_list is not None:
+            for question in suite_question_list:
+                question_obj = getattr(importlib.import_module(
+                    'swell.suites.suite_questions'), question)
+                question_dictionary[question] = asdict(question_obj)
+
+        # Create a dictionary of all task questions for tasks needed by the suite
+        question_dictionary_tasks = {}
+
+        # Create a dictionary associating each task with its list of questions
+        self.questions_per_task = {}
+
+        for task in self.model_ind_tasks + self.model_dep_tasks[1]:
+            question_list_module = importlib.import_module('swell.tasks.task_question_list')
+            if hasattr(question_list_module, task):
+                task_question_list = getattr(question_list_module, task).get('questions')
+                if task_question_list is not None:
+                    for question in task_question_list:
+                        question_obj = getattr(importlib.import_module(
+                            'swell.tasks.task_questions'), question)
+                        question_dictionary_tasks[question] = asdict(question_obj)
+            else:
+                task_question_list = []
+
+            self.questions_per_task[task] = task_question_list
 
         # Loop through question_dictionary_tasks. If the key does not already exist add to the
         # question_dictionary. If the key does exist then only add the tasks key to the existing
@@ -138,32 +171,6 @@ class PrepareExperimentConfigAndSuite:
         for key, val in question_dictionary_tasks.items():
             if key not in question_dictionary.keys():
                 question_dictionary[key] = val
-            else:
-                # In this case the question is both a suite question and a task question.
-                # To avoid any confusion, only the tasks key is taken from the task dictionary
-                question_dictionary[key]['tasks'] = val['tasks']
-
-        # Iterate over the question_dictionary dictionary and remove keys not associated with this
-        # suite. Note that there might be questions that are not needed by the suite but could still
-        # be needed by the tasks in the suite. These are not removed but the suite key is removed.
-        # Note also that at this point we do not know which tasks will actually be needed so we
-        # can only remove questions that are known not to be needed by the suite.
-        keys_to_remove = []
-        for key, val in question_dictionary.items():
-            if 'suites' in val:
-                # If this suite question needed then skip to the next question
-                if val['suites'] == ['all'] or self.suite in val['suites']:
-                    continue
-                else:
-                    if 'tasks' not in val:
-                        # Question not needed by suite and not a task question: remove
-                        keys_to_remove.append(key)
-                    else:
-                        # Question not needed by suite but might be needed by tasks.
-                        # Reduce to a task only question.
-                        val.pop('suites')
-        for key in keys_to_remove:
-            del question_dictionary[key]
 
         # At this point we can check to see if this is a suite that requires model components
         self.suite_needs_model_components = True
@@ -177,7 +184,7 @@ class PrepareExperimentConfigAndSuite:
         # and questions not required by the suite
         keys_to_remove = []
         for key, val in question_dictionary_model_ind.items():
-            if 'models' in val.keys():
+            if val['models'] is not None:
                 keys_to_remove.append(key)
 
         # Cycle times can be a special case that is needed even when models are not. Though if they
@@ -211,7 +218,7 @@ class PrepareExperimentConfigAndSuite:
         # and questions not required by the suite
         keys_to_remove = []
         for key, val in question_dictionary_model_dep.items():
-            if 'models' not in val.keys():
+            if val['models'] is None:
                 keys_to_remove.append(key)
         for key in keys_to_remove:
             del question_dictionary_model_dep[key]
@@ -225,7 +232,7 @@ class PrepareExperimentConfigAndSuite:
         for model in self.possible_model_components:
             keys_to_remove = []
             for key, val in self.question_dictionary_model_dep[model].items():
-                if val['models'] != ['all'] and model not in val['models']:
+                if val['models'] != ['all_models'] and model not in val['models']:
                     keys_to_remove.append(key)  # Remove if not needed by this model
 
             for key in keys_to_remove:
@@ -381,7 +388,7 @@ class PrepareExperimentConfigAndSuite:
 
             # Ask only the suite questions first
             # ----------------------------------
-            if 'suites' in self.question_dictionary_model_ind[question_key]:
+            if self.question_dictionary_model_ind[question_key]['question_type'] == 'suite':
 
                 # Ask the question
                 self.ask_a_question(self.question_dictionary_model_ind, question_key)
@@ -400,13 +407,10 @@ class PrepareExperimentConfigAndSuite:
 
             # Ask the task questions
             # ----------------------
-            if 'suites' not in self.question_dictionary_model_ind[question_key]:
+            if self.question_dictionary_model_ind[question_key]['question_type'] != 'suite':
 
-                # Get list of tasks for the question
-                question_tasks = self.question_dictionary_model_ind[question_key]['tasks']
-
-                # Check whether any of model_ind_tasks are in question_tasks
-                if any(elem in question_tasks for elem in model_ind_tasks):
+                # Check if the question is associated with any model independent tasks
+                if any(question_key in self.questions_per_task[task] for task in model_ind_tasks):
 
                     # Ask the question
                     self.ask_a_question(self.question_dictionary_model_ind, question_key)
@@ -432,7 +436,7 @@ class PrepareExperimentConfigAndSuite:
             for question_key in model_dict:
 
                 # Ask only the suite questions first
-                if 'suites' in model_dict[question_key]:
+                if model_dict[question_key]['question_type'] == 'suite':
 
                     # Ask the question
                     self.ask_a_question(model_dict, question_key, model)
@@ -456,13 +460,10 @@ class PrepareExperimentConfigAndSuite:
         # -----------------------------------------------------------------------
         for question_key in self.question_dictionary_model_ind:
 
-            if 'tasks' in self.question_dictionary_model_ind[question_key]:
+            if self.question_dictionary_model_ind[question_key]['question_type'] == 'task':
 
-                # Get list of tasks for the question
-                question_tasks = self.question_dictionary_model_ind[question_key]['tasks']
-
-                # Check whether any of model_dep_tasks are in question_tasks
-                if any(elem in question_tasks for elem in all_tasks):
+                # Check whether the question is associated with any model dependent tasks
+                if any(question_key in self.questions_per_task[task] for task in all_tasks):
 
                     # Ask the question
                     self.ask_a_question(self.question_dictionary_model_ind, question_key)
@@ -477,14 +478,11 @@ class PrepareExperimentConfigAndSuite:
 
                 # Ask only the task questions first
                 # ----------------------------------
-                if 'suites' not in self.question_dictionary_model_dep[model][question_key]:
-
-                    # Get list of tasks for the question
-                    question_tasks = \
-                        self.question_dictionary_model_dep[model][question_key]['tasks']
+                if self.question_dictionary_model_dep[model][question_key] != 'task':
 
                     # Check whether any of model_dep_tasks are in question_tasks
-                    if any(elem in question_tasks for elem in model_dep_tasks[model]):
+                    if any(question_key in self.questions_per_task[task]
+                           for task in model_dep_tasks[model]):
 
                         # Ask the question
                         self.ask_a_question(self.question_dictionary_model_dep[model], question_key,
@@ -522,22 +520,23 @@ class PrepareExperimentConfigAndSuite:
                     f"Configuration for the {model} model component."
 
         # Check the dependency chain for the question
-        if 'depends' in qd:
+        if qd['depends'] is not None:
+            for key, val in qd['depends'].items():
 
-            # Check is dependency has been asked
-            if qd['depends']['key'] not in self.experiment_dict:
+                # Check is dependency has been asked
+                if key not in self.experiment_dict:
 
-                # Iteratively ask the dependent question
-                self.ask_a_question(full_question_dictionary, qd['depends']['key'], model)
+                    # Iteratively ask the dependent question
+                    self.ask_a_question(full_question_dictionary, key, model)
 
-            # Check that answer for dependency matches the required value
-            if model is None:
-                if self.experiment_dict[qd['depends']['key']] != qd['depends']['value']:
-                    ask_question = False
-            else:
-                prev = self.experiment_dict['models'][model][qd['depends']['key']]
-                if prev != qd['depends']['value']:
-                    ask_question = False
+                # Check that answer for dependency matches the required value
+                if model is None:
+                    if self.experiment_dict[key] != val:
+                        ask_question = False
+                else:
+                    prev = self.experiment_dict['models'][model][key]
+                    if prev != val:
+                        ask_question = False
 
         # Ask the question using the selected client
         if ask_question:

--- a/src/swell/deployment/prepare_config_and_suite/prepare_config_and_suite.py
+++ b/src/swell/deployment/prepare_config_and_suite/prepare_config_and_suite.py
@@ -141,9 +141,7 @@ class PrepareExperimentConfigAndSuite:
 
         if suite_question_list is not None:
             for question in suite_question_list:
-                question_obj = getattr(importlib.import_module(
-                    'swell.suites.suite_questions'), question)
-                question_dictionary[question] = asdict(question_obj)
+                question_dictionary[question.name] = asdict(question)
 
         # Create a dictionary of all task questions for tasks needed by the suite
         question_dictionary_tasks = {}
@@ -156,10 +154,8 @@ class PrepareExperimentConfigAndSuite:
             if hasattr(question_list_module, task):
                 task_question_list = getattr(question_list_module, task).get('questions')
                 if task_question_list is not None:
-                    for question in task_question_list:
-                        question_obj = getattr(importlib.import_module(
-                            'swell.tasks.task_questions'), question)
-                        question_dictionary_tasks[question] = asdict(question_obj)
+                    for question_obj in task_question_list:
+                        question_dictionary_tasks[question.name] = asdict(question)
             else:
                 task_question_list = []
 

--- a/src/swell/suites/suite_question_list.py
+++ b/src/swell/suites/suite_question_list.py
@@ -1,3 +1,4 @@
+# --------------------------------------------------------------------------------------------------
 # (C) Copyright 2021- United States Government as represented by the Administrator of the
 # National Aeronautics and Space Administration. All Rights Reserved.
 #
@@ -7,9 +8,6 @@
 
 # --------------------------------------------------------------------------------------------------
 
-
-import os
-from dataclasses import dataclass
 
 from swell.utilities.swell_questions import SuiteQuestionList
 import swell.suites.suite_questions as sq

--- a/src/swell/suites/suite_question_list.py
+++ b/src/swell/suites/suite_question_list.py
@@ -1,0 +1,212 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+import os
+from dataclasses import dataclass
+
+from swell.utilities.swell_questions import QuestionList
+
+
+# --------------------------------------------------------------------------------------------------
+
+all_models = QuestionList(
+    list_type="model_dependent",
+    name="all_models",
+    questions=[
+        "cycle_times",
+        "ensemble_hofx_packets",
+        "ensemble_hofx_strategy",
+        "skip_ensemble_hofx",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+geos_marine = QuestionList(
+    list_type="model_dependent",
+    name="geos_marine",
+    questions=[
+        "marine_models"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+_3dfgat_atmos = QuestionList(
+    list_type="suite",
+    name="3dfgat_atmos",
+    questions=[
+        "cycle_times",
+        "final_cycle_point",
+        "model_components",
+        "runahead_limit",
+        "start_cycle_point"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+_3dfgat_cycle = QuestionList(
+    list_type="suite",
+    name="3dfgat_cycle",
+    questions=[
+        "cycle_times",
+        "final_cycle_point",
+        "marine_models",
+        "model_components",
+        "runahead_limit",
+        "start_cycle_point"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+_3dvar = QuestionList(
+    list_type="suite",
+    name="3dvar",
+    questions=[
+        "cycle_times",
+        "final_cycle_point",
+        "marine_models",
+        "model_components",
+        "runahead_limit",
+        "start_cycle_point"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+_3dvar_atmos = QuestionList(
+    list_type="suite",
+    name="3dvar_atmos",
+    questions=[
+        "cycle_times",
+        "final_cycle_point",
+        "model_components",
+        "runahead_limit",
+        "start_cycle_point"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+_3dvar_cycle = QuestionList(
+    list_type="suite",
+    name="3dvar_cycle",
+    questions=[
+        "cycle_times",
+        "final_cycle_point",
+        "marine_models",
+        "model_components",
+        "runahead_limit",
+        "start_cycle_point"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+all_suites = QuestionList(
+    list_type="suite",
+    name="all_suites",
+    questions=[
+        "experiment_id",
+        "experiment_root"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+convert_ncdiags = QuestionList(
+    list_type="suite",
+    name="convert_ncdiags",
+    questions=[
+        "cycle_times",
+        "final_cycle_point",
+        "model_components",
+        "runahead_limit",
+        "start_cycle_point"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+forecast_geos = QuestionList(
+    list_type="suite",
+    name="forecast_geos",
+    questions=[
+        "cycle_times",
+        "final_cycle_point",
+        "start_cycle_point"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+hofx = QuestionList(
+    list_type="suite",
+    name="hofx",
+    questions=[
+        "cycle_times",
+        "final_cycle_point",
+        "marine_models",
+        "model_components",
+        "runahead_limit",
+        "start_cycle_point",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+localensembleda = QuestionList(
+    list_type="suite",
+    name="localensembleda",
+    questions=[
+        "cycle_times",
+        "ensemble_hofx_packets",
+        "ensemble_hofx_strategy",
+        "final_cycle_point",
+        "marine_models",
+        "model_components",
+        "runahead_limit",
+        "skip_ensemble_hofx",
+        "start_cycle_point"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+ufo_testing = QuestionList(
+    list_type="suite",
+    name="ufo_testing",
+    questions=[
+        "cycle_times",
+        "final_cycle_point",
+        "model_components",
+        "runahead_limit",
+        "start_cycle_point"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/suite_question_list.py
+++ b/src/swell/suites/suite_question_list.py
@@ -11,200 +11,164 @@
 import os
 from dataclasses import dataclass
 
-from swell.utilities.swell_questions import QuestionList
+from swell.utilities.swell_questions import SuiteQuestionList
+import swell.suites.suite_questions as sq
 
 
 # --------------------------------------------------------------------------------------------------
 
-all_models = QuestionList(
-    list_type="model_dependent",
-    name="all_models",
-    questions=[
-        "cycle_times",
-        "ensemble_hofx_packets",
-        "ensemble_hofx_strategy",
-        "skip_ensemble_hofx",
-        "window_type"
-    ]
-)
-
-
-# --------------------------------------------------------------------------------------------------
-
-geos_marine = QuestionList(
-    list_type="model_dependent",
-    name="geos_marine",
-    questions=[
-        "marine_models"
-    ]
-)
-
-
-# --------------------------------------------------------------------------------------------------
-
-_3dfgat_atmos = QuestionList(
-    list_type="suite",
+_3dfgat_atmos = SuiteQuestionList(
     name="3dfgat_atmos",
     questions=[
-        "cycle_times",
-        "final_cycle_point",
-        "model_components",
-        "runahead_limit",
-        "start_cycle_point"
+        sq.cycle_times,
+        sq.final_cycle_point,
+        sq.model_components,
+        sq.runahead_limit,
+        sq.start_cycle_point
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-_3dfgat_cycle = QuestionList(
-    list_type="suite",
+_3dfgat_cycle = SuiteQuestionList(
     name="3dfgat_cycle",
     questions=[
-        "cycle_times",
-        "final_cycle_point",
-        "marine_models",
-        "model_components",
-        "runahead_limit",
-        "start_cycle_point"
+        sq.cycle_times,
+        sq.final_cycle_point,
+        sq.marine_models,
+        sq.model_components,
+        sq.runahead_limit,
+        sq.start_cycle_point
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-_3dvar = QuestionList(
-    list_type="suite",
+_3dvar = SuiteQuestionList(
     name="3dvar",
     questions=[
-        "cycle_times",
-        "final_cycle_point",
-        "marine_models",
-        "model_components",
-        "runahead_limit",
-        "start_cycle_point"
+        sq.cycle_times,
+        sq.final_cycle_point,
+        sq.marine_models,
+        sq.model_components,
+        sq.runahead_limit,
+        sq.start_cycle_point
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-_3dvar_atmos = QuestionList(
-    list_type="suite",
+_3dvar_atmos = SuiteQuestionList(
     name="3dvar_atmos",
     questions=[
-        "cycle_times",
-        "final_cycle_point",
-        "model_components",
-        "runahead_limit",
-        "start_cycle_point"
+        sq.cycle_times,
+        sq.final_cycle_point,
+        sq.model_components,
+        sq.runahead_limit,
+        sq.start_cycle_point
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-_3dvar_cycle = QuestionList(
-    list_type="suite",
+_3dvar_cycle = SuiteQuestionList(
     name="3dvar_cycle",
     questions=[
-        "cycle_times",
-        "final_cycle_point",
-        "marine_models",
-        "model_components",
-        "runahead_limit",
-        "start_cycle_point"
+        sq.cycle_times,
+        sq.final_cycle_point,
+        sq.marine_models,
+        sq.model_components,
+        sq.runahead_limit,
+        sq.start_cycle_point
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-all_suites = QuestionList(
-    list_type="suite",
+all_suites = SuiteQuestionList(
     name="all_suites",
     questions=[
-        "experiment_id",
-        "experiment_root"
+        sq.experiment_id,
+        sq.experiment_root
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-convert_ncdiags = QuestionList(
-    list_type="suite",
+convert_ncdiags = SuiteQuestionList(
     name="convert_ncdiags",
     questions=[
-        "cycle_times",
-        "final_cycle_point",
-        "model_components",
-        "runahead_limit",
-        "start_cycle_point"
+        sq.cycle_times,
+        sq.final_cycle_point,
+        sq.model_components,
+        sq.runahead_limit,
+        sq.start_cycle_point
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-forecast_geos = QuestionList(
-    list_type="suite",
+forecast_geos = SuiteQuestionList(
     name="forecast_geos",
     questions=[
-        "cycle_times",
-        "final_cycle_point",
-        "start_cycle_point"
+        sq.cycle_times,
+        sq.final_cycle_point,
+        sq.start_cycle_point
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-hofx = QuestionList(
-    list_type="suite",
+hofx = SuiteQuestionList(
     name="hofx",
     questions=[
-        "cycle_times",
-        "final_cycle_point",
-        "marine_models",
-        "model_components",
-        "runahead_limit",
-        "start_cycle_point",
-        "window_type"
+        sq.cycle_times,
+        sq.final_cycle_point,
+        sq.marine_models,
+        sq.model_components,
+        sq.runahead_limit,
+        sq.start_cycle_point,
+        sq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-localensembleda = QuestionList(
-    list_type="suite",
+localensembleda = SuiteQuestionList(
     name="localensembleda",
     questions=[
-        "cycle_times",
-        "ensemble_hofx_packets",
-        "ensemble_hofx_strategy",
-        "final_cycle_point",
-        "marine_models",
-        "model_components",
-        "runahead_limit",
-        "skip_ensemble_hofx",
-        "start_cycle_point"
+        sq.cycle_times,
+        sq.ensemble_hofx_packets,
+        sq.ensemble_hofx_strategy,
+        sq.final_cycle_point,
+        sq.marine_models,
+        sq.model_components,
+        sq.runahead_limit,
+        sq.skip_ensemble_hofx,
+        sq.start_cycle_point
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-ufo_testing = QuestionList(
-    list_type="suite",
+ufo_testing = SuiteQuestionList(
     name="ufo_testing",
     questions=[
-        "cycle_times",
-        "final_cycle_point",
-        "model_components",
-        "runahead_limit",
-        "start_cycle_point"
+        sq.cycle_times,
+        sq.final_cycle_point,
+        sq.model_components,
+        sq.runahead_limit,
+        sq.start_cycle_point
     ]
 )
 

--- a/src/swell/suites/suite_questions.py
+++ b/src/swell/suites/suite_questions.py
@@ -1,0 +1,182 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+import os
+from dataclasses import dataclass
+
+from swell.utilities.swell_questions import SwellQuestion
+
+
+# --------------------------------------------------------------------------------------------------
+
+cycle_times = SwellQuestion(
+    name="cycle_times",
+    question_type="suite",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="Enter the cycle times for this model.",
+    dtype="string-check-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+ensemble_hofx_packets = SwellQuestion(
+    name="ensemble_hofx_packets",
+    question_type="suite",
+    default_value="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="Enter the number of ensemble packets.",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+ensemble_hofx_strategy = SwellQuestion(
+    name="ensemble_hofx_strategy",
+    question_type="suite",
+    default_value="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="Enter the ensemble hofx strategy.",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+experiment_id = SwellQuestion(
+    name="experiment_id",
+    question_type="suite",
+    default_value="defer_to_code",
+    ask_question=True,
+    prompt="What is the experiment id?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+experiment_root = SwellQuestion(
+    name="experiment_root",
+    question_type="suite",
+    default_value="defer_to_platform",
+    ask_question=True,
+    prompt="What is the experiment root (the directory where the experiment will be stored)?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+final_cycle_point = SwellQuestion(
+    name="final_cycle_point",
+    question_type="suite",
+    default_value="2021-12-12T06:00:00Z",
+    ask_question=True,
+    prompt="What is the time of the final cycle (middle of the window)?",
+    dtype="iso-datetime"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+marine_models = SwellQuestion(
+    name="marine_models",
+    question_type="suite",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "geos_marine"
+    ],
+    prompt="Select the active SOCA models for this model.",
+    dtype="string-check-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+model_components = SwellQuestion(
+    name="model_components",
+    question_type="suite",
+    default_value="defer_to_code",
+    ask_question=True,
+    options="defer_to_code",
+    prompt="Enter the model components for this model.",
+    dtype="string-check-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+runahead_limit = SwellQuestion(
+    name="runahead_limit",
+    question_type="suite",
+    default_value="P4",
+    ask_question=True,
+    prompt="Since this suite is non-cycling choose how many hours the workflow can run ahead?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+skip_ensemble_hofx = SwellQuestion(
+    name="skip_ensemble_hofx",
+    question_type="suite",
+    default_value="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="Enter if skip ensemble hofx.",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+start_cycle_point = SwellQuestion(
+    name="start_cycle_point",
+    question_type="suite",
+    default_value="2021-12-12T00:00:00Z",
+    ask_question=True,
+    prompt="What is the time of the first cycle (middle of the window)?",
+    dtype="iso-datetime"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+window_type = SwellQuestion(
+    name="window_type",
+    question_type="suite",
+    default_value="defer_to_model",
+    options=[
+        "3D",
+        "4D"
+    ],
+    models=[
+        "all_models"
+    ],
+    prompt="Enter the window type for this model.",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/task_question_list.py
+++ b/src/swell/tasks/task_question_list.py
@@ -1,3 +1,4 @@
+# --------------------------------------------------------------------------------------------------
 # (C) Copyright 2021- United States Government as represented by the Administrator of the
 # National Aeronautics and Space Administration. All Rights Reserved.
 #
@@ -6,10 +7,6 @@
 
 
 # --------------------------------------------------------------------------------------------------
-
-
-import os
-from dataclasses import dataclass
 
 from swell.utilities.swell_questions import TaskQuestionList
 import swell.tasks.task_questions as tq

--- a/src/swell/tasks/task_question_list.py
+++ b/src/swell/tasks/task_question_list.py
@@ -1,0 +1,822 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+import os
+from dataclasses import dataclass
+
+from swell.utilities.swell_questions import QuestionList
+
+
+# --------------------------------------------------------------------------------------------------
+
+all_models = QuestionList(
+    list_type="model_dependent",
+    name="all_models",
+    questions=[
+        "analysis_forecast_window_offset",
+        "analysis_variables",
+        "background_error_model",
+        "background_experiment",
+        "background_frequency",
+        "background_time_offset",
+        "clean_patterns",
+        "gradient_norm_reduction",
+        "horizontal_resolution",
+        "jedi_forecast_model",
+        "minimizer",
+        "number_of_iterations",
+        "obs_experiment",
+        "obs_provider",
+        "observations",
+        "vertical_resolution",
+        "window_length",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+geos_atmosphere = QuestionList(
+    list_type="model_dependent",
+    name="geos_atmosphere",
+    questions=[
+        "crtm_coeff_dir",
+        "cycling_varbc",
+        "ensemble_hofx_packets",
+        "ensemble_hofx_strategy",
+        "ensemble_num_members",
+        "ensmean_only",
+        "ensmeanvariance_only",
+        "geos_x_background_directory",
+        "geovals_experiment",
+        "geovals_provider",
+        "gsibec_configuration",
+        "horizontal_localization_lengthscale",
+        "horizontal_localization_max_nobs",
+        "horizontal_localization_method",
+        "local_ensemble_inflation_mult",
+        "local_ensemble_inflation_rtpp",
+        "local_ensemble_inflation_rtps",
+        "local_ensemble_save_posterior_ensemble",
+        "local_ensemble_save_posterior_ensemble_increments",
+        "local_ensemble_save_posterior_mean",
+        "local_ensemble_save_posterior_mean_increment",
+        "local_ensemble_solver",
+        "local_ensemble_use_linear_observer",
+        "npx_proc",
+        "npy_proc",
+        "observing_system_records_mksi_path",
+        "observing_system_records_mksi_path_tag",
+        "observing_system_records_path",
+        "path_to_ensemble",
+        "path_to_geos_adas_background",
+        "path_to_gsi_bc_coefficients",
+        "path_to_gsi_nc_diags",
+        "produce_geovals",
+        "single_observations",
+        "skip_ensemble_hofx",
+        "vertical_localization_apply_log_transform",
+        "vertical_localization_function",
+        "vertical_localization_ioda_vertical_coord",
+        "vertical_localization_ioda_vertical_coord_group",
+        "vertical_localization_lengthscale",
+        "vertical_localization_method"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+geos_marine = QuestionList(
+    list_type="model_dependent",
+    name="geos_marine",
+    questions=[
+        "cice6_domains",
+        "marine_models",
+        "mom6_iau",
+        "total_processors"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+geos_ocean = QuestionList(
+    list_type="model_dependent",
+    name="geos_ocean",
+    questions=[
+        "mom6_iau",
+        "total_processors"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GetBackground = QuestionList(
+    list_type="task",
+    name="GetBackground",
+    questions=[
+        "analysis_forecast_window_offset",
+        "background_experiment",
+        "background_frequency",
+        "horizontal_resolution",
+        "r2d2_local_path",
+        "window_length",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+MoveDaRestart = QuestionList(
+    list_type="task",
+    name="MoveDaRestart",
+    questions=[
+        "analysis_forecast_window_offset",
+        "mom6_iau",
+        "window_length"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+PrepareAnalysis = QuestionList(
+    list_type="task",
+    name="PrepareAnalysis",
+    questions=[
+        "analysis_forecast_window_offset",
+        "analysis_variables",
+        "mom6_iau",
+        "total_processors"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+StoreBackground = QuestionList(
+    list_type="task",
+    name="StoreBackground",
+    questions=[
+        "analysis_forecast_window_offset",
+        "background_experiment",
+        "background_frequency",
+        "horizontal_resolution",
+        "r2d2_local_path",
+        "window_length",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GenerateBClimatology = QuestionList(
+    list_type="task",
+    name="GenerateBClimatology",
+    questions=[
+        "analysis_variables",
+        "background_error_model",
+        "generate_yaml_and_exit",
+        "horizontal_resolution",
+        "marine_models",
+        "npx_proc",
+        "npy_proc",
+        "swell_static_files",
+        "swell_static_files_user",
+        "total_processors",
+        "vertical_resolution",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+RunJediConvertStateSoca2ciceExecutable = QuestionList(
+    list_type="task",
+    name="RunJediConvertStateSoca2ciceExecutable",
+    questions=[
+        "analysis_variables",
+        "cice6_domains",
+        "generate_yaml_and_exit",
+        "jedi_forecast_model",
+        "marine_models",
+        "observations",
+        "total_processors",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+RunJediEnsembleMeanVariance = QuestionList(
+    list_type="task",
+    name="RunJediEnsembleMeanVariance",
+    questions=[
+        "analysis_variables",
+        "ensemble_num_members",
+        "generate_yaml_and_exit",
+        "horizontal_resolution",
+        "jedi_forecast_model",
+        "npx_proc",
+        "npy_proc",
+        "observations",
+        "observing_system_records_path",
+        "vertical_resolution",
+        "window_length",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+RunJediFgatExecutable = QuestionList(
+    list_type="task",
+    name="RunJediFgatExecutable",
+    questions=[
+        "analysis_variables",
+        "background_frequency",
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "generate_yaml_and_exit",
+        "gradient_norm_reduction",
+        "gsibec_configuration",
+        "horizontal_resolution",
+        "jedi_forecast_model",
+        "marine_models",
+        "minimizer",
+        "npx_proc",
+        "npy_proc",
+        "number_of_iterations",
+        "observations",
+        "observing_system_records_path",
+        "total_processors",
+        "vertical_resolution",
+        "window_length",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+RunJediVariationalExecutable = QuestionList(
+    list_type="task",
+    name="RunJediVariationalExecutable",
+    questions=[
+        "analysis_variables",
+        "background_frequency",
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "generate_yaml_and_exit",
+        "gradient_norm_reduction",
+        "gsibec_configuration",
+        "horizontal_resolution",
+        "jedi_forecast_model",
+        "minimizer",
+        "npx_proc",
+        "npy_proc",
+        "number_of_iterations",
+        "observations",
+        "observing_system_records_path",
+        "total_processors",
+        "vertical_resolution",
+        "window_length",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GenerateBClimatologyByLinking = QuestionList(
+    list_type="task",
+    name="GenerateBClimatologyByLinking",
+    questions=[
+        "background_error_model",
+        "horizontal_resolution",
+        "swell_static_files",
+        "swell_static_files_user",
+        "vertical_resolution",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GetBackgroundGeosExperiment = QuestionList(
+    list_type="task",
+    name="GetBackgroundGeosExperiment",
+    questions=[
+        "background_experiment",
+        "background_time_offset",
+        "geos_x_background_directory"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+LinkGeosOutput = QuestionList(
+    list_type="task",
+    name="LinkGeosOutput",
+    questions=[
+        "background_frequency",
+        "marine_models",
+        "window_length",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+RunJediHofxEnsembleExecutable = QuestionList(
+    list_type="task",
+    name="RunJediHofxEnsembleExecutable",
+    questions=[
+        "background_frequency",
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "ensemble_hofx_packets",
+        "ensemble_hofx_strategy",
+        "ensemble_num_members",
+        "generate_yaml_and_exit",
+        "horizontal_resolution",
+        "jedi_forecast_model",
+        "npx_proc",
+        "npy_proc",
+        "observations",
+        "total_processors",
+        "vertical_resolution",
+        "window_length",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+RunJediHofxExecutable = QuestionList(
+    list_type="task",
+    name="RunJediHofxExecutable",
+    questions=[
+        "background_frequency",
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "generate_yaml_and_exit",
+        "horizontal_resolution",
+        "jedi_forecast_model",
+        "npx_proc",
+        "npy_proc",
+        "observations",
+        "observing_system_records_path",
+        "save_geovals",
+        "total_processors",
+        "vertical_resolution",
+        "window_length",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+RunJediObsfiltersExecutable = QuestionList(
+    list_type="task",
+    name="RunJediObsfiltersExecutable",
+    questions=[
+        "background_frequency",
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "generate_yaml_and_exit",
+        "horizontal_resolution",
+        "jedi_forecast_model",
+        "npx_proc",
+        "npy_proc",
+        "observations",
+        "observing_system_records_path",
+        "total_processors",
+        "vertical_resolution",
+        "window_length",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+EvaObservations = QuestionList(
+    list_type="task",
+    name="EvaObservations",
+    questions=[
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "observations",
+        "observing_system_records_path",
+        "window_offset"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GetGeovals = QuestionList(
+    list_type="task",
+    name="GetGeovals",
+    questions=[
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "geovals_experiment",
+        "geovals_provider",
+        "observations",
+        "r2d2_local_path",
+        "window_length",
+        "window_offset"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GetObservations = QuestionList(
+    list_type="task",
+    name="GetObservations",
+    questions=[
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "cycling_varbc",
+        "obs_experiment",
+        "obs_provider",
+        "observations",
+        "observing_system_records_path",
+        "r2d2_local_path",
+        "window_length",
+        "window_offset"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GsiBcToIoda = QuestionList(
+    list_type="task",
+    name="GsiBcToIoda",
+    questions=[
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "observations",
+        "observing_system_records_path",
+        "window_offset"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+RunJediLocalEnsembleDaExecutable = QuestionList(
+    list_type="task",
+    name="RunJediLocalEnsembleDaExecutable",
+    questions=[
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "ensemble_hofx_packets",
+        "ensemble_hofx_strategy",
+        "ensemble_num_members",
+        "ensmean_only",
+        "ensmeanvariance_only",
+        "generate_yaml_and_exit",
+        "horizontal_localization_lengthscale",
+        "horizontal_localization_max_nobs",
+        "horizontal_localization_method",
+        "horizontal_resolution",
+        "jedi_forecast_model",
+        "local_ensemble_inflation_mult",
+        "local_ensemble_inflation_rtpp",
+        "local_ensemble_inflation_rtps",
+        "local_ensemble_save_posterior_ensemble",
+        "local_ensemble_save_posterior_ensemble_increments",
+        "local_ensemble_save_posterior_mean",
+        "local_ensemble_save_posterior_mean_increment",
+        "local_ensemble_solver",
+        "local_ensemble_use_linear_observer",
+        "npx_proc",
+        "npy_proc",
+        "observations",
+        "observing_system_records_path",
+        "skip_ensemble_hofx",
+        "total_processors",
+        "vertical_localization_apply_log_transform",
+        "vertical_localization_function",
+        "vertical_localization_ioda_vertical_coord",
+        "vertical_localization_ioda_vertical_coord_group",
+        "vertical_localization_lengthscale",
+        "vertical_localization_method",
+        "vertical_resolution",
+        "window_length",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+RunJediUfoTestsExecutable = QuestionList(
+    list_type="task",
+    name="RunJediUfoTestsExecutable",
+    questions=[
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "generate_yaml_and_exit",
+        "observations",
+        "observing_system_records_path",
+        "single_observations",
+        "window_length",
+        "window_offset"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+SaveObsDiags = QuestionList(
+    list_type="task",
+    name="SaveObsDiags",
+    questions=[
+        "background_time_offset",
+        "crtm_coeff_dir",
+        "observations",
+        "observing_system_records_path",
+        "r2d2_local_path",
+        "window_offset"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+BuildJedi = QuestionList(
+    list_type="task",
+    name="BuildJedi",
+    questions=[
+        "bundles",
+        "jedi_build_method"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+CloneJedi = QuestionList(
+    list_type="task",
+    name="CloneJedi",
+    questions=[
+        "bundles",
+        "existing_jedi_source_directory",
+        "existing_jedi_source_directory_pinned",
+        "jedi_build_method"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+CleanCycle = QuestionList(
+    list_type="task",
+    name="CleanCycle",
+    questions=[
+        "clean_patterns"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+BuildGeosByLinking = QuestionList(
+    list_type="task",
+    name="BuildGeosByLinking",
+    questions=[
+        "existing_geos_gcm_build_path",
+        "geos_build_method"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+PrepGeosRunDir = QuestionList(
+    list_type="task",
+    name="PrepGeosRunDir",
+    questions=[
+        "existing_geos_gcm_build_path",
+        "forecast_duration",
+        "geos_experiment_directory",
+        "swell_static_files",
+        "swell_static_files_user"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+CloneGeos = QuestionList(
+    list_type="task",
+    name="CloneGeos",
+    questions=[
+        "existing_geos_gcm_source_path",
+        "geos_build_method",
+        "geos_gcm_tag"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+BuildJediByLinking = QuestionList(
+    list_type="task",
+    name="BuildJediByLinking",
+    questions=[
+        "existing_jedi_build_directory",
+        "existing_jedi_build_directory_pinned",
+        "jedi_build_method"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+MoveForecastRestart = QuestionList(
+    list_type="task",
+    name="MoveForecastRestart",
+    questions=[
+        "forecast_duration"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+BuildGeos = QuestionList(
+    list_type="task",
+    name="BuildGeos",
+    questions=[
+        "geos_build_method"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GetGeosRestart = QuestionList(
+    list_type="task",
+    name="GetGeosRestart",
+    questions=[
+        "geos_restarts_directory",
+        "swell_static_files",
+        "swell_static_files_user"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+StageJedi = QuestionList(
+    list_type="task",
+    name="StageJedi",
+    questions=[
+        "gsibec_configuration",
+        "horizontal_resolution",
+        "swell_static_files",
+        "swell_static_files_user",
+        "vertical_resolution"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+EvaIncrement = QuestionList(
+    list_type="task",
+    name="EvaIncrement",
+    questions=[
+        "marine_models",
+        "window_offset",
+        "window_type"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GenerateObservingSystemRecords = QuestionList(
+    list_type="task",
+    name="GenerateObservingSystemRecords",
+    questions=[
+        "observations",
+        "observing_system_records_mksi_path",
+        "observing_system_records_path"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GsiNcdiagToIoda = QuestionList(
+    list_type="task",
+    name="GsiNcdiagToIoda",
+    questions=[
+        "observations",
+        "produce_geovals",
+        "single_observations",
+        "window_offset"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+CloneGeosMksi = QuestionList(
+    list_type="task",
+    name="CloneGeosMksi",
+    questions=[
+        "observing_system_records_mksi_path",
+        "observing_system_records_mksi_path_tag"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GetEnsemble = QuestionList(
+    list_type="task",
+    name="GetEnsemble",
+    questions=[
+        "path_to_ensemble"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GetGeosAdasBackground = QuestionList(
+    list_type="task",
+    name="GetGeosAdasBackground",
+    questions=[
+        "path_to_geos_adas_background"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GetGsiBc = QuestionList(
+    list_type="task",
+    name="GetGsiBc",
+    questions=[
+        "path_to_gsi_bc_coefficients",
+        "window_length"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+GetGsiNcdiag = QuestionList(
+    list_type="task",
+    name="GetGsiNcdiag",
+    questions=[
+        "path_to_gsi_nc_diags"
+    ]
+)
+
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/task_question_list.py
+++ b/src/swell/tasks/task_question_list.py
@@ -11,810 +11,664 @@
 import os
 from dataclasses import dataclass
 
-from swell.utilities.swell_questions import QuestionList
+from swell.utilities.swell_questions import TaskQuestionList
+import swell.tasks.task_questions as tq
 
 
 # --------------------------------------------------------------------------------------------------
 
-all_models = QuestionList(
-    list_type="model_dependent",
-    name="all_models",
-    questions=[
-        "analysis_forecast_window_offset",
-        "analysis_variables",
-        "background_error_model",
-        "background_experiment",
-        "background_frequency",
-        "background_time_offset",
-        "clean_patterns",
-        "gradient_norm_reduction",
-        "horizontal_resolution",
-        "jedi_forecast_model",
-        "minimizer",
-        "number_of_iterations",
-        "obs_experiment",
-        "obs_provider",
-        "observations",
-        "vertical_resolution",
-        "window_length",
-        "window_offset",
-        "window_type"
-    ]
-)
-
-
-# --------------------------------------------------------------------------------------------------
-
-geos_atmosphere = QuestionList(
-    list_type="model_dependent",
-    name="geos_atmosphere",
-    questions=[
-        "crtm_coeff_dir",
-        "cycling_varbc",
-        "ensemble_hofx_packets",
-        "ensemble_hofx_strategy",
-        "ensemble_num_members",
-        "ensmean_only",
-        "ensmeanvariance_only",
-        "geos_x_background_directory",
-        "geovals_experiment",
-        "geovals_provider",
-        "gsibec_configuration",
-        "horizontal_localization_lengthscale",
-        "horizontal_localization_max_nobs",
-        "horizontal_localization_method",
-        "local_ensemble_inflation_mult",
-        "local_ensemble_inflation_rtpp",
-        "local_ensemble_inflation_rtps",
-        "local_ensemble_save_posterior_ensemble",
-        "local_ensemble_save_posterior_ensemble_increments",
-        "local_ensemble_save_posterior_mean",
-        "local_ensemble_save_posterior_mean_increment",
-        "local_ensemble_solver",
-        "local_ensemble_use_linear_observer",
-        "npx_proc",
-        "npy_proc",
-        "observing_system_records_mksi_path",
-        "observing_system_records_mksi_path_tag",
-        "observing_system_records_path",
-        "path_to_ensemble",
-        "path_to_geos_adas_background",
-        "path_to_gsi_bc_coefficients",
-        "path_to_gsi_nc_diags",
-        "produce_geovals",
-        "single_observations",
-        "skip_ensemble_hofx",
-        "vertical_localization_apply_log_transform",
-        "vertical_localization_function",
-        "vertical_localization_ioda_vertical_coord",
-        "vertical_localization_ioda_vertical_coord_group",
-        "vertical_localization_lengthscale",
-        "vertical_localization_method"
-    ]
-)
-
-
-# --------------------------------------------------------------------------------------------------
-
-geos_marine = QuestionList(
-    list_type="model_dependent",
-    name="geos_marine",
-    questions=[
-        "cice6_domains",
-        "marine_models",
-        "mom6_iau",
-        "total_processors"
-    ]
-)
-
-
-# --------------------------------------------------------------------------------------------------
-
-geos_ocean = QuestionList(
-    list_type="model_dependent",
-    name="geos_ocean",
-    questions=[
-        "mom6_iau",
-        "total_processors"
-    ]
-)
-
-
-# --------------------------------------------------------------------------------------------------
-
-GetBackground = QuestionList(
-    list_type="task",
+GetBackground = TaskQuestionList(
     name="GetBackground",
     questions=[
-        "analysis_forecast_window_offset",
-        "background_experiment",
-        "background_frequency",
-        "horizontal_resolution",
-        "r2d2_local_path",
-        "window_length",
-        "window_offset",
-        "window_type"
+        tq.analysis_forecast_window_offset,
+        tq.background_experiment,
+        tq.background_frequency,
+        tq.horizontal_resolution,
+        tq.r2d2_local_path,
+        tq.window_length,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-MoveDaRestart = QuestionList(
-    list_type="task",
+MoveDaRestart = TaskQuestionList(
     name="MoveDaRestart",
     questions=[
-        "analysis_forecast_window_offset",
-        "mom6_iau",
-        "window_length"
+        tq.analysis_forecast_window_offset,
+        tq.mom6_iau,
+        tq.window_length
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-PrepareAnalysis = QuestionList(
-    list_type="task",
+PrepareAnalysis = TaskQuestionList(
     name="PrepareAnalysis",
     questions=[
-        "analysis_forecast_window_offset",
-        "analysis_variables",
-        "mom6_iau",
-        "total_processors"
+        tq.analysis_forecast_window_offset,
+        tq.analysis_variables,
+        tq.mom6_iau,
+        tq.total_processors
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-StoreBackground = QuestionList(
-    list_type="task",
+StoreBackground = TaskQuestionList(
     name="StoreBackground",
     questions=[
-        "analysis_forecast_window_offset",
-        "background_experiment",
-        "background_frequency",
-        "horizontal_resolution",
-        "r2d2_local_path",
-        "window_length",
-        "window_offset",
-        "window_type"
+        tq.analysis_forecast_window_offset,
+        tq.background_experiment,
+        tq.background_frequency,
+        tq.horizontal_resolution,
+        tq.r2d2_local_path,
+        tq.window_length,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GenerateBClimatology = QuestionList(
-    list_type="task",
+GenerateBClimatology = TaskQuestionList(
     name="GenerateBClimatology",
     questions=[
-        "analysis_variables",
-        "background_error_model",
-        "generate_yaml_and_exit",
-        "horizontal_resolution",
-        "marine_models",
-        "npx_proc",
-        "npy_proc",
-        "swell_static_files",
-        "swell_static_files_user",
-        "total_processors",
-        "vertical_resolution",
-        "window_offset",
-        "window_type"
+        tq.analysis_variables,
+        tq.background_error_model,
+        tq.generate_yaml_and_exit,
+        tq.horizontal_resolution,
+        tq.marine_models,
+        tq.npx_proc,
+        tq.npy_proc,
+        tq.swell_static_files,
+        tq.swell_static_files_user,
+        tq.total_processors,
+        tq.vertical_resolution,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-RunJediConvertStateSoca2ciceExecutable = QuestionList(
-    list_type="task",
+RunJediConvertStateSoca2ciceExecutable = TaskQuestionList(
     name="RunJediConvertStateSoca2ciceExecutable",
     questions=[
-        "analysis_variables",
-        "cice6_domains",
-        "generate_yaml_and_exit",
-        "jedi_forecast_model",
-        "marine_models",
-        "observations",
-        "total_processors",
-        "window_offset",
-        "window_type"
+        tq.analysis_variables,
+        tq.cice6_domains,
+        tq.generate_yaml_and_exit,
+        tq.jedi_forecast_model,
+        tq.marine_models,
+        tq.observations,
+        tq.total_processors,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-RunJediEnsembleMeanVariance = QuestionList(
-    list_type="task",
+RunJediEnsembleMeanVariance = TaskQuestionList(
     name="RunJediEnsembleMeanVariance",
     questions=[
-        "analysis_variables",
-        "ensemble_num_members",
-        "generate_yaml_and_exit",
-        "horizontal_resolution",
-        "jedi_forecast_model",
-        "npx_proc",
-        "npy_proc",
-        "observations",
-        "observing_system_records_path",
-        "vertical_resolution",
-        "window_length",
-        "window_offset",
-        "window_type"
+        tq.analysis_variables,
+        tq.ensemble_num_members,
+        tq.generate_yaml_and_exit,
+        tq.horizontal_resolution,
+        tq.jedi_forecast_model,
+        tq.npx_proc,
+        tq.npy_proc,
+        tq.observations,
+        tq.observing_system_records_path,
+        tq.vertical_resolution,
+        tq.window_length,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-RunJediFgatExecutable = QuestionList(
-    list_type="task",
+RunJediFgatExecutable = TaskQuestionList(
     name="RunJediFgatExecutable",
     questions=[
-        "analysis_variables",
-        "background_frequency",
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "generate_yaml_and_exit",
-        "gradient_norm_reduction",
-        "gsibec_configuration",
-        "horizontal_resolution",
-        "jedi_forecast_model",
-        "marine_models",
-        "minimizer",
-        "npx_proc",
-        "npy_proc",
-        "number_of_iterations",
-        "observations",
-        "observing_system_records_path",
-        "total_processors",
-        "vertical_resolution",
-        "window_length",
-        "window_offset",
-        "window_type"
+        tq.analysis_variables,
+        tq.background_frequency,
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.generate_yaml_and_exit,
+        tq.gradient_norm_reduction,
+        tq.gsibec_configuration,
+        tq.horizontal_resolution,
+        tq.jedi_forecast_model,
+        tq.marine_models,
+        tq.minimizer,
+        tq.npx_proc,
+        tq.npy_proc,
+        tq.number_of_iterations,
+        tq.observations,
+        tq.observing_system_records_path,
+        tq.total_processors,
+        tq.vertical_resolution,
+        tq.window_length,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-RunJediVariationalExecutable = QuestionList(
-    list_type="task",
+RunJediVariationalExecutable = TaskQuestionList(
     name="RunJediVariationalExecutable",
     questions=[
-        "analysis_variables",
-        "background_frequency",
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "generate_yaml_and_exit",
-        "gradient_norm_reduction",
-        "gsibec_configuration",
-        "horizontal_resolution",
-        "jedi_forecast_model",
-        "minimizer",
-        "npx_proc",
-        "npy_proc",
-        "number_of_iterations",
-        "observations",
-        "observing_system_records_path",
-        "total_processors",
-        "vertical_resolution",
-        "window_length",
-        "window_offset",
-        "window_type"
+        tq.analysis_variables,
+        tq.background_frequency,
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.generate_yaml_and_exit,
+        tq.gradient_norm_reduction,
+        tq.gsibec_configuration,
+        tq.horizontal_resolution,
+        tq.jedi_forecast_model,
+        tq.minimizer,
+        tq.npx_proc,
+        tq.npy_proc,
+        tq.number_of_iterations,
+        tq.observations,
+        tq.observing_system_records_path,
+        tq.total_processors,
+        tq.vertical_resolution,
+        tq.window_length,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GenerateBClimatologyByLinking = QuestionList(
-    list_type="task",
+GenerateBClimatologyByLinking = TaskQuestionList(
     name="GenerateBClimatologyByLinking",
     questions=[
-        "background_error_model",
-        "horizontal_resolution",
-        "swell_static_files",
-        "swell_static_files_user",
-        "vertical_resolution",
-        "window_offset",
-        "window_type"
+        tq.background_error_model,
+        tq.horizontal_resolution,
+        tq.swell_static_files,
+        tq.swell_static_files_user,
+        tq.vertical_resolution,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GetBackgroundGeosExperiment = QuestionList(
-    list_type="task",
+GetBackgroundGeosExperiment = TaskQuestionList(
     name="GetBackgroundGeosExperiment",
     questions=[
-        "background_experiment",
-        "background_time_offset",
-        "geos_x_background_directory"
+        tq.background_experiment,
+        tq.background_time_offset,
+        tq.geos_x_background_directory
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-LinkGeosOutput = QuestionList(
-    list_type="task",
+LinkGeosOutput = TaskQuestionList(
     name="LinkGeosOutput",
     questions=[
-        "background_frequency",
-        "marine_models",
-        "window_length",
-        "window_offset",
-        "window_type"
+        tq.background_frequency,
+        tq.marine_models,
+        tq.window_length,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-RunJediHofxEnsembleExecutable = QuestionList(
-    list_type="task",
+RunJediHofxEnsembleExecutable = TaskQuestionList(
     name="RunJediHofxEnsembleExecutable",
     questions=[
-        "background_frequency",
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "ensemble_hofx_packets",
-        "ensemble_hofx_strategy",
-        "ensemble_num_members",
-        "generate_yaml_and_exit",
-        "horizontal_resolution",
-        "jedi_forecast_model",
-        "npx_proc",
-        "npy_proc",
-        "observations",
-        "total_processors",
-        "vertical_resolution",
-        "window_length",
-        "window_offset",
-        "window_type"
+        tq.background_frequency,
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.ensemble_hofx_packets,
+        tq.ensemble_hofx_strategy,
+        tq.ensemble_num_members,
+        tq.generate_yaml_and_exit,
+        tq.horizontal_resolution,
+        tq.jedi_forecast_model,
+        tq.npx_proc,
+        tq.npy_proc,
+        tq.observations,
+        tq.total_processors,
+        tq.vertical_resolution,
+        tq.window_length,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-RunJediHofxExecutable = QuestionList(
-    list_type="task",
+RunJediHofxExecutable = TaskQuestionList(
     name="RunJediHofxExecutable",
     questions=[
-        "background_frequency",
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "generate_yaml_and_exit",
-        "horizontal_resolution",
-        "jedi_forecast_model",
-        "npx_proc",
-        "npy_proc",
-        "observations",
-        "observing_system_records_path",
-        "save_geovals",
-        "total_processors",
-        "vertical_resolution",
-        "window_length",
-        "window_offset",
-        "window_type"
+        tq.background_frequency,
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.generate_yaml_and_exit,
+        tq.horizontal_resolution,
+        tq.jedi_forecast_model,
+        tq.npx_proc,
+        tq.npy_proc,
+        tq.observations,
+        tq.observing_system_records_path,
+        tq.save_geovals,
+        tq.total_processors,
+        tq.vertical_resolution,
+        tq.window_length,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-RunJediObsfiltersExecutable = QuestionList(
-    list_type="task",
+RunJediObsfiltersExecutable = TaskQuestionList(
     name="RunJediObsfiltersExecutable",
     questions=[
-        "background_frequency",
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "generate_yaml_and_exit",
-        "horizontal_resolution",
-        "jedi_forecast_model",
-        "npx_proc",
-        "npy_proc",
-        "observations",
-        "observing_system_records_path",
-        "total_processors",
-        "vertical_resolution",
-        "window_length",
-        "window_offset",
-        "window_type"
+        tq.background_frequency,
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.generate_yaml_and_exit,
+        tq.horizontal_resolution,
+        tq.jedi_forecast_model,
+        tq.npx_proc,
+        tq.npy_proc,
+        tq.observations,
+        tq.observing_system_records_path,
+        tq.total_processors,
+        tq.vertical_resolution,
+        tq.window_length,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-EvaObservations = QuestionList(
-    list_type="task",
+EvaObservations = TaskQuestionList(
     name="EvaObservations",
     questions=[
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "observations",
-        "observing_system_records_path",
-        "window_offset"
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.observations,
+        tq.observing_system_records_path,
+        tq.window_offset
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GetGeovals = QuestionList(
-    list_type="task",
+GetGeovals = TaskQuestionList(
     name="GetGeovals",
     questions=[
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "geovals_experiment",
-        "geovals_provider",
-        "observations",
-        "r2d2_local_path",
-        "window_length",
-        "window_offset"
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.geovals_experiment,
+        tq.geovals_provider,
+        tq.observations,
+        tq.r2d2_local_path,
+        tq.window_length,
+        tq.window_offset
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GetObservations = QuestionList(
-    list_type="task",
+GetObservations = TaskQuestionList(
     name="GetObservations",
     questions=[
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "cycling_varbc",
-        "obs_experiment",
-        "obs_provider",
-        "observations",
-        "observing_system_records_path",
-        "r2d2_local_path",
-        "window_length",
-        "window_offset"
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.cycling_varbc,
+        tq.obs_experiment,
+        tq.obs_provider,
+        tq.observations,
+        tq.observing_system_records_path,
+        tq.r2d2_local_path,
+        tq.window_length,
+        tq.window_offset
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GsiBcToIoda = QuestionList(
-    list_type="task",
+GsiBcToIoda = TaskQuestionList(
     name="GsiBcToIoda",
     questions=[
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "observations",
-        "observing_system_records_path",
-        "window_offset"
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.observations,
+        tq.observing_system_records_path,
+        tq.window_offset
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-RunJediLocalEnsembleDaExecutable = QuestionList(
-    list_type="task",
+RunJediLocalEnsembleDaExecutable = TaskQuestionList(
     name="RunJediLocalEnsembleDaExecutable",
     questions=[
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "ensemble_hofx_packets",
-        "ensemble_hofx_strategy",
-        "ensemble_num_members",
-        "ensmean_only",
-        "ensmeanvariance_only",
-        "generate_yaml_and_exit",
-        "horizontal_localization_lengthscale",
-        "horizontal_localization_max_nobs",
-        "horizontal_localization_method",
-        "horizontal_resolution",
-        "jedi_forecast_model",
-        "local_ensemble_inflation_mult",
-        "local_ensemble_inflation_rtpp",
-        "local_ensemble_inflation_rtps",
-        "local_ensemble_save_posterior_ensemble",
-        "local_ensemble_save_posterior_ensemble_increments",
-        "local_ensemble_save_posterior_mean",
-        "local_ensemble_save_posterior_mean_increment",
-        "local_ensemble_solver",
-        "local_ensemble_use_linear_observer",
-        "npx_proc",
-        "npy_proc",
-        "observations",
-        "observing_system_records_path",
-        "skip_ensemble_hofx",
-        "total_processors",
-        "vertical_localization_apply_log_transform",
-        "vertical_localization_function",
-        "vertical_localization_ioda_vertical_coord",
-        "vertical_localization_ioda_vertical_coord_group",
-        "vertical_localization_lengthscale",
-        "vertical_localization_method",
-        "vertical_resolution",
-        "window_length",
-        "window_offset",
-        "window_type"
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.ensemble_hofx_packets,
+        tq.ensemble_hofx_strategy,
+        tq.ensemble_num_members,
+        tq.ensmean_only,
+        tq.ensmeanvariance_only,
+        tq.generate_yaml_and_exit,
+        tq.horizontal_localization_lengthscale,
+        tq.horizontal_localization_max_nobs,
+        tq.horizontal_localization_method,
+        tq.horizontal_resolution,
+        tq.jedi_forecast_model,
+        tq.local_ensemble_inflation_mult,
+        tq.local_ensemble_inflation_rtpp,
+        tq.local_ensemble_inflation_rtps,
+        tq.local_ensemble_save_posterior_ensemble,
+        tq.local_ensemble_save_posterior_ensemble_increments,
+        tq.local_ensemble_save_posterior_mean,
+        tq.local_ensemble_save_posterior_mean_increment,
+        tq.local_ensemble_solver,
+        tq.local_ensemble_use_linear_observer,
+        tq.npx_proc,
+        tq.npy_proc,
+        tq.observations,
+        tq.observing_system_records_path,
+        tq.skip_ensemble_hofx,
+        tq.total_processors,
+        tq.vertical_localization_apply_log_transform,
+        tq.vertical_localization_function,
+        tq.vertical_localization_ioda_vertical_coord,
+        tq.vertical_localization_ioda_vertical_coord_group,
+        tq.vertical_localization_lengthscale,
+        tq.vertical_localization_method,
+        tq.vertical_resolution,
+        tq.window_length,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-RunJediUfoTestsExecutable = QuestionList(
-    list_type="task",
+RunJediUfoTestsExecutable = TaskQuestionList(
     name="RunJediUfoTestsExecutable",
     questions=[
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "generate_yaml_and_exit",
-        "observations",
-        "observing_system_records_path",
-        "single_observations",
-        "window_length",
-        "window_offset"
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.generate_yaml_and_exit,
+        tq.observations,
+        tq.observing_system_records_path,
+        tq.single_observations,
+        tq.window_length,
+        tq.window_offset
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-SaveObsDiags = QuestionList(
-    list_type="task",
+SaveObsDiags = TaskQuestionList(
     name="SaveObsDiags",
     questions=[
-        "background_time_offset",
-        "crtm_coeff_dir",
-        "observations",
-        "observing_system_records_path",
-        "r2d2_local_path",
-        "window_offset"
+        tq.background_time_offset,
+        tq.crtm_coeff_dir,
+        tq.observations,
+        tq.observing_system_records_path,
+        tq.r2d2_local_path,
+        tq.window_offset
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-BuildJedi = QuestionList(
-    list_type="task",
+BuildJedi = TaskQuestionList(
     name="BuildJedi",
     questions=[
-        "bundles",
-        "jedi_build_method"
+        tq.bundles,
+        tq.jedi_build_method
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-CloneJedi = QuestionList(
-    list_type="task",
+CloneJedi = TaskQuestionList(
     name="CloneJedi",
     questions=[
-        "bundles",
-        "existing_jedi_source_directory",
-        "existing_jedi_source_directory_pinned",
-        "jedi_build_method"
+        tq.bundles,
+        tq.existing_jedi_source_directory,
+        tq.existing_jedi_source_directory_pinned,
+        tq.jedi_build_method
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-CleanCycle = QuestionList(
-    list_type="task",
+CleanCycle = TaskQuestionList(
     name="CleanCycle",
     questions=[
-        "clean_patterns"
+        tq.clean_patterns
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-BuildGeosByLinking = QuestionList(
-    list_type="task",
+BuildGeosByLinking = TaskQuestionList(
     name="BuildGeosByLinking",
     questions=[
-        "existing_geos_gcm_build_path",
-        "geos_build_method"
+        tq.existing_geos_gcm_build_path,
+        tq.geos_build_method
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-PrepGeosRunDir = QuestionList(
-    list_type="task",
+PrepGeosRunDir = TaskQuestionList(
     name="PrepGeosRunDir",
     questions=[
-        "existing_geos_gcm_build_path",
-        "forecast_duration",
-        "geos_experiment_directory",
-        "swell_static_files",
-        "swell_static_files_user"
+        tq.existing_geos_gcm_build_path,
+        tq.forecast_duration,
+        tq.geos_experiment_directory,
+        tq.swell_static_files,
+        tq.swell_static_files_user
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-CloneGeos = QuestionList(
-    list_type="task",
+CloneGeos = TaskQuestionList(
     name="CloneGeos",
     questions=[
-        "existing_geos_gcm_source_path",
-        "geos_build_method",
-        "geos_gcm_tag"
+        tq.existing_geos_gcm_source_path,
+        tq.geos_build_method,
+        tq.geos_gcm_tag
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-BuildJediByLinking = QuestionList(
-    list_type="task",
+BuildJediByLinking = TaskQuestionList(
     name="BuildJediByLinking",
     questions=[
-        "existing_jedi_build_directory",
-        "existing_jedi_build_directory_pinned",
-        "jedi_build_method"
+        tq.existing_jedi_build_directory,
+        tq.existing_jedi_build_directory_pinned,
+        tq.jedi_build_method
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-MoveForecastRestart = QuestionList(
-    list_type="task",
+MoveForecastRestart = TaskQuestionList(
     name="MoveForecastRestart",
     questions=[
-        "forecast_duration"
+        tq.forecast_duration
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-BuildGeos = QuestionList(
-    list_type="task",
+BuildGeos = TaskQuestionList(
     name="BuildGeos",
     questions=[
-        "geos_build_method"
+        tq.geos_build_method
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GetGeosRestart = QuestionList(
-    list_type="task",
+GetGeosRestart = TaskQuestionList(
     name="GetGeosRestart",
     questions=[
-        "geos_restarts_directory",
-        "swell_static_files",
-        "swell_static_files_user"
+        tq.geos_restarts_directory,
+        tq.swell_static_files,
+        tq.swell_static_files_user
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-StageJedi = QuestionList(
-    list_type="task",
+StageJedi = TaskQuestionList(
     name="StageJedi",
     questions=[
-        "gsibec_configuration",
-        "horizontal_resolution",
-        "swell_static_files",
-        "swell_static_files_user",
-        "vertical_resolution"
+        tq.gsibec_configuration,
+        tq.horizontal_resolution,
+        tq.swell_static_files,
+        tq.swell_static_files_user,
+        tq.vertical_resolution
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-EvaIncrement = QuestionList(
-    list_type="task",
+EvaIncrement = TaskQuestionList(
     name="EvaIncrement",
     questions=[
-        "marine_models",
-        "window_offset",
-        "window_type"
+        tq.marine_models,
+        tq.window_offset,
+        tq.window_type
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GenerateObservingSystemRecords = QuestionList(
-    list_type="task",
+GenerateObservingSystemRecords = TaskQuestionList(
     name="GenerateObservingSystemRecords",
     questions=[
-        "observations",
-        "observing_system_records_mksi_path",
-        "observing_system_records_path"
+        tq.observations,
+        tq.observing_system_records_mksi_path,
+        tq.observing_system_records_path
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GsiNcdiagToIoda = QuestionList(
-    list_type="task",
+GsiNcdiagToIoda = TaskQuestionList(
     name="GsiNcdiagToIoda",
     questions=[
-        "observations",
-        "produce_geovals",
-        "single_observations",
-        "window_offset"
+        tq.observations,
+        tq.produce_geovals,
+        tq.single_observations,
+        tq.window_offset
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-CloneGeosMksi = QuestionList(
-    list_type="task",
+CloneGeosMksi = TaskQuestionList(
     name="CloneGeosMksi",
     questions=[
-        "observing_system_records_mksi_path",
-        "observing_system_records_mksi_path_tag"
+        tq.observing_system_records_mksi_path,
+        tq.observing_system_records_mksi_path_tag
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GetEnsemble = QuestionList(
-    list_type="task",
+GetEnsemble = TaskQuestionList(
     name="GetEnsemble",
     questions=[
-        "path_to_ensemble"
+        tq.path_to_ensemble
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GetGeosAdasBackground = QuestionList(
-    list_type="task",
+GetGeosAdasBackground = TaskQuestionList(
     name="GetGeosAdasBackground",
     questions=[
-        "path_to_geos_adas_background"
+        tq.path_to_geos_adas_background
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GetGsiBc = QuestionList(
-    list_type="task",
+GetGsiBc = TaskQuestionList(
     name="GetGsiBc",
     questions=[
-        "path_to_gsi_bc_coefficients",
-        "window_length"
+        tq.path_to_gsi_bc_coefficients,
+        tq.window_length
     ]
 )
 
 
 # --------------------------------------------------------------------------------------------------
 
-GetGsiNcdiag = QuestionList(
-    list_type="task",
+GetGsiNcdiag = TaskQuestionList(
     name="GetGsiNcdiag",
     questions=[
-        "path_to_gsi_nc_diags"
+        tq.path_to_gsi_nc_diags
     ]
 )
 

--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -1,0 +1,1284 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+import os
+from dataclasses import dataclass
+
+from swell.utilities.swell_questions import SwellQuestion
+
+
+# --------------------------------------------------------------------------------------------------
+analysis_forecast_window_offset = SwellQuestion(
+    name="analysis_forecast_window_offset",
+    question_type="task",
+    default_value="defer_to_model",
+    options="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="What is the duration from the middle of the window when forecasts start?",
+    dtype="string-check-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+analysis_variables = SwellQuestion(
+    name="analysis_variables",
+    question_type="task",
+    default_value="defer_to_model",
+    options="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="What are the analysis variables?",
+    dtype="string-check-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+background_error_model = SwellQuestion(
+    name="background_error_model",
+    question_type="task",
+    default_value="defer_to_model",
+    options="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="Which background error model do you want to use?",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+background_experiment = SwellQuestion(
+    name="background_experiment",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "all_models"
+    ],
+    prompt="What is the name of the name of the experiment providing the backgrounds?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+background_frequency = SwellQuestion(
+    name="background_frequency",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    depends={
+        "window_type": "4D"
+    },
+    prompt="What is the frequency of the background files?",
+    dtype="iso-duration"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+background_time_offset = SwellQuestion(
+    name="background_time_offset",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="How long before the middle of the analysis window did" +
+    " the background providing forecast begin?",
+    dtype="iso-duration"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+bundles = SwellQuestion(
+    name="bundles",
+    question_type="task",
+    default_value=[
+        "fv3-jedi",
+        "soca",
+        "iodaconv",
+        "ufo"
+    ],
+    ask_question=True,
+    options=[
+        "fv3-jedi",
+        "soca",
+        "iodaconv",
+        "ufo",
+        "ioda",
+        "oops",
+        "saber"
+    ],
+    depends={
+        "jedi_build_method": "create"
+    },
+    prompt="Which JEDI bundles do you wish to build?",
+    dtype="string-check-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+cice6_domains = SwellQuestion(
+    name="cice6_domains",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "geos_marine"
+    ],
+    prompt="Which CICE6 domains do you wish to run DA for?",
+    dtype="string-check-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+clean_patterns = SwellQuestion(
+    name="clean_patterns",
+    question_type="task",
+    default_value="defer_to_model",
+    options="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="Provide a list of patterns that you wish to remove from the cycle directory.",
+    dtype="string-check-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+crtm_coeff_dir = SwellQuestion(
+    name="crtm_coeff_dir",
+    question_type="task",
+    default_value="defer_to_platform",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the path to the CRTM coefficient files?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+cycling_varbc = SwellQuestion(
+    name="cycling_varbc",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Do you want to use cycling VarBC option?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+ensemble_hofx_packets = SwellQuestion(
+    name="ensemble_hofx_packets",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Enter number of packets in which ensemble observers should be computed.",
+    dtype="integer"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+ensemble_hofx_strategy = SwellQuestion(
+    name="ensemble_hofx_strategy",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Enter hofx strategy.",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+ensemble_num_members = SwellQuestion(
+    name="ensemble_num_members",
+    question_type="task",
+    default_value="defer_to_model",
+    options="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="How many members comprise the ensemble?",
+    dtype="integer"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+ensmean_only = SwellQuestion(
+    name="ensmean_only",
+    question_type="task",
+    default_value=False,
+    options=[
+        True,
+        False
+    ],
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Calculate ensemble mean only?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+ensmeanvariance_only = SwellQuestion(
+    name="ensmeanvariance_only",
+    question_type="task",
+    default_value=False,
+    options=[
+        True,
+        False
+    ],
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Calculate ensemble mean and variance only?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+existing_geos_gcm_build_path = SwellQuestion(
+    name="existing_geos_gcm_build_path",
+    question_type="task",
+    default_value="defer_to_platform",
+    ask_question=True,
+    depends={
+        "geos_build_method": "use_existing"
+    },
+    prompt="What is the path to the existing GEOS build directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+existing_geos_gcm_source_path = SwellQuestion(
+    name="existing_geos_gcm_source_path",
+    question_type="task",
+    default_value="defer_to_platform",
+    ask_question=True,
+    depends={
+        "geos_build_method": "use_existing"
+    },
+    prompt="What is the path to the existing GEOS source code directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+existing_jedi_build_directory = SwellQuestion(
+    name="existing_jedi_build_directory",
+    question_type="task",
+    default_value="defer_to_platform",
+    ask_question=True,
+    depends={
+        "jedi_build_method": "use_existing"
+    },
+    prompt="What is the path to the existing JEDI build directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+existing_jedi_build_directory_pinned = SwellQuestion(
+    name="existing_jedi_build_directory_pinned",
+    question_type="task",
+    default_value="defer_to_platform",
+    ask_question=True,
+    depends={
+        "jedi_build_method": "use_pinned_existing"
+    },
+    prompt="What is the path to the existing pinned JEDI build directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+existing_jedi_source_directory = SwellQuestion(
+    name="existing_jedi_source_directory",
+    question_type="task",
+    default_value="defer_to_platform",
+    ask_question=True,
+    depends={
+        "jedi_build_method": "use_existing"
+    },
+    prompt="What is the path to the existing JEDI source code directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+existing_jedi_source_directory_pinned = SwellQuestion(
+    name="existing_jedi_source_directory_pinned",
+    question_type="task",
+    default_value="defer_to_platform",
+    ask_question=True,
+    depends={
+        "jedi_build_method": "use_pinned_existing"
+    },
+    prompt="What is the path to the existing pinned JEDI source code directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+forecast_duration = SwellQuestion(
+    name="forecast_duration",
+    question_type="task",
+    default_value="PT12H",
+    ask_question=True,
+    prompt="GEOS forecast duration",
+    dtype="iso-duration"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+generate_yaml_and_exit = SwellQuestion(
+    name="generate_yaml_and_exit",
+    question_type="task",
+    default_value=False,
+    prompt="Generate JEDI executable YAML and exit?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+geos_build_method = SwellQuestion(
+    name="geos_build_method",
+    question_type="task",
+    default_value="create",
+    ask_question=True,
+    options=[
+        "use_existing",
+        "create"
+    ],
+    prompt="Do you want to use an existing GEOS build or create a new build?",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+geos_experiment_directory = SwellQuestion(
+    name="geos_experiment_directory",
+    question_type="task",
+    default_value="defer_to_platform",
+    ask_question=True,
+    prompt="What is the path to the GEOS restarts directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+geos_gcm_tag = SwellQuestion(
+    name="geos_gcm_tag",
+    question_type="task",
+    default_value="v11.6.0",
+    ask_question=True,
+    prompt="Which GEOS tag do you wish to clone?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+geos_restarts_directory = SwellQuestion(
+    name="geos_restarts_directory",
+    question_type="task",
+    default_value="defer_to_platform",
+    ask_question=True,
+    prompt="What is the path to the GEOS restarts directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+geos_x_background_directory = SwellQuestion(
+    name="geos_x_background_directory",
+    question_type="task",
+    default_value="/dev/null/",
+    ask_question=True,
+    options=[
+        "/dev/null/",
+        "/gpfsm/dnb05/projects/p139/dao_it/archive/"
+    ],
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the path to the GEOS X-backgrounds directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+geovals_experiment = SwellQuestion(
+    name="geovals_experiment",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the name of the R2D2 experiment providing the GeoVaLs?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+geovals_provider = SwellQuestion(
+    name="geovals_provider",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the name of the R2D2 database providing the GeoVaLs?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+gradient_norm_reduction = SwellQuestion(
+    name="gradient_norm_reduction",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="What value of gradient norm reduction for convergence?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+gsibec_configuration = SwellQuestion(
+    name="gsibec_configuration",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Which GSIBEC climatological or hybrid?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+horizontal_localization_lengthscale = SwellQuestion(
+    name="horizontal_localization_lengthscale",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the length scale for horizontal covariance localization?",
+    dtype="float"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+horizontal_localization_max_nobs = SwellQuestion(
+    name="horizontal_localization_max_nobs",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the maximum number of observations to consider"
+    + " for horizontal covariance localization?",
+    dtype="integer"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+horizontal_localization_method = SwellQuestion(
+    name="horizontal_localization_method",
+    question_type="task",
+    default_value="defer_to_model",
+    options="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Which localization scheme should be applied in the horizontal?",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+horizontal_resolution = SwellQuestion(
+    name="horizontal_resolution",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="What is the horizontal resolution for the forecast model and backgrounds?",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+jedi_build_method = SwellQuestion(
+    name="jedi_build_method",
+    question_type="task",
+    default_value="create",
+    ask_question=True,
+    options=[
+        "use_existing",
+        "use_pinned_existing",
+        "create",
+        "pinned_create"
+    ],
+    prompt="Do you want to use an existing JEDI build or create a new build?",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+jedi_forecast_model = SwellQuestion(
+    name="jedi_forecast_model",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    depends={
+        "window_type": "4D"
+    },
+    prompt="What forecast model should be used within JEDI for 4D window propagation?",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+local_ensemble_inflation_mult = SwellQuestion(
+    name="local_ensemble_inflation_mult",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Specify the multiplicative prior inflation coefficient (0, inf].",
+    dtype="float"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+local_ensemble_inflation_rtpp = SwellQuestion(
+    name="local_ensemble_inflation_rtpp",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Specify the Relaxation To Prior Perturbation (RTPP) coefficient (0, 1].",
+    dtype="float"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+local_ensemble_inflation_rtps = SwellQuestion(
+    name="local_ensemble_inflation_rtps",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Specify the Relaxation To Prior Spread (RTPS) coefficient (0, 1].",
+    dtype="float"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+local_ensemble_save_posterior_ensemble = SwellQuestion(
+    name="local_ensemble_save_posterior_ensemble",
+    question_type="task",
+    default_value=False,
+    options=[
+        True,
+        False
+    ],
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Save the posterior ensemble members?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+local_ensemble_save_posterior_ensemble_increments = SwellQuestion(
+    name="local_ensemble_save_posterior_ensemble_increments",
+    question_type="task",
+    default_value=False,
+    ask_question=True,
+    options=[
+        True,
+        False
+    ],
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Save the posterior ensemble member increments?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+local_ensemble_save_posterior_mean = SwellQuestion(
+    name="local_ensemble_save_posterior_mean",
+    question_type="task",
+    default_value=False,
+    ask_question=True,
+    options=[
+        True,
+        False
+    ],
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Save the posterior ensemble mean?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+local_ensemble_save_posterior_mean_increment = SwellQuestion(
+    name="local_ensemble_save_posterior_mean_increment",
+    question_type="task",
+    default_value=True,
+    ask_question=True,
+    options=[
+        True,
+        False
+    ],
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Save the posterior ensemble mean increment?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+local_ensemble_solver = SwellQuestion(
+    name="local_ensemble_solver",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Which local ensemble solver type should be implemented?",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+local_ensemble_use_linear_observer = SwellQuestion(
+    name="local_ensemble_use_linear_observer",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Which local ensemble solver type should be implemented?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+marine_models = SwellQuestion(
+    name="marine_models",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "geos_marine"
+    ],
+    prompt="Enter the active SOCA models for this model.",
+    dtype="string-check-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+minimizer = SwellQuestion(
+    name="minimizer",
+    question_type="task",
+    default_value="defer_to_model",
+    options="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="Which data assimilation minimizer do you wish to use?",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+mom6_iau = SwellQuestion(
+    name="mom6_iau",
+    question_type="task",
+    default_value="defer_to_model",
+    options=[
+        True,
+        False
+    ],
+    models=[
+        "geos_marine",
+        "geos_ocean"
+    ],
+    prompt="Do you wish to use IAU for MOM6?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+npx_proc = SwellQuestion(
+    name="npx_proc",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What number of processors do you wish to use in the x-direction?",
+    dtype="integer"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+npy_proc = SwellQuestion(
+    name="npy_proc",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What number of processors do you wish to use in the y-direction?",
+    dtype="integer"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+number_of_iterations = SwellQuestion(
+    name="number_of_iterations",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="What number of iterations do you wish to use for each outer loop?" +
+    " Provide a list of integers the same length as the number of outer loops.",
+    dtype="integer-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+obs_experiment = SwellQuestion(
+    name="obs_experiment",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "all_models"
+    ],
+    prompt="What is the database providing the observations?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+obs_provider = SwellQuestion(
+    name="obs_provider",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "all_models"
+    ],
+    prompt="Which group(s) provide the observations?",
+    dtype="string-check-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+observations = SwellQuestion(
+    name="observations",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="Which observations do you want to include?",
+    dtype="string-check-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+observing_system_records_mksi_path = SwellQuestion(
+    name="observing_system_records_mksi_path",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the path to the GSI formatted observing system records?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+observing_system_records_mksi_path_tag = SwellQuestion(
+    name="observing_system_records_mksi_path_tag",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the GSI formatted observing system records tag?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+observing_system_records_path = SwellQuestion(
+    name="observing_system_records_path",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the path to the Swell formatted observing system records?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+path_to_ensemble = SwellQuestion(
+    name="path_to_ensemble",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the path to where ensemble members are stored?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+path_to_geos_adas_background = SwellQuestion(
+    name="path_to_geos_adas_background",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the path to where the cubed sphere backgrounds are in the GEOSadas run?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+path_to_gsi_bc_coefficients = SwellQuestion(
+    name="path_to_gsi_bc_coefficients",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the location where GSI bias correction files can be found?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+path_to_gsi_nc_diags = SwellQuestion(
+    name="path_to_gsi_nc_diags",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the path to where the GSI ncdiags are stored?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+produce_geovals = SwellQuestion(
+    name="produce_geovals",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options=[
+        True,
+        False
+    ],
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="When running the ncdiag to ioda converted do you want to produce GeoVaLs files?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+r2d2_local_path = SwellQuestion(
+    name="r2d2_local_path",
+    question_type="task",
+    default_value="defer_to_platform",
+    prompt="What is the path to the R2D2 local directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+save_geovals = SwellQuestion(
+    name="save_geovals",
+    question_type="task",
+    default_value=False,
+    options=[
+        True,
+        False
+    ],
+    prompt="When running hofx do you want to output the GeoVaLs?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+single_observations = SwellQuestion(
+    name="single_observations",
+    question_type="task",
+    default_value=False,
+    options=[
+        True,
+        False
+    ],
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Is it a single-observation test?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+skip_ensemble_hofx = SwellQuestion(
+    name="skip_ensemble_hofx",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Which local ensemble solver type should be implemented?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+swell_static_files = SwellQuestion(
+    name="swell_static_files",
+    question_type="task",
+    default_value="defer_to_platform",
+    prompt="What is the path to the Swell Static files directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+swell_static_files_user = SwellQuestion(
+    name="swell_static_files_user",
+    question_type="task",
+    default_value="None",
+    prompt="What is the path to the user provided Swell Static Files directory?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+total_processors = SwellQuestion(
+    name="total_processors",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "geos_marine",
+        "geos_ocean"
+    ],
+    prompt="What is the number of processors for JEDI?",
+    dtype="integer"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+vertical_localization_apply_log_transform = SwellQuestion(
+    name="vertical_localization_apply_log_transform",
+    question_type="task",
+    default_value=True,
+    options=[
+        True,
+        False
+    ],
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Should a log (base 10) transformation be applied to vertical coordinate when" +
+    " constructing vertical localization?",
+    dtype="boolean"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+vertical_localization_function = SwellQuestion(
+    name="vertical_localization_function",
+    question_type="task",
+    default_value="defer_to_model",
+    options="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Which localization scheme should be applied in the vertical?",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+vertical_localization_ioda_vertical_coord = SwellQuestion(
+    name="vertical_localization_ioda_vertical_coord",
+    question_type="task",
+    default_value="defer_to_model",
+    options="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Which coordinate should be used in constructing vertical localization?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+vertical_localization_ioda_vertical_coord_group = SwellQuestion(
+    name="vertical_localization_ioda_vertical_coord_group",
+    question_type="task",
+    default_value="defer_to_model",
+    options="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="Which vertical coordinate group should be used in constructing vertical localization?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+vertical_localization_lengthscale = SwellQuestion(
+    name="vertical_localization_lengthscale",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What is the length scale for vertical covariance localization?",
+    dtype="integer"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+vertical_localization_method = SwellQuestion(
+    name="vertical_localization_method",
+    question_type="task",
+    default_value="defer_to_model",
+    options="defer_to_model",
+    models=[
+        "geos_atmosphere"
+    ],
+    prompt="What localization scheme should be applied in constructing a vertical localization?",
+    dtype="string"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+vertical_resolution = SwellQuestion(
+    name="vertical_resolution",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="What is the vertical resolution for the forecast model and background?",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+window_length = SwellQuestion(
+    name="window_length",
+    question_type="task",
+    default_value="defer_to_model",
+    models=[
+        "all_models"
+    ],
+    prompt="What is the duration for the data assimilation window?",
+    dtype="iso-duration"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+window_offset = SwellQuestion(
+    name="window_offset",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    models=[
+        "all_models"
+    ],
+    prompt="What is the duration between the middle of the window and the beginning?",
+    dtype="iso-duration"
+)
+
+
+# --------------------------------------------------------------------------------------------------
+
+window_type = SwellQuestion(
+    name="window_type",
+    question_type="task",
+    default_value="defer_to_model",
+    ask_question=True,
+    options=[
+        "3D",
+        "4D"
+    ],
+    models=[
+        "all_models"
+    ],
+    prompt="Do you want to use a 3D or 4D (including FGAT) window?",
+    dtype="string-drop-list"
+)
+
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/utilities/swell_questions.py
+++ b/src/swell/utilities/swell_questions.py
@@ -1,20 +1,3 @@
-# (C) Copyright 2021- United States Government as represented by the Administrator of the
-# National Aeronautics and Space Administration. All Rights Reserved.
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
-# --------------------------------------------------------------------------------------------------
-
-
-import os
-import yaml
-from typing import Callable
-
-from swell.swell_path import get_swell_path
-from swell.utilities.logger import Logger
-
-
 # --------------------------------------------------------------------------------------------------
 #  @package configuration
 #
@@ -26,7 +9,7 @@ from swell.utilities.logger import Logger
 
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional 
 
 
 # --------------------------------------------------------------------------------------------------
@@ -76,12 +59,14 @@ class QuestionList:
 
 
 class TaskQuestionList(QuestionList):
+    questions: List[TaskQuestion]
     list_type = 'task'
 
 # --------------------------------------------------------------------------------------------------
 
 
 class SuiteQuestionList(QuestionList):
+    questions: List[SuiteQuestion]
     list_type = 'suite'
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/utilities/swell_questions.py
+++ b/src/swell/utilities/swell_questions.py
@@ -26,6 +26,7 @@ from swell.utilities.logger import Logger
 
 
 from dataclasses import dataclass
+from typing import Optional
 
 
 # --------------------------------------------------------------------------------------------------
@@ -35,16 +36,28 @@ class SwellQuestion:
     """Basic dataclass for defining Swell questions for suites and tasks"""
     name: str
     dtype: str
-    question_type: str
     default_value: str
     prompt: str
-    depends: dict = None
-    models: list = None
+    question_type: str = None
+    depends: Optional[dict] = None
+    models: Optional[list] = None
     ask_question: bool = False
-    options: str = None
+    options: Optional[str] = None
 
     def get(self, attr, default=None):
         return getattr(self, attr, default)
+
+# --------------------------------------------------------------------------------------------------
+
+
+class TaskQuestion(SwellQuestion):
+    question_type = 'task'
+
+# --------------------------------------------------------------------------------------------------
+
+
+class SuiteQuestion(SwellQuestion):
+    question_type = 'suite'
 
 # --------------------------------------------------------------------------------------------------
 
@@ -53,10 +66,22 @@ class SwellQuestion:
 class QuestionList:
     """Basic dataclass containing a list of questions for each model, suite, task"""
     name: str
-    list_type: str
     questions: list
+    list_type: str = None
 
     def get(self, attr, default=None):
         return getattr(self, attr, default)
+
+# --------------------------------------------------------------------------------------------------
+
+
+class TaskQuestionList(QuestionList):
+    list_type = 'task'
+
+# --------------------------------------------------------------------------------------------------
+
+
+class SuiteQuestionList(QuestionList):
+    list_type = 'suite'
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/utilities/swell_questions.py
+++ b/src/swell/utilities/swell_questions.py
@@ -1,0 +1,62 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# --------------------------------------------------------------------------------------------------
+
+
+import os
+import yaml
+from typing import Callable
+
+from swell.swell_path import get_swell_path
+from swell.utilities.logger import Logger
+
+
+# --------------------------------------------------------------------------------------------------
+#  @package configuration
+#
+#  Class containing the configuration. This is a dictionary that is converted from
+#  an input yaml configuration file. Various function are included for interacting with the
+#  dictionary.
+#
+# --------------------------------------------------------------------------------------------------
+
+
+from dataclasses import dataclass
+
+
+# --------------------------------------------------------------------------------------------------
+
+@dataclass
+class SwellQuestion:
+    """Basic dataclass for defining Swell questions for suites and tasks"""
+    name: str
+    dtype: str
+    question_type: str
+    default_value: str
+    prompt: str
+    depends: dict = None
+    models: list = None
+    ask_question: bool = False
+    options: str = None
+
+    def get(self, attr, default=None):
+        return getattr(self, attr, default)
+
+# --------------------------------------------------------------------------------------------------
+
+
+@dataclass
+class QuestionList:
+    """Basic dataclass containing a list of questions for each model, suite, task"""
+    name: str
+    list_type: str
+    questions: list
+
+    def get(self, attr, default=None):
+        return getattr(self, attr, default)
+
+# --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is a prototype for an alternative method of handling task and suite questions. Rather than having a set of questions that tell Swell what tasks they belong to, tasks and suites can be defined as a list of questions, whose properties are defined separately. All Swell questions have been refactored as python dataclass objects, and have had their task/suite declarations transformed into a list of questions associated with each task and suite. 

`prepare_config_and_suite.py` has been modified to accept this new approach. Rather than reading the entire list of all potential suite and task questions for everything in swell, only the list of questions for the particular suite being run are read, as well as only questions for the tasks needed by the suite.

From what I’ve tested, it behaves almost identically to the previous method as far as creating `experiment.yaml` is concerned, with the exception that some questions appear in a different order, which should probably be fixed for readability. `code_tests` will need to be modified as well, but I wanted to get opinions on whether this is even a good method.

I believe the major positive to this method are that it is more intuitive to look at things from a suite and task perspective, rather than having questions defining what task and suites they are a part of, like Alexey said in (#314). Having questions defined per suite and task also gives some flexibility in letting us spread out definitions a bit, rather than having to read it all in a centralized place, then throw out what we don’t need. The python dataclasses also will allow for some more powerful options for value assignments.

As for cons, in its current configuration I’m not sure this does much to fix the concern of having all swell-wide questions within two files. It adds separate files for declaring all questions for each task and suites `task_question_list.py`, `suite_question_list.py`, which we could spread out into separate files (maybe even into the existing task python files). It also doesn’t yet address the need to potentially have different defaults depending on the context. I think we could probably implement a simple system where `default_value` is defined as a dictionary with some basic dependencies like task or suite being run, but that might get messy if you have multiple tasks using the same question during setup. 

Let me know if this looks like a good way to proceed, or any suggestions!

