### PR TITLE
Define IO Pool - help in high processor runs

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/aircraft_temperature.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/aircraft_temperature.yaml
@@ -4,6 +4,7 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/aircraft_temperature.{{window_begin}}.nc4'
+      missing file action: warn
     obsgrouping:
       group variables: ["stationIdentification", "releaseTime"]
       sort variable: "pressure"
@@ -12,6 +13,8 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.aircraft_temperature.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [airTemperature]
 
 obs bias:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/aircraft_wind.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/aircraft_wind.yaml
@@ -4,6 +4,7 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/aircraft_wind.{{window_begin}}.nc4'
+      missing file action: warn
     obsgrouping:
       group variables: ["stationIdentification", "releaseTime"]
       sort variable: "pressure"
@@ -12,6 +13,8 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.aircraft_wind.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [windEastward, windNorthward]
 
 obs operator:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/airs_aqua.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/airs_aqua.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.airs_aqua.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &airs_aqua_channels {{airs_aqua_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/amsr2_gcom-w1.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.amsr2_gcom-w1.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &amsr2_gcom-w1_available_channels {{amsr2_gcomw1_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_aqua.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/amsua_aqua.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.amsua_aqua.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &amsua_aqua_available_channels {{amsua_aqua_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-b.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/amsua_metop-b.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.amsua_metop-b.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &amsua_metop-b_available_channels {{amsua_metopb_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_metop-c.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/amsua_metop-c.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.amsua_metop-c.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &amsua_metop-c_available_channels {{amsua_metopc_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n15.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/amsua_n15.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.amsua_n15.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &amsua_n15_available_channels {{amsua_n15_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n18.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/amsua_n18.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.amsua_n18.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &amsua_n18_available_channels {{amsua_n18_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsua_n19.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/amsua_n19.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.amsua_n19.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &amsua_n19_available_channels {{amsua_n19_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n20.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/atms_n20.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.atms_n20.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &atms_n20_channels {{atms_n20_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n21.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_n21.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/atms_n21.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.atms_n21.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &atms_n21_channels {{atms_n21_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/atms_npp.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/atms_npp.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.atms_npp.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &atms_npp_channels {{atms_npp_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-b.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/avhrr3_metop-b.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.avhrr3_metop-b.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &avhrr3_metop-b_channels {{avhrr3_metopb_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_metop-c.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/avhrr3_metop-c.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.avhrr3_metop-c.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &avhrr3_metop-c_channels {{avhrr3_metopb_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n18.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/avhrr3_n18.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.avhrr3_n18.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &avhrr3_n18_channels {{avhrr3_n18_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/avhrr3_n19.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/avhrr3_n19.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.avhrr3_n19.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &avhrr3_n19_channels {{avhrr3_n19_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n20.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/cris-fsr_n20.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.cris-fsr_n20.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &cris-fsr_n20_channels {{crisfsr_n20_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n21.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_n21.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/cris-fsr_n21.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.cris-fsr_n21.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &cris-fsr_n21_channels {{crisfsr_n21_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/cris-fsr_npp.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/cris-fsr_npp.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.cris-fsr_npp.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &cris-fsr_npp_channels {{crisfsr_npp_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/gmi_gpm.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.gmi_gpm.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &gmi_gpm_available_channels {{gmi_gpm_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gps.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gps.yaml
@@ -4,6 +4,7 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/gps.{{window_begin}}.nc4'
+      missing file action: warn
     obsgrouping:
       group variables: [ 'sequenceNumber' ]
       sort variable: 'impactHeightRO'
@@ -12,6 +13,8 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.gps.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [bendingAngle]
 
 obs operator:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-b.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/iasi_metop-b.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.iasi_metop-b.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &iasi_metop-b_channels {{iasi_metopb_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/iasi_metop-c.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/iasi_metop-c.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.iasi_metop-c.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &iasi_metop-c_channels {{iasi_metopc_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/mhs_metop-b.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.mhs_metop-b.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &mhs_metop-b_available_channels {{mhs_metopb_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/mhs_metop-c.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.mhs_metop-c.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &mhs_metop-c_available_channels {{mhs_metopc_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/mhs_n19.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.mhs_n19.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [brightnessTemperature]
   channels: &mhs_n19_available_channels {{mhs_n19_avail_channels}}
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mls55_aura.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mls55_aura.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/mls55_aura.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.mls55_aura.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [ozoneProfile]
 
 obs operator:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/omi_aura.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/omi_aura.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/omi_aura.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.omi_aura.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [ozoneTotal]
 
 obs operator:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ompslpnc_n21.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ompslpnc_n21.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/ompslpnc_n21.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.ompslpnc_n21.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [ozoneProfile]
 
 obs operator:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ompslpnc_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ompslpnc_npp.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/ompslpnc_npp.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.ompslpnc_npp.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [ozoneProfile]
 
 obs operator:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ompsnm_npp.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ompsnm_npp.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/ompsnm_npp.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.ompsnm_npp.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [ozoneTotal]
 
 obs operator:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pibal.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pibal.yaml
@@ -4,6 +4,7 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/pibal.{{window_begin}}.nc4'
+      missing file action: warn
     obsgrouping:
       group variables: ["stationIdentification", "releaseTime"]
       sort variable: "pressure"
@@ -12,6 +13,8 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.pibal.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [windEastward, windNorthward]
 
 obs operator:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/satwind.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/satwind.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/satwind.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.satwind.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [windEastward, windNorthward]
 
 obs operator:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/scatwind.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/scatwind.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/scatwind.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.scatwind.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [windEastward, windNorthward]
 
 obs operator:

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/sfc.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.sfc.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [windEastward, windNorthward, virtualTemperature, airTemperature,
                         specificHumidity, stationPressure]
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfcship.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfcship.yaml
@@ -4,10 +4,13 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/sfcship.{{window_begin}}.nc4'
+      missing file action: warn
   obsdataout:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.sfcship.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [windEastward, windNorthward, virtualTemperature, airTemperature,
                         specificHumidity, stationPressure]
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sondes.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sondes.yaml
@@ -4,6 +4,7 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/sondes.{{window_begin}}.nc4'
+      missing file action: error
     obsgrouping:
       group variables: ["stationIdentification", "releaseTime"]
       sort variable: "pressure"
@@ -12,6 +13,8 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.sondes.{{window_begin}}.nc4'
+  io pool:
+    max pool size: 6
   simulated variables: [windEastward, windNorthward, virtualTemperature, airTemperature,
                         specificHumidity, stationPressure]
 

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ssmis_f17.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/ssmis_f17.yaml
@@ -1,3 +1,18 @@
+  obs space:
+    name: &Sensor_ID ssmis_f17
+    obsdatain:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/ssmis_f17.{{window_begin}}.nc4'
+        missing file action: warn
+    obsdataout:
+      engine:
+        type: H5File
+        obsfile: '{{cycle_dir}}/{{experiment_id}}.ssmis_f17.{{window_begin}}.nc4'
+    simulated variables: [brightnessTemperature]
+    channels: &ssmis_f17_channels {{ssmis_f17_avail_channels}} 
+  io pool:
+    max pool size: 6
   obs operator:
     name: CRTM
     Absorbers: [H2O,O3,CO2]
@@ -5,21 +20,9 @@
       Absorbers: [H2O,O3]
       Surfaces: [Water_Temperature,Land_Temperature,Ice_Temperature,Snow_Temperature]
     obs options:
-      Sensor_ID: &Sensor_ID ssmis_f17
+      Sensor_ID: *Sensor_ID
       EndianType: little_endian
       CoefficientPath: '{{crtm_coeff_dir}}/'
-  obs space:
-    name: *Sensor_ID
-    obsdatain:
-      engine:
-        type: H5File
-        obsfile: '{{cycle_dir}}/ssmis_f17.{{window_begin}}.nc4'
-    obsdataout:
-      engine:
-        type: H5File
-        obsfile: '{{cycle_dir}}/{{experiment_id}}.ssmis_f17.{{window_begin}}.nc4'
-    simulated variables: [brightnessTemperature]
-    channels: &ssmis_f17_channels {{ssmis_f17_avail_channels}} 
   obs bias:
     input file: '{{cycle_dir}}/ssmis_f17.{{background_time}}.satbias.nc4'
     output file: '{{cycle_dir}}/ssmis_f17.{{window_begin}}.satbias.nc4'


### PR DESCRIPTION
## Description

Having IO Pool defined is important for high-PE runs; not noticeable in the SWELL default cases.

## Dependencies

None

## Impact

None
