### PR TITLE
Add perhost opt for mpi execs

### DIFF
--- a/src/swell/tasks/run_jedi_variational_executable.py
+++ b/src/swell/tasks/run_jedi_variational_executable.py
@@ -163,13 +163,8 @@ class RunJediVariationalExecutable(taskBase):
         # -----------------------
         if not generate_yaml_and_exit:
             self.logger.info('Running '+jedi_executable_path+' with '+str(np)+' processors.')
-            if perhost is None:
-               run_executable(self.logger, self.cycle_dir(), np, jedi_executable_path,
-                              jedi_config_file, output_log_file)
-            else:
-               perhost = eval(perhost)
-               run_executable(self.logger, self.cycle_dir(), np, jedi_executable_path,
-                              jedi_config_file, output_log_file, perhost)
+            run_executable(self.logger, self.cycle_dir(), np, jedi_executable_path,
+                           jedi_config_file, output_log_file, perhost)
         else:
             self.logger.info('YAML generated, now exiting.')
 

--- a/src/swell/tasks/run_jedi_variational_executable.py
+++ b/src/swell/tasks/run_jedi_variational_executable.py
@@ -38,6 +38,7 @@ class RunJediVariationalExecutable(taskBase):
         observations = self.config.observations()
         jedi_forecast_model = self.config.jedi_forecast_model(None)
         generate_yaml_and_exit = self.config.generate_yaml_and_exit(False)
+        perhost = self.config.perhost(None)
 
         # Set the observing system records path
         self.jedi_rendering.set_obs_records_path(self.config.observing_system_records_path(None))
@@ -81,7 +82,6 @@ class RunJediVariationalExecutable(taskBase):
         self.jedi_rendering.add_key('npx_proc', npx_proc)
         self.jedi_rendering.add_key('npy_proc', npy_proc)
         self.jedi_rendering.add_key('total_processors', self.config.total_processors(None))
-        self.jedi_rendering.add_key('perhost', self.config.perhost(None))
 
         # Observations
         # ------------
@@ -152,7 +152,6 @@ class RunJediVariationalExecutable(taskBase):
         # Compute number of processors
         # ----------------------------
         np = eval(str(model_component_meta['total_processors']))
-        perhost = str(model_component_meta['perhost'])
 
         # Jedi executable name
         # --------------------

--- a/src/swell/tasks/run_jedi_variational_executable.py
+++ b/src/swell/tasks/run_jedi_variational_executable.py
@@ -81,6 +81,7 @@ class RunJediVariationalExecutable(taskBase):
         self.jedi_rendering.add_key('npx_proc', npx_proc)
         self.jedi_rendering.add_key('npy_proc', npy_proc)
         self.jedi_rendering.add_key('total_processors', self.config.total_processors(None))
+        self.jedi_rendering.add_key('perhost', self.config.perhost(None))
 
         # Observations
         # ------------
@@ -151,6 +152,7 @@ class RunJediVariationalExecutable(taskBase):
         # Compute number of processors
         # ----------------------------
         np = eval(str(model_component_meta['total_processors']))
+        perhost = str(model_component_meta['perhost'])
 
         # Jedi executable name
         # --------------------
@@ -162,8 +164,13 @@ class RunJediVariationalExecutable(taskBase):
         # -----------------------
         if not generate_yaml_and_exit:
             self.logger.info('Running '+jedi_executable_path+' with '+str(np)+' processors.')
-            run_executable(self.logger, self.cycle_dir(), np, jedi_executable_path,
-                           jedi_config_file, output_log_file)
+            if perhost is None:
+               run_executable(self.logger, self.cycle_dir(), np, jedi_executable_path,
+                              jedi_config_file, output_log_file)
+            else:
+               perhost = eval(perhost)
+               run_executable(self.logger, self.cycle_dir(), np, jedi_executable_path,
+                              jedi_config_file, output_log_file, perhost)
         else:
             self.logger.info('YAML generated, now exiting.')
 

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -825,6 +825,16 @@ path_to_gsi_nc_diags:
   - GetGsiNcdiag
   type: string
 
+perhost:
+  ask_question: true
+  default_value: None
+  models:
+  - geos_atmosphere
+  prompt: What is the number of processors per host?
+  tasks:
+  - RunJediVariationalExecutable
+  type: integer
+
 produce_geovals:
   ask_question: true
   default_value: defer_to_model
@@ -929,17 +939,6 @@ total_processors:
   - RunJediObsfiltersExecutable
   - RunJediVariationalExecutable
   type: integer
-
-perhost:
-  ask_question: true
-  default_value: None
-  models:
-  - geos_atmosphere
-  prompt: What is the number of processors per host?
-  tasks:
-  - RunJediVariationalExecutable
-  type: integer
-
 
 vertical_localization_apply_log_transform:
   ask_question: false

--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -930,6 +930,17 @@ total_processors:
   - RunJediVariationalExecutable
   type: integer
 
+perhost:
+  ask_question: true
+  default_value: None
+  models:
+  - geos_atmosphere
+  prompt: What is the number of processors per host?
+  tasks:
+  - RunJediVariationalExecutable
+  type: integer
+
+
 vertical_localization_apply_log_transform:
   ask_question: false
   default_value: true

--- a/src/swell/utilities/render_jedi_interface_files.py
+++ b/src/swell/utilities/render_jedi_interface_files.py
@@ -105,6 +105,7 @@ class JediConfigRendering():
             'npy_proc',
             'number_of_iterations',
             'packet_ensemble_members',
+            'perhost',
             'skip_ensemble_hofx',
             'swell_static_files',
             'total_processors',

--- a/src/swell/utilities/run_jedi_executables.py
+++ b/src/swell/utilities/run_jedi_executables.py
@@ -113,7 +113,7 @@ def run_executable(
     jedi_executable_path: str,
     jedi_config_file: str,
     output_log: str,
-    perhost: Optional[int]=None
+    perhost: Optional[int] = None
 ) -> None:
 
     # Run the JEDI executable

--- a/src/swell/utilities/run_jedi_executables.py
+++ b/src/swell/utilities/run_jedi_executables.py
@@ -118,11 +118,12 @@ def run_executable(
 
     # Run the JEDI executable
     # -----------------------
-    logger.info('Running '+jedi_executable_path+' with '+str(np)+' processors.')
 
     if perhost is None:
+       logger.info('Running '+jedi_executable_path+' with '+str(np)+' processors.')
        command = ['mpirun', '-np', str(np), jedi_executable_path, jedi_config_file]
     else:
+       logger.info('Running '+jedi_executable_path+' with '+str(np)+' processors & perhost '+str(perhost))
        command = ['mpirun', '-np', str(np), '-perhost', str(perhost), jedi_executable_path, jedi_config_file]
 
     # Run command

--- a/src/swell/utilities/run_jedi_executables.py
+++ b/src/swell/utilities/run_jedi_executables.py
@@ -120,11 +120,24 @@ def run_executable(
     # -----------------------
 
     if perhost is None:
-       logger.info('Running '+jedi_executable_path+' with '+str(np)+' processors.')
-       command = ['mpirun', '-np', str(np), jedi_executable_path, jedi_config_file]
+        logger.info(f"Running {jedi_executable_path} with {str(np)} processors.")
+        command = [
+            'mpirun',
+            '-np', str(np),
+            jedi_executable_path,
+            jedi_config_file
+        ]
     else:
-       logger.info('Running '+jedi_executable_path+' with '+str(np)+' processors & perhost '+str(perhost))
-       command = ['mpirun', '-np', str(np), '-perhost', str(perhost), jedi_executable_path, jedi_config_file]
+        logger.info(
+            f"Running {jedi_executable_path} with {str(np)} processors & perhost {str(perhost)}"
+        )
+        command = [
+            'mpirun',
+            '-np', str(np),
+            '-perhost', str(perhost),
+            jedi_executable_path,
+            jedi_config_file
+        ]
 
     # Run command
     # -----------

--- a/src/swell/utilities/run_jedi_executables.py
+++ b/src/swell/utilities/run_jedi_executables.py
@@ -113,7 +113,7 @@ def run_executable(
     jedi_executable_path: str,
     jedi_config_file: str,
     output_log: str,
-    perhost: int=None
+    perhost: Optional[int]=None
 ) -> None:
 
     # Run the JEDI executable

--- a/src/swell/utilities/run_jedi_executables.py
+++ b/src/swell/utilities/run_jedi_executables.py
@@ -112,14 +112,18 @@ def run_executable(
     np: int,
     jedi_executable_path: str,
     jedi_config_file: str,
-    output_log: str
+    output_log: str,
+    perhost: int=None
 ) -> None:
 
     # Run the JEDI executable
     # -----------------------
     logger.info('Running '+jedi_executable_path+' with '+str(np)+' processors.')
 
-    command = ['mpirun', '-np', str(np), jedi_executable_path, jedi_config_file]
+    if perhost is None:
+       command = ['mpirun', '-np', str(np), jedi_executable_path, jedi_config_file]
+    else:
+       command = ['mpirun', '-np', str(np), '-perhost', str(perhost), jedi_executable_path, jedi_config_file]
 
     # Run command
     # -----------


### PR DESCRIPTION
## Description

Some mpirun execs require a perhost option in the mpirun command line. 

This works now.

## Dependencies

None

## Impact

Allows for memory handling when job needs nodes need to be split and info passed to mpirun command line
