### PR TITLE
Peg mksi to tag

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -246,7 +246,7 @@ observing_system_records_mksi_path:
   default_value: None
 
 observing_system_records_mksi_path_tag:
-  default_value: None
+  default_value: g5.41.3
 
 observing_system_records_path:
   default_value: None


### PR DESCRIPTION
## Description

This is a bug fix: the latest version of swell is aimed at testing (atmos) x0050 - this requires mksi to be pegged to particular version of mksi. 

Is the change made enough to take care of this?   I believe it is, but would be nice to confirm that this is indeed the only needed changed.

## Dependencies

none

## Impact

- [ ] this is something that would have been affecting results from some of the experiments before updating to x0050 as default of atmos Var. This is because x0048 (which was the provious default) had a different mksi). Not a big deal for previous stuff but needs fixing.
