### PR TITLE
Updating to latest JEDI Dev (22May2025)

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
@@ -3,13 +3,27 @@ saber central block:
   saber block name: gsi hybrid covariance
   read:
     gsi akbk: './fv3-jedi/fv3files/akbk{{vertical_resolution}}.nc4'
-    gsi error covariance file: './fv3-jedi/gsibec/gsibec_coefficients_c{{horizontal_resolution}}.nc4'
-    gsi berror namelist file: './fv3-jedi/gsibec/{{gsibec_configuration}}_c{{horizontal_resolution}}.nml'
+    gsi error covariance file: './fv3-jedi/gsibec/gsibec_coefficients_x{{gsibec_nlons}}y{{gsibec_nlats}}l{{vertical_resolution}}.nc4'
+    gsi berror namelist file: './fv3-jedi/gsibec/{{gsibec_configuration}}_x{{gsibec_nlons}}y{{gsibec_nlats}}l{{vertical_resolution}}.nml'
     processor layout x direction: {{gsibec_npx_proc}}
     processor layout y direction: {{gsibec_npy_proc}}
     debugging mode: false
 saber outer blocks:
-- saber block name: gsi interpolation to model grid
+- saber block name: interpolation
+  inner geometry:
+    function space: StructuredColumns
+    custom grid matching gsi:
+      type: latlon
+      lats: {{gsibec_nlats}}
+      lons: {{gsibec_nlons}}
+    custom partitioner matching gsi:
+      bands: {{gsibec_npy_proc}}
+    halo: 1
+  forward interpolator:
+    local interpolator type: oops unstructured grid interpolator
+  inverse interpolator:
+    local interpolator type: oops unstructured grid interpolator
+
   state variables to inverse: &bvars [eastward_wind,
                                       northward_wind,air_temperature,
                                       air_pressure_at_surface,
@@ -24,12 +38,6 @@ saber outer blocks:
                                       fraction_of_ice,
                                       geopotential_height_times_gravity_at_surface,
                                       skin_temperature_at_surface]
-  gsi akbk: './fv3-jedi/fv3files/akbk{{vertical_resolution}}.nc4'
-  gsi error covariance file: './fv3-jedi/gsibec/gsibec_coefficients_c{{horizontal_resolution}}.nc4'
-  gsi berror namelist file: './fv3-jedi/gsibec/{{gsibec_configuration}}_c{{horizontal_resolution}}.nml'
-  processor layout x direction: {{gsibec_npx_proc}}
-  processor layout y direction: {{gsibec_npy_proc}}
-  debugging mode: false
 linear variable change:
   linear variable change name: Control2Analysis
   input variables: *bvars

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
@@ -3,8 +3,8 @@ saber central block:
   saber block name: gsi hybrid covariance
   read:
     gsi akbk: './fv3-jedi/fv3files/akbk{{vertical_resolution}}.nc4'
-    gsi error covariance file: './fv3-jedi/gsibec/gsibec_coefficients_x{{gsibec_nlons}}y{{gsibec_nlats}}l{{vertical_resolution}}.nc4'
-    gsi berror namelist file: './fv3-jedi/gsibec/{{gsibec_configuration}}_x{{gsibec_nlons}}y{{gsibec_nlats}}l{{vertical_resolution}}.nml'
+    gsi error covariance file: './fv3-jedi/gsibec/gsi-coeffs-gmao-global-l{{vertical_resolution}}x{{gsibec_nlons}}y{{gsibec_nlats}}.nc4'
+    gsi berror namelist file: './fv3-jedi/gsibec/{{gsibec_configuration}}_l{{vertical_resolution}}x{{gsibec_nlons}}y{{gsibec_nlats}}.nml'
     processor layout x direction: {{gsibec_npx_proc}}
     processor layout y direction: {{gsibec_npy_proc}}
     debugging mode: false

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage.yaml
@@ -3,6 +3,6 @@
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/GEOS_CRTM_Surface/geos.crtmsrf.{{horizontal_resolution}}.nc4', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/bkg/']
       - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi/test/Data/fieldmetadata/*', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fieldmetadata/']
       - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi/test/Data/fv3files/*', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/']
-      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/gsibec_coefficients_c{{horizontal_resolution}}.nc4', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/gsibec/']
-      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/{{gsibec_configuration}}_c{{horizontal_resolution}}.nml', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/gsibec/']
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/1.0.1/gsi-coeffs-gmao-global-l{{vertical_resolution}}x{{gsibec_nlons}}y{{gsibec_nlats}}.nc4', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/gsibec/']
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/1.0.1/{{gsibec_configuration}}_l{{vertical_resolution}}x{{gsibec_nlons}}y{{gsibec_nlats}}.nml', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/gsibec/']
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/rcov/1.0.0/*', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/rcov/']

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage_cycle.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage_cycle.yaml
@@ -3,6 +3,6 @@
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/GEOS_CRTM_Surface/geos.crtmsrf.{{horizontal_resolution}}.nc4', '{{cycle_dir}}/fv3-jedi/bkg/']
       - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi/test/Data/fieldmetadata/*', '{{cycle_dir}}/fv3-jedi/fieldmetadata/']
       - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi/test/Data/fv3files/*', '{{cycle_dir}}/fv3-jedi/fv3files/']
-      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/gsibec_coefficients_c{{horizontal_resolution}}.nc4', '{{cycle_dir}}/fv3-jedi/gsibec/']
-      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/{{gsibec_configuration}}_c{{horizontal_resolution}}.nml', '{{cycle_dir}}/fv3-jedi/gsibec/']
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/gsibec_coefficients_x{{gsibec_nlons}}y{{gsibec_nlats}}l{{vertical_resolution}}.nc4', '{{cycle_dir}}/fv3-jedi/gsibec/']
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/{{gsibec_configuration}}_x{{gsibec_nlons}}y{{gsibec_nlats}}l{{vertical_resolution}}.nml', '{{cycle_dir}}/fv3-jedi/gsibec/']
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/rcov/1.0.0/*', '{{cycle_dir}}/fv3-jedi/rcov/']

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage_cycle.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage_cycle.yaml
@@ -3,6 +3,6 @@
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/GEOS_CRTM_Surface/geos.crtmsrf.{{horizontal_resolution}}.nc4', '{{cycle_dir}}/fv3-jedi/bkg/']
       - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi/test/Data/fieldmetadata/*', '{{cycle_dir}}/fv3-jedi/fieldmetadata/']
       - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi/test/Data/fv3files/*', '{{cycle_dir}}/fv3-jedi/fv3files/']
-      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/gsibec_coefficients_x{{gsibec_nlons}}y{{gsibec_nlats}}l{{vertical_resolution}}.nc4', '{{cycle_dir}}/fv3-jedi/gsibec/']
-      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/{{gsibec_configuration}}_x{{gsibec_nlons}}y{{gsibec_nlats}}l{{vertical_resolution}}.nml', '{{cycle_dir}}/fv3-jedi/gsibec/']
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/1.0.1/gsi-coeffs-gmao-global-l{{vertical_resolution}}x{{gsibec_nlons}}y{{gsibec_nlats}}.nc4', '{{cycle_dir}}/fv3-jedi/gsibec/']
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec//1.0.1/{{gsibec_configuration}}_l{{vertical_resolution}}x{{gsibec_nlons}}y{{gsibec_nlats}}.nml', '{{cycle_dir}}/fv3-jedi/gsibec/']
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/rcov/1.0.0/*', '{{cycle_dir}}/fv3-jedi/rcov/']

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -102,20 +102,20 @@ gsibec_configuration:
 gsibec_nlats:
   default_value: 181
   options:
-  - '46'
-  - '91'
-  - '181'
-  - '361'
-  - '721'
+  - 46
+  - 91
+  - 181
+  - 361
+  - 721
 
 gsibec_nlons:
   default_value: 288
   options:
-  - '72'
-  - '144'
-  - '288'
-  - '576'
-  - '1152'
+  - 72
+  - 144
+  - 288
+  - 576
+  - 1152
 
 horizontal_localization_lengthscale:
   default_value: 10000e3

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -99,6 +99,24 @@ gradient_norm_reduction:
 gsibec_configuration:
   default_value: cli_gsibec_configuration
 
+gsibec_nlats:
+  default_value: 181
+  options:
+  - '46'
+  - '91'
+  - '181'
+  - '361'
+  - '721'
+
+gsibec_nlons:
+  default_value: 288
+  options:
+  - '72'
+  - '144'
+  - '288'
+  - '576'
+  - '1152'
+
 horizontal_localization_lengthscale:
   default_value: 10000e3
 

--- a/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
@@ -8,7 +8,7 @@ existing_geos_gcm_source_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.6.0/
 
 existing_jedi_build_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_02062025/build-intel-release
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_05222025/build-intel-release/
 
 existing_jedi_build_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/build/

--- a/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
@@ -14,7 +14,7 @@ existing_jedi_build_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/build/
 
 existing_jedi_source_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_02062025
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_05222025
 
 existing_jedi_source_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles/current_pinned_jedi_bundle/source/

--- a/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
@@ -14,7 +14,7 @@ existing_jedi_build_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/build/
 
 existing_jedi_source_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_02062025
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_05222025
 
 existing_jedi_source_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/source/

--- a/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
@@ -8,7 +8,7 @@ existing_geos_gcm_source_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.6.0/
 
 existing_jedi_build_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_02062025/build-intel-release
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_05222025/build-intel-release/
 
 existing_jedi_build_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/build/

--- a/src/swell/suites/3dvar_atmos/suite_config.py
+++ b/src/swell/suites/3dvar_atmos/suite_config.py
@@ -44,6 +44,8 @@ class SuiteConfig(QuestionContainer, Enum):
             qd.window_offset("PT3H"),
             qd.window_type("3D"),
             qd.horizontal_resolution("91"),
+            qd.gsibec_nlats("91"),
+            qd.gsibec_nlons("144"),
             qd.vertical_resolution("72"),
             qd.observations([
                 "aircraft_temperature",

--- a/src/swell/tasks/run_jedi_fgat_executable.py
+++ b/src/swell/tasks/run_jedi_fgat_executable.py
@@ -44,6 +44,8 @@ class RunJediFgatExecutable(taskBase):
         # Set the observing system records path
         self.jedi_rendering.set_obs_records_path(self.config.observing_system_records_path(None))
 
+        gsibec_nlats = self.config.gsibec_nlats(None)
+        gsibec_nlons = self.config.gsibec_nlons(None)
         npx_proc = self.config.npx_proc(None)
         npy_proc = self.config.npy_proc(None)
 
@@ -80,6 +82,8 @@ class RunJediFgatExecutable(taskBase):
         # Geometry
         # --------
         self.jedi_rendering.add_key('vertical_resolution', self.config.vertical_resolution())
+        self.jedi_rendering.add_key('gsibec_nlats', gsibec_nlats)
+        self.jedi_rendering.add_key('gsibec_nlons', gsibec_nlons)
         self.jedi_rendering.add_key('npx_proc', npx_proc)
         self.jedi_rendering.add_key('npy_proc', npy_proc)
         self.jedi_rendering.add_key('total_processors', self.config.total_processors(None))
@@ -94,6 +98,8 @@ class RunJediFgatExecutable(taskBase):
         # ---------------------------------
         if npx_proc is not None and npy_proc is not None:
             self.jedi_rendering.add_key('gsibec_configuration', self.config.gsibec_configuration())
+            self.jedi_rendering.add_key('gsibec_nlats', gsibec_nlats)
+            self.jedi_rendering.add_key('gsibec_nlons', gsibec_nlons)
             self.jedi_rendering.add_key('gsibec_npx_proc', npx_proc)
             self.jedi_rendering.add_key('gsibec_npy_proc', 6*npy_proc)
 

--- a/src/swell/tasks/run_jedi_variational_executable.py
+++ b/src/swell/tasks/run_jedi_variational_executable.py
@@ -43,6 +43,8 @@ class RunJediVariationalExecutable(taskBase):
         # Set the observing system records path
         self.jedi_rendering.set_obs_records_path(self.config.observing_system_records_path(None))
 
+        gsibec_nlats = self.config.gsibec_nlats(None)
+        gsibec_nlons = self.config.gsibec_nlons(None)
         npx_proc = self.config.npx_proc(None)
         npy_proc = self.config.npy_proc(None)
 
@@ -79,6 +81,8 @@ class RunJediVariationalExecutable(taskBase):
         # Geometry
         # --------
         self.jedi_rendering.add_key('vertical_resolution', self.config.vertical_resolution())
+        self.jedi_rendering.add_key('gsibec_nlats', gsibec_nlats)
+        self.jedi_rendering.add_key('gsibec_nlons', gsibec_nlons)
         self.jedi_rendering.add_key('npx_proc', npx_proc)
         self.jedi_rendering.add_key('npy_proc', npy_proc)
         self.jedi_rendering.add_key('total_processors', self.config.total_processors(None))
@@ -93,6 +97,8 @@ class RunJediVariationalExecutable(taskBase):
         # ---------------------------------
         if npx_proc is not None and npy_proc is not None:
             self.jedi_rendering.add_key('gsibec_configuration', self.config.gsibec_configuration())
+            self.jedi_rendering.add_key('gsibec_nlats', gsibec_nlats)
+            self.jedi_rendering.add_key('gsibec_nlons', gsibec_nlons)
             self.jedi_rendering.add_key('gsibec_npx_proc', npx_proc)
             self.jedi_rendering.add_key('gsibec_npy_proc', 6*npy_proc)
 

--- a/src/swell/tasks/stage_jedi.py
+++ b/src/swell/tasks/stage_jedi.py
@@ -46,12 +46,16 @@ class StageJedi(taskBase):
 
         vertical_resolution = self.config.vertical_resolution()
         gsibec_configuration = self.config.gsibec_configuration(None)
+        gsibec_nlats = self.config.gsibec_nlats(None)
+        gsibec_nlons = self.config.gsibec_nlons(None)
 
         # Add jedi interface template keys
         self.jedi_rendering.add_key('horizontal_resolution', horizontal_resolution)
         self.jedi_rendering.add_key('swell_static_files', swell_static_files)
         self.jedi_rendering.add_key('vertical_resolution', vertical_resolution)
         self.jedi_rendering.add_key('gsibec_configuration', gsibec_configuration)
+        self.jedi_rendering.add_key('gsibec_nlats', gsibec_nlats)
+        self.jedi_rendering.add_key('gsibec_nlons', gsibec_nlons)
 
         # Open the stage configuration file
         # ---------------------------------

--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -76,6 +76,8 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.generate_yaml_and_exit(),
             qd.gradient_norm_reduction(),
             qd.gsibec_configuration(),
+            qd.gsibec_nlats(),
+            qd.gsibec_nlons(),
             qd.jedi_forecast_model(),
             qd.minimizer(),
             qd.number_of_iterations(),
@@ -526,6 +528,8 @@ class TaskQuestions(QuestionContainer, Enum):
         questions=[
             swell_static_file_questions,
             qd.gsibec_configuration(),
+            qd.gsibec_nlats(),
+            qd.gsibec_nlons(),
             qd.horizontal_resolution(),
             qd.vertical_resolution()
         ]

--- a/src/swell/utilities/pinned_versions/pinned_versions.yaml
+++ b/src/swell/utilities/pinned_versions/pinned_versions.yaml
@@ -1,21 +1,21 @@
-# Pinned versions for 2025-02-06
+# Pinned versions for 2025-05-22
 - jedicmake:
     branch: 40d521f9a2d796fcbc6234d77abceeffefb8eb7f
     commit: true
 - oops:
-    branch: 765aeb1204a6999f78cf4fd589074af42cd4700c
+    branch: c5e6d732110ab3a9cb8b2b13d9ea059febbfb9d0
     commit: true
 - saber:
-    branch: b85ece54b9928c9aed0a11b46f7a3a963f78e635
+    branch: 3d40cd513414f289decd195fa3b31c15c1c9ceaa
     commit: true
 - ioda:
-    branch: cae6614602b415262b10f1f648757c76a657b5af
+    branch: 6ed76e083c9c5e33daceec146d528b062631b0b1
     commit: true
 - ufo:
-    branch: f761f4727b22b58d9a39accd6d7e626c1dd00ad9
+    branch: 7ca1792e14942483669c39501477ed3a83a42ea4
     commit: true
 - vader:
-    branch: 0792f693148c3d09a166021e6b8c2758cb8a1251
+    branch: c1f90b143e6fb4dc114fb563e362f5752f002dae
     commit: true
 - fv3:
     branch: ab25dc09d955271f34ca6a3fa83af1093c85d9f7
@@ -27,23 +27,23 @@
     branch: 4f12677d345e683bf910b5f76f0df120ad27482d
     commit: true
 - fv3-jedi:
-    branch: a391d2fd2263056c1ace87b8507960d7b936380a
+    branch: 2eea747bdd877627c396d533b5ee176f0347efc0
     commit: true
 - ioda-data:
-    branch: 9d414d76d9859701ed5eb126dddf08e704a1e159
+    branch: ebcb457290e6c9cdca5cef040564e499c66f31a1
     commit: true
 - fv3-jedi-data:
-    branch: effbda720365a4b095114bd97adcd9367b0b34e3
+    branch: 290b7ebbe73205eaac2775b158ba839728e96601
     commit: true
 - soca:
-    branch: b4378059d8306aef6fbb80cac536ee3849f6353b
+    branch: b9a89f4a2a238ca85bdf59ca9a95673f5af5e791
     commit: true
 - iodaconv:
-    branch: ab99fd23178155458d24ab5cc9ef4d04406cd17c
+    branch: 5a445d4988c14e81be8dfc465441dbabbfcf009d
     commit: true
 - gsw:
     branch: 697cbeb7605d70ed3857664c5f54a5c05346e31f
     commit: true
 - ufo-data:
-    branch: ca4e6f544b1330e9977552aff153f33ed178fb72
+    branch: da0a3f9ec45e283f4155dd237763707a51d8b3c4
     commit: true

--- a/src/swell/utilities/question_defaults.py
+++ b/src/swell/utilities/question_defaults.py
@@ -618,8 +618,8 @@ class QuestionDefaults():
         models: List[str] = mutable_field([
             "geos_atmosphere"
         ])
-        prompt: str = "How many number of latutides in GSIBEC grid?"
-        widget_type: WType = WType.STRING
+        prompt: str = "Number of latitudes in GSIBEC grid?"
+        widget_type: WType = WType.INTEGER
 
     # --------------------------------------------------------------------------------------------------
 
@@ -630,8 +630,8 @@ class QuestionDefaults():
         models: List[str] = mutable_field([
             "geos_atmosphere"
         ])
-        prompt: str = "How many number of longitudes in GSIBEC grid?"
-        widget_type: WType = WType.STRING
+        prompt: str = "Number of longitudes in GSIBEC grid?"
+        widget_type: WType = WType.INTEGER
 
     # --------------------------------------------------------------------------------------------------
 

--- a/src/swell/utilities/question_defaults.py
+++ b/src/swell/utilities/question_defaults.py
@@ -612,6 +612,30 @@ class QuestionDefaults():
     # --------------------------------------------------------------------------------------------------
 
     @dataclass
+    class gsibec_nlats(TaskQuestion):
+        default_value: str = "defer_to_model"
+        question_name: str = "gsibec_nlats"
+        models: List[str] = mutable_field([
+            "geos_atmosphere"
+        ])
+        prompt: str = "How many number of latutides in GSIBEC grid?"
+        widget_type: WType = WType.STRING
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
+    class gsibec_nlons(TaskQuestion):
+        default_value: str = "defer_to_model"
+        question_name: str = "gsibec_nlons"
+        models: List[str] = mutable_field([
+            "geos_atmosphere"
+        ])
+        prompt: str = "How many number of longitudes in GSIBEC grid?"
+        widget_type: WType = WType.STRING
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
     class horizontal_localization_lengthscale(TaskQuestion):
         default_value: str = "defer_to_model"
         question_name: str = "horizontal_localization_lengthscale"

--- a/src/swell/utilities/render_jedi_interface_files.py
+++ b/src/swell/utilities/render_jedi_interface_files.py
@@ -82,6 +82,8 @@ class JediConfigRendering():
             'ensmeanvariance_only',
             'gradient_norm_reduction',
             'gsibec_configuration',
+            'gsibec_nlats',
+            'gsibec_nlons',
             'gsibec_npx_proc',
             'gsibec_npy_proc',
             'horizontal_localization_lengthscale',


### PR DESCRIPTION
## Description

This introduce changes to how the background error covariance term based on GSIBEC is handled in the latest version of JEDI. The out-block now handle the interpolation in a different way - needing different parameters including the number of lat and lon grid points that JEDI has not referenced so far. I am using this requirement to generalize the handling of the static files so that choice of horizontal and vertical grids are more encompassing. 

## Dependencies

Latest JEDI version (22 May 2025)

## Impact

Shouldn't be any