### PR TITLE
Reviving 3dvar_cycle and 3dfgat_cycle suite defaults

### DIFF
--- a/src/swell/__init__.py
+++ b/src/swell/__init__.py
@@ -9,4 +9,4 @@ import os
 repo_directory = os.path.dirname(__file__)
 
 # Set the version for swell
-__version__ = '1.9.6'
+__version__ = '1.9.7'

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/background.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/background.yaml
@@ -6,9 +6,11 @@ ocn_filename: 'MOM6.res.{{local_background_time}}.nc'
 ice_filename: 'cice.res.{{local_background_time}}.nc'
 {% endif %}
 state variables:
+{% if 'cice6' in marine_models %}
   - sea_ice_area_fraction
   - sea_ice_thickness
   - sea_ice_snow_thickness
+{% endif %}
   - sea_water_salinity
   - sea_water_potential_temperature
   - sea_surface_height_above_geoid

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/background_error.yaml
@@ -2,9 +2,11 @@ covariance model: SABER
 saber central block:
   saber block name: diffusion
   active variables:
+  {% if 'cice6' in marine_models %}
     - sea_ice_area_fraction
     - sea_ice_thickness
     - sea_ice_snow_thickness
+  {% endif %}
     - sea_water_potential_temperature
     - sea_water_salinity
     - sea_surface_height_above_geoid
@@ -18,9 +20,11 @@ saber central block:
         filepath: 'background_error_model/vt.{{local_background_time}}'
     - variables:
       - sea_surface_height_above_geoid
+    {% if 'cice6' in marine_models %}
       - sea_ice_area_fraction
       - sea_ice_thickness
       - sea_ice_snow_thickness
+    {% endif %}
       horizontal:
         filepath: 'background_error_model/hz_rossby_1p5'
 

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/r2d2.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/r2d2.yaml
@@ -2,13 +2,17 @@ fetch:
   an:
     - file_type: MOM.res
       filename: '{{cycle_dir}}/MOM6.res.{{local_background_time}}.nc'
+    {% if 'cice6' in marine_models %}
     - file_type: cice.res
       filename: '{{cycle_dir}}/cice.res.{{local_background_time}}.nc'
+    {% endif %}
   fc:
     - file_type: MOM.res
       filename: '{{cycle_dir}}/MOM6.res.{{local_background_time}}.nc'
+    {% if 'cice6' in marine_models %}
     - file_type: cice.res
       filename: '{{cycle_dir}}/cice.res.{{local_background_time}}.nc'
+    {% endif %}
 store:
   fc:
     - file_type: MOM.res

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/states.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/states.yaml
@@ -10,9 +10,11 @@
       - sea_water_potential_temperature
       - sea_water_salinity
       - sea_water_cell_thickness
+    {% if 'cice6' in marine_models %}
       - sea_ice_area_fraction
       - sea_ice_thickness
       - sea_ice_snow_thickness
+    {% endif %}
   output:
     datadir: ./
     exp: {{experiment_id}}

--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/variable_change_soca2cice.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/variable_change_soca2cice.yaml
@@ -1,18 +1,24 @@
 # Notice the difference between iced (CICE6 restart) and cice (SOCA CICE6 input)
 variable change name: Soca2Cice
-do inverse: false
-seaice edge: 0.8
-shuffle: false
-rescale prior:
-  min hice: 0.5
-  min hsno: 0.1
-domain: {{cice6_domain}}
+arctic:
+  seaice edge: 0.4
+  shuffle: true
+  rescale prior:
+    rescale: true
+    min hice: 0.5
+    min hsno: 0.1
+antarctic:
+  seaice edge: 0.4
+  shuffle: true
+  rescale prior:
+    rescale: true
+    min hice: 0.5
+    min hsno: 0.1
 cice background state:
   restart: 'iced.res.{{local_background_time}}.nc'
   ncat: 5
   ice_lev: 7
   sno_lev: 1
-  tstep: PT1H
 cice output:
   restart: 'iced.res.{{local_background_time}}.nc'
 output variables:

--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/sst_ostia.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/sst_ostia.yaml
@@ -30,10 +30,6 @@ obs filters:
     minvalue: 0.001
 - filter: Domain Check
   where:
-  - variable: { name: GeoVaLs/sea_ice_area_fraction}
-    maxvalue: 0.00001
-- filter: Domain Check
-  where:
   - variable: {name: GeoVaLs/distance_from_coast}
     minvalue: 100e3
 - filter: Domain Check
@@ -42,3 +38,9 @@ obs filters:
   where:
   - variable: {name: GeoVaLs/sea_area_fraction}
     maxvalue: 0.9
+{% if 'cice6' in marine_models %}
+- filter: Domain Check
+  where:
+  - variable: { name: GeoVaLs/sea_ice_area_fraction}
+    maxvalue: 0.00001
+{% endif %}

--- a/src/swell/configuration/jedi/interfaces/geos_marine/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/task_questions.yaml
@@ -25,17 +25,11 @@ background_experiment:
 
 background_frequency:
   default_value: PT3H
+  options:
+  - PT3H
 
 background_time_offset:
   default_value: PT9H
-
-cice6_domains:
-  default_value:
-  - arctic
-  - antarctic
-  options:
-  - arctic
-  - antarctic
 
 clean_patterns:
   default_value:
@@ -134,4 +128,6 @@ window_offset:
 
 window_type:
   default_value: 3D
-
+  options:
+  - 3D
+  - 4D

--- a/src/swell/configuration/jedi/interfaces/geos_marine/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/task_questions.yaml
@@ -131,3 +131,4 @@ window_type:
   options:
   - 3D
   - 4D
+

--- a/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
@@ -20,10 +20,10 @@ existing_jedi_source_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles/current_pinned_jedi_bundle/source/
 
 geos_experiment_directory:
-  default_value: 5deg_v11
+  default_value: 5deg_0701
 
 geos_restarts_directory:
-  default_value: restarts_20210601_030000
+  default_value: restarts_20210701_210000_5deg
 
 r2d2_local_path:
   default_value: /discover/nobackup/${USER}/R2D2DataStore/Local

--- a/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
@@ -20,10 +20,10 @@ existing_jedi_source_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/source/
 
 geos_experiment_directory:
-  default_value: 5deg_v11
+  default_value: 5deg_0701
 
 geos_restarts_directory:
-  default_value: restarts_20210601_030000
+  default_value: restarts_20210701_210000_5deg
 
 r2d2_local_path:
   default_value: /discover/nobackup/${USER}/R2D2DataStore/Local

--- a/src/swell/suites/3dfgat_cycle/flow.cylc
+++ b/src/swell/suites/3dfgat_cycle/flow.cylc
@@ -82,7 +82,6 @@
             GenerateBClimatologyByLinking-{{model_component}} :fail? => GenerateBClimatology-{{model_component}}
 
             LinkGeosOutput-{{model_component}} => RunJediFgatExecutable-{{model_component}}
-            # StageJedi-{{model_component}}[^] => RunJediFgatExecutable-{{model_component}}
             StageJediCycle-{{model_component}} => RunJediFgatExecutable-{{model_component}}
             GenerateBClimatologyByLinking-{{model_component}}? | GenerateBClimatology-{{model_component}} => RunJediFgatExecutable-{{model_component}}
             GetObservations-{{model_component}} => RunJediFgatExecutable-{{model_component}}

--- a/src/swell/suites/3dvar_cycle/eva/increment-geos_marine.yaml
+++ b/src/swell/suites/3dvar_cycle/eva/increment-geos_marine.yaml
@@ -7,12 +7,14 @@ datasets:
     variables: [Temp, Salt, ave_ssh]
     coordinate variables: [lon, lat]
 
+{% if 'cice6' in marine_models %}
   - name: seaice_increment
     type: SocaRestart
     soca_filenames: {{ice_increment_file_path}}
     geometry_file: {{cycle_dir}}/INPUT/soca_gridspec.nc
     variables: [aice_h]
     coordinate variables: [lon, lat]
+{% endif %}
 
 graphics:
 
@@ -108,6 +110,7 @@ graphics:
           vmin: -1
           vmax: 1
 
+{% if 'cice6' in marine_models %}
   - batch figure:
       variables: [aice_h]
     figure:
@@ -164,3 +167,4 @@ graphics:
           cmap: 'bwr'
           vmin: -1
           vmax: 1
+{% endif %}

--- a/src/swell/suites/3dvar_cycle/eva/increment-geos_ocean.yaml
+++ b/src/swell/suites/3dvar_cycle/eva/increment-geos_ocean.yaml
@@ -1,0 +1,103 @@
+datasets:
+
+  - name: experiment_increment
+    type: SocaRestart
+    soca_filenames: {{increment_file_path}}
+    geometry_file: {{cycle_dir}}/INPUT/soca_gridspec.nc
+
+    variables: [Temp, Salt, ave_ssh]
+    coordinate variables: [lon, lat]
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  - batch figure:
+      variables: [ave_ssh]
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'SOCA Increment'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SSH Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment::SOCAgrid::lat
+          data:
+            variable: experiment_increment::SOCAVars::ave_ssh
+          label: ave_ssh increment
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.25
+          vmax: 0.25
+
+  - batch figure:
+      variables: [Temp]
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'Soca Increment'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SST Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment::SOCAgrid::lat
+          data:
+            variable: experiment_increment::SOCAVars::Temp
+            slices: '[0,...]'
+          label: SST increment
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -3
+          vmax: 3
+
+  - batch figure:
+      variables: [Salt]
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'Soca Increment'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SSS Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment::SOCAgrid::lat
+          data:
+            variable: experiment_increment::SOCAVars::Salt
+            slices: '[0,...]'
+          label: SSS increment
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1

--- a/src/swell/suites/3dvar_cycle/eva/jedi_log-geos_ocean.yaml
+++ b/src/swell/suites/3dvar_cycle/eva/jedi_log-geos_ocean.yaml
@@ -1,0 +1,57 @@
+datasets:
+
+- type: JediLog
+  collection_name: jedi_log_test
+  jedi_log_to_parse: '{{cycle_dir}}/jedi_variational_log.log'
+  data_to_parse:
+    convergence: true
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  - figure:
+      layout: [3,1]
+      figure size: [12,10]
+      title: 'Residual Norm and Norm Reduction Plots'
+      output name: '{{cycle_dir}}/eva/jedi_log/convergence/residual_norm_reduction.png'
+    plots:
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Residual norm'
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::residual_norm
+          color: 'black'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Norm reduction'
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::norm_reduction
+          color: 'black'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Normalized Value'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::residual_norm_normalized
+          color: 'red'
+          label: 'Normalized residual norm'
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::norm_reduction_normalized
+          color: 'blue'
+          label: 'Normalized norm reduction'

--- a/src/swell/suites/3dvar_cycle/eva/observations-geos_ocean.yaml
+++ b/src/swell/suites/3dvar_cycle/eva/observations-geos_ocean.yaml
@@ -1,0 +1,293 @@
+datasets:
+
+- name: experiment
+  type: IodaObsSpace
+  filenames:
+    - {{obs_path_file}}
+  groups:
+    - name: ObsValue
+      variables: &variables {{simulated_variables}}
+    - name: hofx0
+    - name: hofx1
+    - name: ombg
+    - name: oman
+    - name: MetaData
+    - name: EffectiveQC0
+    - name: EffectiveQC1
+
+transforms:
+
+# Generate Increment for JEDI
+- transform: arithmetic
+  new name: experiment::increment::${variable}
+  equals: experiment::ombg::${variable}-experiment::oman::${variable}
+  for:
+    variable: *variables
+
+# Generate hofx0 that passed QC for JEDI
+- transform: accept where
+  new name: experiment::hofx0PassedQc::${variable}
+  starting field: experiment::hofx0::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate hofx1 that passed QC for JEDI
+- transform: accept where
+  new name: experiment::hofx1PassedQc::${variable}
+  starting field: experiment::hofx1::${variable}
+  where:
+    - experiment::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate ombg that passed QC for JEDI
+- transform: accept where
+  new name: experiment::ombgPassedQc::${variable}
+  starting field: experiment::ombg::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate oman that passed QC for JEDI
+- transform: accept where
+  new name: experiment::omanPassedQc::${variable}
+  starting field: experiment::oman::${variable}
+  where:
+    - experiment::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate obs that passed QC for JEDI
+- transform: accept where
+  new name: experiment::ObsValuePassedQc::${variable}
+  starting field: experiment::ObsValue::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  # Correlation scatter plots
+  # -------------------------
+
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}/jedi_hofx_vs_obs_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Observation Value'
+        add_ylabel: 'JEDI h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofx0PassedQc::${variable}
+          markersize: 5
+          color: 'black'
+          label: 'JEDI h(x)_0 versus obs (passed QC in JEDI)'
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofx1PassedQc::${variable}
+          markersize: 5
+          color: 'red'
+          label: 'JEDI h(x)_1 versus obs (passed QC in JEDI)'
+
+  # Histogram plots
+  # ---------------
+
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: histogram_bins
+        data variable: experiment::omanPassedQc::${variable}
+        number of bins rule: 'rice'
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/histogram/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Difference'
+        add_ylabel: 'Count'
+        set_xlim: [-3, 3]
+        add_legend:
+          loc: 'upper left'
+        statistics:
+          fields:
+            - field_name: experiment::ombgPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.10
+              kwargs:
+                color: 'black'
+                fontsize: 8
+                fontfamily: monospace
+            - field_name: experiment::omanPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.13
+              kwargs:
+                color: 'red'
+                fontsize: 8
+                fontfamily: monospace
+          statistics_variables:
+          - n
+          - min
+          - mean
+          - max
+          - std
+        layers:
+        - type: Histogram
+          data:
+            variable: experiment::ombgPassedQc::${variable}
+          color: 'red'
+          label: 'observations minus background '
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+        - type: Histogram
+          data:
+            variable: experiment::omanPassedQc::${variable}
+          color: 'blue'
+          label: 'observations minus analysis'
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+
+  # Map plots
+  # ---------
+  # Increment
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::ombgPassedQc::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [2,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::ombgPassedQc::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::omanPassedQc::${variable}
+          markersize: 2
+          label: OmBg
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::EffectiveQC1::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/effectiveQC_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: EffectiveQC1
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::EffectiveQC1::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::increment::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/increment_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Increment (OmBg - OmAn)
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::increment::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}

--- a/src/swell/suites/3dvar_cycle/flow.cylc
+++ b/src/swell/suites/3dvar_cycle/flow.cylc
@@ -87,7 +87,7 @@
 
             # Run analysis diagnostics
             RunJediVariationalExecutable-{{model_component}} => EvaObservations-{{model_component}}
-            RunJediFgatExecutable-{{model_component}} => EvaJediLog-{{model_component}}
+            RunJediVariationalExecutable-{{model_component}} => EvaJediLog-{{model_component}}
             RunJediVariationalExecutable-{{model_component}} => EvaIncrement-{{model_component}}
 
             # Prepare analysis for next forecast

--- a/src/swell/suites/3dvar_cycle/flow.cylc
+++ b/src/swell/suites/3dvar_cycle/flow.cylc
@@ -81,23 +81,26 @@
             GenerateBClimatologyByLinking-{{model_component}} :fail? => GenerateBClimatology-{{model_component}}
 
             LinkGeosOutput-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
-            # StageJedi-{{model_component}}[^] => RunJediVariationalExecutable-{{model_component}}
             StageJediCycle-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GenerateBClimatologyByLinking-{{model_component}}? | GenerateBClimatology-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GetObservations-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
 
-            # Prepare analysis for next forecast
-            RunJediVariationalExecutable-{{model_component}} => EvaIncrement-{{model_component}}
-            PrepareAnalysis-{{model_component}} =>  RunJediConvertStateSoca2ciceExecutable-{{model_component}}
-            RunJediConvertStateSoca2ciceExecutable-{{model_component}} =>  SaveRestart-{{model_component}}
-
             # Run analysis diagnostics
             RunJediVariationalExecutable-{{model_component}} => EvaObservations-{{model_component}}
-            RunJediVariationalExecutable-{{model_component}} => EvaJediLog-{{model_component}}
+            RunJediFgatExecutable-{{model_component}} => EvaJediLog-{{model_component}}
+            RunJediVariationalExecutable-{{model_component}} => EvaIncrement-{{model_component}}
+
+            # Prepare analysis for next forecast
             EvaIncrement-{{model_component}} => PrepareAnalysis-{{model_component}}
+            {% if 'cice6' in models["geos_marine"]["marine_models"] %}
+            PrepareAnalysis-{{model_component}} => RunJediConvertStateSoca2ciceExecutable-{{model_component}}
+            RunJediConvertStateSoca2ciceExecutable-{{model_component}} => SaveRestart-{{model_component}}
+            RunJediConvertStateSoca2ciceExecutable-{{model_component}} => CleanCycle-{{model_component}}
+            {% else %}
+            PrepareAnalysis-{{model_component}} => SaveRestart-{{model_component}}
+            {% endif %}
 
             # Move restart to next cycle
-            RunJediConvertStateSoca2ciceExecutable-{{model_component}} => SaveRestart-{{model_component}}
             SaveRestart-{{model_component}} => MoveDaRestart-{{model_component}}
 
             # Save analysis output
@@ -113,7 +116,7 @@
 
             # Clean up large files
             # EvaObservations-{{model_component}} & EvaJediLog-{{model_component}} & SaveObsDiags-{{model_component}} & RemoveForecastDir =>
-            EvaObservations-{{model_component}} & EvaJediLog-{{model_component}} & EvaIncrement-{{model_component}} & RunJediConvertStateSoca2ciceExecutable-{{model_component}} =>
+            EvaObservations-{{model_component}} & EvaJediLog-{{model_component}} & EvaIncrement-{{model_component}} =>
             CleanCycle-{{model_component}}
         {% endfor %}
         """
@@ -213,6 +216,8 @@
     [[GenerateBClimatologyByLinking-{{model_component}}]]
         script = "swell task GenerateBClimatologyByLinking $config -d $datetime -m {{model_component}}"
 
+    {% if 'cice6' in models["geos_marine"]["marine_models"] %}
+
     [[RunJediConvertStateSoca2ciceExecutable-{{model_component}}]]
         script = "swell task RunJediConvertStateSoca2ciceExecutable $config -d $datetime -m {{model_component}}"
         platform = {{platform}}
@@ -221,6 +226,8 @@
         {%- for key, value in scheduling["RunJediConvertStateSoca2ciceExecutable"]["directives"][model_component].items() %}
             --{{key}} = {{value}}
         {%- endfor %}
+
+    {% endif %}
 
     [[RunJediVariationalExecutable-{{model_component}}]]
         script = "swell task RunJediVariationalExecutable $config -d $datetime -m {{model_component}}"

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -52,6 +52,7 @@ class EvaObservations(taskBase):
         # Get the model
         # -------------
         model = self.get_model()
+        self.jedi_rendering.add_key('marine_models', self.config.marine_models())
 
         # Determine if running on login or compute node and set workers
         # -------------------------------------------------------------

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -52,7 +52,7 @@ class EvaObservations(taskBase):
         # Get the model
         # -------------
         model = self.get_model()
-        self.jedi_rendering.add_key('marine_models', self.config.marine_models())
+        self.jedi_rendering.add_key('marine_models', self.config.marine_models(None))
 
         # Determine if running on login or compute node and set workers
         # -------------------------------------------------------------

--- a/src/swell/tasks/get_geos_restart.py
+++ b/src/swell/tasks/get_geos_restart.py
@@ -64,8 +64,7 @@ class GetGeosRestart(taskBase):
 
         # Create a dictionary of src/dst for the single files
         # ---------------------------------------------------
-        src_dst = {'tile.bin': '',
-                   'iced.nc': 'INPUT',
+        src_dst = {'iced.nc': 'INPUT',
                    }
 
         for src, dst in src_dst.items():

--- a/src/swell/tasks/link_geos_output.py
+++ b/src/swell/tasks/link_geos_output.py
@@ -35,7 +35,7 @@ class LinkGeosOutput(taskBase):
 
         # Parse configuration
         # -------------------
-        self.marine_models = self.config.marine_models(None)
+        self.marine_models = self.config.marine_models(None) or []
         self.window_type = self.config.window_type()
         self.window_length = self.config.window_length()
         self.window_offset = self.config.window_offset()

--- a/src/swell/tasks/prep_geos_run_dir.py
+++ b/src/swell/tasks/prep_geos_run_dir.py
@@ -117,7 +117,7 @@ class PrepGeosRunDir(taskBase):
         # ------------------------------------------------------
         self.gcm_dict = self.geos.parse_gcmrun(self.forecast_dir('gcm_run.j'))
 
-        # Beginning GEOSgcm v11.6.0, linkbcs is a separate file from gcm_run.j.
+        # Beginning GEOSgcm v11.6.0, linkbcs is a separate file outside of gcm_run.j.
         # So parse linkbcs file using parse_gcmrun method and update gcm_dict
         # -----------------------------------------------------------------------
         self.gcm_dict.update(self.geos.parse_gcmrun(self.forecast_dir('linkbcs')))
@@ -150,6 +150,13 @@ class PrepGeosRunDir(taskBase):
         # -----------------
         self.get_dynamic()
 
+        # Create tile.bin file if it doesn't exist already
+        # ------------------------------------------------
+        if not os.path.exists(self.forecast_dir('tile.bin')):
+            self.logger.info('Creating tile.bin')
+            self.geos.run_geos_script(self.geosbin, 'binarytile.x', input='tile.data',
+                                      output='tile.bin')
+
         # Create cap_restart in GEOSgcm preferred format
         # ----------------------------------------------
         with open(self.forecast_dir('cap_restart'), 'w') as file:
@@ -157,7 +164,7 @@ class PrepGeosRunDir(taskBase):
 
         # Run bundleParser
         # ------------------
-        self.geos.exec_python(self.geosbin, 'bundleParser.py')
+        self.geos.run_geos_script(self.geosbin, 'bundleParser.py')
 
     # ----------------------------------------------------------------------------------------------
 
@@ -189,8 +196,8 @@ class PrepGeosRunDir(taskBase):
                 self.geos.resub(self.forecast_dir('ExtData.rc'), pattern, replacement)
         else:
             self.logger.info('Creating extdata.yaml')
-            self.geos.exec_python(self.geosbin, 'construct_extdata_yaml_list.py',
-                                  './GEOS_ChemGridComp.rc')
+            self.geos.run_geos_script(self.geosbin, 'construct_extdata_yaml_list.py',
+                                      './GEOS_ChemGridComp.rc')
             open(self.forecast_dir('ExtData.rc'), 'w').close()
 
     # ----------------------------------------------------------------------------------------------

--- a/src/swell/tasks/run_jedi_convert_state_soca2cice_executable.py
+++ b/src/swell/tasks/run_jedi_convert_state_soca2cice_executable.py
@@ -24,23 +24,9 @@ class RunJediConvertStateSoca2ciceExecutable(taskBase):
 
     def execute(self) -> None:
 
-        # Number of processors for JEDI executable
-        # ----------------------------------------
-        N_PROCESSORS = 36
-
         # Jedi application name
         # ---------------------
         jedi_application = 'convert_state_soca2cice'
-
-        # Parse configuration
-        # -------------------
-        marine_models = self.config.marine_models(None) or []
-
-        # Fail-safe
-        # ---------
-        if 'cice6' not in marine_models:
-            self.logger.info('Skipping Soca2cice as CICE6 analysis is not enabled.')
-            return
 
         jedi_forecast_model = self.config.jedi_forecast_model(None)
         generate_yaml_and_exit = self.config.generate_yaml_and_exit(False)
@@ -75,12 +61,12 @@ class RunJediConvertStateSoca2ciceExecutable(taskBase):
         # Jedi configuration file
         # -----------------------
         jedi_config_file = os.path.join(self.cycle_dir(),
-                                        f'jedi_{jedi_application}_{cice6_domain}_config.yaml')
+                                        f'jedi_{jedi_application}_config.yaml')
 
         # Output log file
         # ---------------
         output_log_file = os.path.join(self.cycle_dir(),
-                                       f'jedi_{jedi_application}_{cice6_domain}_log.log')
+                                       f'jedi_{jedi_application}_log.log')
 
         # Open the JEDI config file and fill initial templates
         # ----------------------------------------------------

--- a/src/swell/tasks/run_jedi_convert_state_soca2cice_executable.py
+++ b/src/swell/tasks/run_jedi_convert_state_soca2cice_executable.py
@@ -46,6 +46,7 @@ class RunJediConvertStateSoca2ciceExecutable(taskBase):
         # Populate jedi interface templates dictionary
         # --------------------------------------------
         self.jedi_rendering.add_key('analysis_variables', self.config.analysis_variables())
+        self.jedi_rendering.add_key('marine_models', self.config.marine_models(None))
 
         # Background and analysis times
         # -----------------------------

--- a/src/swell/tasks/run_jedi_convert_state_soca2cice_executable.py
+++ b/src/swell/tasks/run_jedi_convert_state_soca2cice_executable.py
@@ -34,8 +34,7 @@ class RunJediConvertStateSoca2ciceExecutable(taskBase):
 
         # Parse configuration
         # -------------------
-        marine_models = self.config.marine_models()
-        self.jedi_rendering.add_key('marine_models', marine_models)
+        marine_models = self.config.marine_models(None) or []
 
         # Fail-safe
         # ---------
@@ -43,8 +42,6 @@ class RunJediConvertStateSoca2ciceExecutable(taskBase):
             self.logger.info('Skipping Soca2cice as CICE6 analysis is not enabled.')
             return
 
-        # cice6_domains = self.config.cice6_domains()
-        cice6_domains = ['arctic', 'antarctic']
         jedi_forecast_model = self.config.jedi_forecast_model(None)
         generate_yaml_and_exit = self.config.generate_yaml_and_exit(False)
         observations = self.config.observations(None)
@@ -75,60 +72,51 @@ class RunJediConvertStateSoca2ciceExecutable(taskBase):
         # --------
         self.jedi_rendering.add_key('total_processors', self.config.total_processors(None))
 
-        # Loop over active CICE6 DA domains
-        # ---------------------------------
-        for cice6_domain in cice6_domains:
+        # Jedi configuration file
+        # -----------------------
+        jedi_config_file = os.path.join(self.cycle_dir(),
+                                        f'jedi_{jedi_application}_{cice6_domain}_config.yaml')
 
-            # Add CICE6 domain to templates dictionary
-            # ----------------------------------------
-            self.jedi_rendering.add_key('cice6_domain', cice6_domain)
+        # Output log file
+        # ---------------
+        output_log_file = os.path.join(self.cycle_dir(),
+                                       f'jedi_{jedi_application}_{cice6_domain}_log.log')
 
-            # Jedi configuration file
-            # -----------------------
-            jedi_config_file = os.path.join(self.cycle_dir(),
-                                            f'jedi_{jedi_application}_{cice6_domain}_config.yaml')
+        # Open the JEDI config file and fill initial templates
+        # ----------------------------------------------------
+        jedi_config_dict = self.jedi_rendering.render_oops_file(f'{jedi_application}')
 
-            # Output log file
-            # ---------------
-            output_log_file = os.path.join(self.cycle_dir(),
-                                           f'jedi_{jedi_application}_{cice6_domain}_log.log')
+        # Perform complete template rendering
+        # -----------------------------------
+        jedi_dictionary_iterator(jedi_config_dict, self.jedi_rendering, window_type,
+                                 observations, jedi_forecast_model)
 
-            # Open the JEDI config file and fill initial templates
-            # ----------------------------------------------------
-            jedi_config_dict = self.jedi_rendering.render_oops_file(f'{jedi_application}')
+        # Write the expanded dictionary to YAML file
+        # ------------------------------------------
+        with open(jedi_config_file, 'w') as jedi_config_file_open:
+            yaml.dump(jedi_config_dict, jedi_config_file_open, default_flow_style=False)
 
-            # Perform complete template rendering
-            # -----------------------------------
-            jedi_dictionary_iterator(jedi_config_dict, self.jedi_rendering, window_type,
-                                     observations, jedi_forecast_model)
+        # Get the JEDI interface metadata
+        # -------------------------------
+        model_component_meta = self.jedi_rendering.render_interface_meta()
 
-            # Write the expanded dictionary to YAML file
-            # ------------------------------------------
-            with open(jedi_config_file, 'w') as jedi_config_file_open:
-                yaml.dump(jedi_config_dict, jedi_config_file_open, default_flow_style=False)
+        # Compute number of processors
+        # ----------------------------
+        np = eval(str(model_component_meta['total_processors']))
 
-            # Get the JEDI interface metadata
-            # -------------------------------
-            model_component_meta = self.jedi_rendering.render_interface_meta()
+        # Jedi executable name
+        # --------------------
+        jedi_executable = model_component_meta['executables'][f'{jedi_application}']
+        jedi_executable_path = os.path.join(self.experiment_path(), 'jedi_bundle',
+                                            'build', 'bin', jedi_executable)
 
-            # Compute number of processors (only requires a single node and fails
-            # for multiple nodes, so we set it to 36 processors for now)
-            # ----------------------------------------------------------
-            np = N_PROCESSORS
-
-            # Jedi executable name
-            # --------------------
-            jedi_executable = model_component_meta['executables'][f'{jedi_application}']
-            jedi_executable_path = os.path.join(self.experiment_path(), 'jedi_bundle',
-                                                'build', 'bin', jedi_executable)
-
-            # Run the JEDI executable
-            # -----------------------
-            if not generate_yaml_and_exit:
-                self.logger.info('Running '+jedi_executable_path+' with '+str(np)+' processors.')
-                run_executable(self.logger, self.cycle_dir(), np, jedi_executable_path,
-                               jedi_config_file, output_log_file)
-            else:
-                self.logger.info('YAML generated, now exiting.')
+        # Run the JEDI executable
+        # -----------------------
+        if not generate_yaml_and_exit:
+            self.logger.info('Running '+jedi_executable_path+' with '+str(np)+' processors.')
+            run_executable(self.logger, self.cycle_dir(), np, jedi_executable_path,
+                           jedi_config_file, output_log_file)
+        else:
+            self.logger.info('YAML generated, now exiting.')
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -614,10 +614,10 @@ marine_models:
   prompt: Enter the active SOCA models for this model.
   tasks:
   - EvaIncrement
+  - EvaObservations
   - GenerateBClimatology
   - GetObservations
   - LinkGeosOutput
-  - RunJediConvertStateSoca2ciceExecutable
   - RunJediFgatExecutable
   - RunJediVariationalExecutable
   type: string-check-list

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -618,6 +618,7 @@ marine_models:
   - GenerateBClimatology
   - GetObservations
   - LinkGeosOutput
+  - RunJediConvertStateSoca2ciceExecutable
   - RunJediFgatExecutable
   - RunJediVariationalExecutable
   type: string-check-list

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -119,17 +119,6 @@ bundles:
   - CloneJedi
   type: string-check-list
 
-cice6_domains:
-  ask_question: true
-  default_value: defer_to_model
-  models:
-  - geos_marine
-  options: defer_to_model
-  prompt: Which CICE6 domains do you wish to run DA for?
-  tasks:
-  - RunJediConvertStateSoca2ciceExecutable
-  type: string-check-list
-
 clean_patterns:
   ask_question: false
   default_value: defer_to_model

--- a/src/swell/test/suite_tests/3dfgat_cycle-tier1.yaml
+++ b/src/swell/test/suite_tests/3dfgat_cycle-tier1.yaml
@@ -11,31 +11,44 @@ models:
     - T06
     - T12
     - T18
+    analysis_variables:
+      - sea_water_salinity
+      - sea_water_potential_temperature
+      - sea_surface_height_above_geoid
+      - sea_water_cell_thickness
+      - sea_ice_area_fraction
+      - sea_ice_thickness
+      - sea_ice_snow_thickness
     window_length: PT6H
     window_offset: PT3H
     horizontal_resolution: 72x36
     vertical_resolution: '50'
     total_processors: 6
     observations:
-     - adt_cryosat2n
-     - adt_jason3
-     - adt_saral
-     - adt_sentinel3a
-     - adt_sentinel3b
-     - insitu_profile_argo
-     - sst_ostia
-     - sss_smos
-     - sss_smapv5
-     - sst_abi_g16_l3c
-     - sst_gmi_l3u
-     - sst_viirs_n20_l3u
-     - temp_profile_xbt
+      - adt_cryosat2n
+      - adt_jason3
+      - adt_saral
+      - adt_sentinel3a
+      - adt_sentinel3b
+      - insitu_profile_argo
+      - icec_amsr2_north
+      - icec_amsr2_south
+      - icec_nsidc_nh
+      - icec_nsidc_sh
+      - sst_ostia
+      - sss_smos
+      - sss_smapv5
+      - sst_abi_g16_l3c
+      - sst_gmi_l3u
+      - sst_viirs_n20_l3u
+      - temp_profile_xbt
     number_of_iterations:
     - 10
     obs_provider: ['odas', 'gdas_marine']
     mom6_iau: True
     analysis_forecast_window_offset: -PT3H
     background_time_offset: PT9H
+    window_type: 4D
     clean_patterns:
     - '*.nc4'
     - '*.txt'

--- a/src/swell/test/suite_tests/3dfgat_cycle-tier1.yaml
+++ b/src/swell/test/suite_tests/3dfgat_cycle-tier1.yaml
@@ -1,5 +1,5 @@
-start_cycle_point: '2021-06-01T12:00:00Z'
-final_cycle_point: '2021-06-02T00:00:00Z'
+start_cycle_point: '2021-07-02T06:00:00Z'
+final_cycle_point: '2021-07-02T12:00:00Z'
 runahead_limit: P2
 jedi_build_method: use_existing
 geos_build_method: use_existing

--- a/src/swell/test/suite_tests/3dvar_cycle-tier1.yaml
+++ b/src/swell/test/suite_tests/3dvar_cycle-tier1.yaml
@@ -3,9 +3,9 @@ final_cycle_point: '2021-07-02T12:00:00Z'
 runahead_limit: P2
 jedi_build_method: use_existing
 geos_build_method: use_existing
-model_components: ['geos_ocean']
+model_components: ['geos_marine']
 models:
-  geos_ocean:
+  geos_marine:
     cycle_times:
     - T00
     - T06
@@ -13,6 +13,8 @@ models:
     - T18
     window_length: PT6H
     window_offset: PT3H
+    marine_models:
+    - mom6
     horizontal_resolution: 72x36
     vertical_resolution: '50'
     total_processors: 6

--- a/src/swell/test/suite_tests/3dvar_cycle-tier1.yaml
+++ b/src/swell/test/suite_tests/3dvar_cycle-tier1.yaml
@@ -1,5 +1,5 @@
-start_cycle_point: '2021-06-01T12:00:00Z'
-final_cycle_point: '2021-06-02T00:00:00Z'
+start_cycle_point: '2021-07-02T06:00:00Z'
+final_cycle_point: '2021-07-02T12:00:00Z'
 runahead_limit: P2
 jedi_build_method: use_existing
 geos_build_method: use_existing

--- a/src/swell/utilities/geos.py
+++ b/src/swell/utilities/geos.py
@@ -99,14 +99,19 @@ class Geos():
 
     # ----------------------------------------------------------------------------------------------
 
-    def exec_python(self, script_src: str, script: str, input: str = '') -> None:
+    def run_geos_script(
+        self,
+        script_src: str,
+        script: str,
+        input: str = '',
+        output: str = '',
+        **kwargs
+    ) -> None:
 
-        # Source g5_modules and execute py scripts in a new shell process then
-        # return to the current one
+        # Source g5_modules and execute scripts in a new shell process then return
         # Define the command to source the Bash script and run the Python command
         # -----------------------------------------------------------------------
-        command = f'source {script_src}/g5_modules.sh \n' + \
-            f'{script_src}/{script} {input}'
+        command = f'source {script_src}/g5_modules.sh && {script_src}/{script} {input} {output}'
 
         # Containerized run of the GEOS build steps
         # -----------------------------------------


### PR DESCRIPTION
- Includes updating 5-deg experiment setup and restart file folders.

- 3fgat_cycle uses cice6 + mom6 marine_models meanwhile 3dvar_cycle uses mom6 only

- Soca2cice configuration had some changes recently, this PR also addresses that.

- I resorted to using `marine_models` key in geos_marine configurations to separate cases where mom6 is active and cice6 is not. While this is a working approach not the only one. https://github.com/GEOS-ESM/swell/pull/491 could address this in a different way.

- I'm taking out `ufo_testing` from tier1 and tier2 tests and adding `3dvar_cycle` so after months we will have tier2 test running (fingers crossed)

- As I mentioned, this is another step closer to abandoning `geos_ocean`, almost there.

@DavidSRussell this is ready for testing, please take a look (you will need spack-stack 1.9 modules)

closes #499