### PR TITLE
Assimilate ADT from Sentinel-6A satellite

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/adt_sentinel6a.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/adt_sentinel6a.yaml
@@ -1,0 +1,40 @@
+obs space:
+  name: adt_sentinel6a
+  obsdatain:
+    engine:
+      type: H5File
+      obsfile: '{{cycle_dir}}/adt_sentinel6a.{{window_begin}}.nc4'
+  obsdataout:
+    engine:
+      type: H5File
+      obsfile: '{{cycle_dir}}/{{experiment_id}}.adt_sentinel6a.{{window_begin}}.nc4'
+  simulated variables: [absoluteDynamicTopography]
+obs operator:
+  name: ADT
+obs error:
+  covariance model: diagonal
+obs filters:
+- filter: Domain Check
+  where:
+  - variable: {name: GeoVaLs/sea_area_fraction}
+    minvalue: 0.9
+- filter: Domain Check
+  where:
+  - variable: { name: GeoVaLs/sea_surface_temperature}
+    minvalue: 7.5
+- filter: Background Check
+  absolute threshold: 0.2
+- filter: Domain Check
+  where:
+  - variable: {name: GeoVaLs/sea_floor_depth_below_sea_surface}
+    minvalue: 500
+- filter: Domain Check
+  where:
+  - variable: { name: GeoVaLs/distance_from_coast}
+    minvalue: 100e3
+{% if 'cice6' in marine_models %}
+- filter: Domain Check
+  where:
+  - variable: { name: GeoVaLs/sea_ice_area_fraction}
+    maxvalue: 0.00001
+{% endif %}

--- a/src/swell/configuration/jedi/observation_ioda_names.yaml
+++ b/src/swell/configuration/jedi/observation_ioda_names.yaml
@@ -154,6 +154,9 @@ ioda instrument names:
   - ioda name: adt_sentinel3b
     full name: ADT Sentinel-3B
     inst type: altimeter
+  - ioda name: adt_sentinel6a
+    full name: ADT Sentinel-6A
+    inst type: altimeter
   - ioda name: adt_coperl4
     full name: ADT Copernicus Level-4
     inst type: altimeter


### PR DESCRIPTION
## Description

The Sentinel-6A altimetry satellite entered service in 2021 and GMAO has IODA observation files for it, but Swell does not yet have it in its list of observation types. This update adds it to the list. I've tested it with a single 6-hr cycle of 3D-FGAT and the EVA diagnostics look as expected.
