### PR TITLE
Remove delp from bkg; avoid confusion

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/analysis.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/analysis.yaml
@@ -9,7 +9,6 @@ field io names:
   eastward_wind: ua
   northward_wind: va
   air_temperature: t
-  air_pressure_thickness: delp
   water_vapor_mixing_ratio_wrt_moist_air: q
   cloud_liquid_ice: qi
   cloud_liquid_water: ql

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
@@ -8,7 +8,6 @@ state variables: &statevars
 - eastward_wind
 - northward_wind
 - air_temperature
-- air_pressure_thickness
 - air_pressure_at_surface
 - water_vapor_mixing_ratio_wrt_moist_air
 - cloud_liquid_ice
@@ -50,7 +49,6 @@ field io names: &field_io_names
   eastward_wind: ua
   northward_wind: va
   air_temperature: t
-  air_pressure_thickness: delp
   water_vapor_mixing_ratio_wrt_moist_air: q
   cloud_liquid_ice: qi
   cloud_liquid_water: ql

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/pseudo-model.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/pseudo-model.yaml
@@ -10,7 +10,6 @@ field io names:
   eastward_wind: ua
   northward_wind: va
   air_temperature: t
-  air_pressure_thickness: delp
   water_vapor_mixing_ratio_wrt_moist_air: q
   cloud_liquid_ice: qi
   cloud_liquid_water: ql


### PR DESCRIPTION
## Description

This removes DELP from the background; this not needed for an ak/bk type analysis and it introduces room for confusion in fv3-jedi. Change in results might be seen as roundoff; nothing relevant.

We want to do this to the ensemble as well - but lets do it in a different PR - I believe Yonggang has already a version that removes delp from the ensemble analysis vector (something that never was in Var). We will work on the delp removal and handling examination of how GNSSRO works in the ensemble else where - I believe there is an issue there too.

## Dependencies

None

## Impact

Prep for when handling of 3d-pressure updates change to allow proper use of GNSSRO observations.
