### PR TITLE
Sync w/ 5.42.x - bias correct channels 14 (amsua) and 15 (atms)

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
@@ -25,8 +25,6 @@ obs operator:
 obs bias:
   input file: '{{cycle_dir}}/amsua_aqua.{{background_time}}.satbias.nc4'
   output file: '{{cycle_dir}}/amsua_aqua.{{window_begin}}.satbias.nc4'
-  variables without bc: [brightnessTemperature]
-  channels: 14
   variational bc:
     predictors:
     - name: constant

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
@@ -25,8 +25,6 @@ obs operator:
 obs bias:
   input file: '{{cycle_dir}}/amsua_metop-b.{{background_time}}.satbias.nc4'
   output file: '{{cycle_dir}}/amsua_metop-b.{{window_begin}}.satbias.nc4'
-  variables without bc: [brightnessTemperature]
-  channels: 14
   variational bc:
     predictors:
     - name: constant

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
@@ -25,8 +25,6 @@ obs operator:
 obs bias:
   input file: '{{cycle_dir}}/amsua_metop-c.{{background_time}}.satbias.nc4'
   output file: '{{cycle_dir}}/amsua_metop-c.{{window_begin}}.satbias.nc4'
-  variables without bc: [brightnessTemperature]
-  channels: 14
   variational bc:
     predictors:
     - name: constant

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
@@ -25,8 +25,6 @@ obs operator:
 obs bias:
   input file: '{{cycle_dir}}/amsua_n15.{{background_time}}.satbias.nc4'
   output file: '{{cycle_dir}}/amsua_n15.{{window_begin}}.satbias.nc4'
-  variables without bc: [brightnessTemperature]
-  channels: 14
   variational bc:
     predictors:
     - name: constant

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
@@ -25,8 +25,6 @@ obs operator:
 obs bias:
   input file: '{{cycle_dir}}/amsua_n18.{{background_time}}.satbias.nc4'
   output file: '{{cycle_dir}}/amsua_n18.{{window_begin}}.satbias.nc4'
-  variables without bc: [brightnessTemperature]
-  channels: 14
   variational bc:
     predictors:
     - name: constant

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
@@ -25,8 +25,6 @@ obs operator:
 obs bias:
   input file: '{{cycle_dir}}/amsua_n19.{{background_time}}.satbias.nc4'
   output file: '{{cycle_dir}}/amsua_n19.{{window_begin}}.satbias.nc4'
-  variables without bc: [brightnessTemperature]
-  channels: 14
   variational bc:
     predictors:
     - name: constant

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
@@ -25,8 +25,6 @@ obs operator:
 obs bias:
   input file: '{{cycle_dir}}/atms_n20.{{background_time}}.satbias.nc4'
   output file: '{{cycle_dir}}/atms_n20.{{window_begin}}.satbias.nc4'
-  variables without bc: [brightnessTemperature]
-  channels: 15
   variational bc:
     predictors:
     - name: constant

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n21.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n21.yaml
@@ -25,8 +25,6 @@ obs operator:
 obs bias:
   input file: '{{cycle_dir}}/atms_n21.{{background_time}}.satbias.nc4'
   output file: '{{cycle_dir}}/atms_n21.{{window_begin}}.satbias.nc4'
-  variables without bc: [brightnessTemperature]
-  channels: 15
   variational bc:
     predictors:
     - name: constant

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
@@ -25,8 +25,6 @@ obs operator:
 obs bias:
   input file: '{{cycle_dir}}/atms_npp.{{background_time}}.satbias.nc4'
   output file: '{{cycle_dir}}/atms_npp.{{window_begin}}.satbias.nc4'
-  variables without bc: [brightnessTemperature]
-  channels: 15
   variational bc:
     predictors:
     - name: constant


### PR DESCRIPTION
## Description

This is a part of what is needed to sync swell w/ 5.42.x. Here we let channels 14 (AMSU-A) and 15 of (ATMS) to be bias corrected. 

## Dependencies

None

## Impact

Sync w/ 5.42.x
