### PR TITLE
Use `null` instead of `None` in YAML

### DIFF
--- a/src/swell/tasks/task_questions.yaml
+++ b/src/swell/tasks/task_questions.yaml
@@ -832,7 +832,7 @@ path_to_gsi_nc_diags:
 
 perhost:
   ask_question: true
-  default_value: None
+  default_value: null
   models:
   - geos_atmosphere
   prompt: What is the number of processors per host?

--- a/src/swell/utilities/run_jedi_executables.py
+++ b/src/swell/utilities/run_jedi_executables.py
@@ -133,7 +133,7 @@ def run_executable(
 
     # Run the JEDI executable
     # -----------------------
-    if perhost is None or perhost == "None":
+    if perhost is None:
         logger.info(f"Running {jedi_executable_path} with {str(np)} processors.")
         command = [
             'mpirun',


### PR DESCRIPTION
PyYAML parses `value: None` as `{"value": "None"}` (i.e., the string `"None"`). In YAML, the correct way to represent a `None` object is one of the following:

```
value:

value: null

value: ~
```

I'm using `null` here because, in my opinion, it's the clearest one.

Closes #524.