### PR TITLE
Fixed bug where models in override.yaml would overwrite tier1 defaults

### DIFF
--- a/src/swell/deployment/prepare_config_and_suite/prepare_config_and_suite.py
+++ b/src/swell/deployment/prepare_config_and_suite/prepare_config_and_suite.py
@@ -311,10 +311,10 @@ class PrepareExperimentConfigAndSuite:
         if self.override is not None:
 
             if isinstance(self.override, dict):
-                override_dict.update(self.override)
+                override_dict = update_dict(override_dict, self.override)
             elif isinstance(self.override, str):
                 with open(self.override, 'r') as ymlfile:
-                    override_dict.update(yaml.safe_load(ymlfile))
+                    override_dict = update_dict(override_dict, yaml.safe_load(ymlfile))
             else:
                 self.logger.abort(f'Override must be a dictionary or a path to a yaml file.')
 


### PR DESCRIPTION
This PR fixes a bug (#510 ) where any model being added in `override.yaml` would cause the entire override subdictionary for that model to be overwritten. Since the defaults that swell uses are actually sourced from the tier1 overrides immediately before that step, it means that the usual defaults are deleted and the values from elsewhere (`task_questions.yaml`) are used. This fix just changes the updating of the override dict to use the `update_dict` function from utilities, which can handle replacing values in a dict without overwriting the entire dict.