### PR TITLE
sync RO sources for 5.42x consistency

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gps.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gps.yaml
@@ -29,7 +29,7 @@ obs filters:
   where:
   - variable:
       name: MetaData/satelliteIdentifier
-    is_in: 41,265,266,267,268,421,440,724,725,726,727,728,729
+    is_in: 41,265,266,421,440,724,725,726,727,728,729
 #---
 - filter: Perform Action
   filter variables:
@@ -84,7 +84,7 @@ obs filters:
   where:
   - variable:
       name: MetaData/satelliteIdentifier
-    is_in: 269
+    is_in: 267,268,269
   - variable:
       name: MetaData/satelliteConstellationRO
     is_in: 401
@@ -99,7 +99,7 @@ obs filters:
   where:
   - variable:
       name: MetaData/satelliteIdentifier
-    is_in: 269
+    is_in: 267,268,269
   - variable:
       name: MetaData/satelliteConstellationRO
     is_in: 402-999
@@ -154,7 +154,7 @@ obs filters:
     inflation factor: 2.0
   where:
   - variable: MetaData/satelliteIdentifier
-    is_in: 269
+    is_in: 267,268,269
 
 # Gross check -- need to do obserror = min(cerrormax,max(cerrormin,obserr)
 # assign JediAdjustObsError/bendingAngle <--- ObsErrorData before changing its Min and Max
@@ -184,7 +184,7 @@ obs filters:
     value: is_valid
   - variable:
       name: MetaData/satelliteIdentifier
-    is_in:  41,44,269,440,421,724,725,726,727,728,729,
+    is_in:  41,44,267,268,269,440,421,724,725,726,727,728,729,
             750,751,752,753,754,755,821,825
   defer to post: true
 # reset ObsErrorData to 10.0 if it is > 10.0.

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gps.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gps.yaml
@@ -184,7 +184,7 @@ obs filters:
     value: is_valid
   - variable:
       name: MetaData/satelliteIdentifier
-    is_in:  41,44,267,268,269,440,421,724,725,726,727,728,729,
+    is_in:  3,5,41,42,43,44,267,268,269,440,421,724,725,726,727,728,729,
             750,751,752,753,754,755,821,825
   defer to post: true
 # reset ObsErrorData to 10.0 if it is > 10.0.


### PR DESCRIPTION
## Description

This basically piggy back from a PR #279  - updating that PR will introduces conflicts so I closed it and open this.

Besides, beyond what was in that PR, I believe the settings for obs errors for ex's 

3-5, 42 and 43 need attention - with respect to this please see the following lines:

https://github.com/GEOS-ESM/swell/blob/4aad14a1b41e22919005f7d0e3c145d70676c163/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gps.yaml#L178-L188

it looks to me like we should add the missing satellites 3-5, 42 and 43 here ... but is that really the case? I think there might be a little mingling of the obs-error formulation for COSMIC-2 and COMM satellites as opposed to other satellites. 

Can someone confirm or deny the above?

## Dependencies

None

## Impact

None
