### PR TITLE
Remove redundancy in data/time that swell cannot handle

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -264,7 +264,7 @@ observing_system_records_mksi_path:
   default_value: None
 
 observing_system_records_mksi_path_tag:
-  default_value: v5.42.6
+  default_value: v5.42.7
 
 observing_system_records_path:
   default_value: None


### PR DESCRIPTION
## Description

Very unclear how the code before the fix here would have ever made it in develop! 

In any case, the change - update of mksi - fixes the issue which turns out to point to the disadvantage of revamping code: whereas the original FORTRAN database code can handle date/time redundancy; the SWELL revamp cannot and this is what cause the code to break in SWELL but not in GEOS.

## Dependencies

None

## Impact

None