### PR TITLE
Allow for use of 3d-pressures in interface to observers

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/analysis.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/analysis.yaml
@@ -9,7 +9,8 @@ field io names:
   eastward_wind: ua
   northward_wind: va
   air_temperature: t
-  air_pressure_thickness: delp
+  air_pressure_at_surface: ps
+  air_pressure_levels: pe
   water_vapor_mixing_ratio_wrt_moist_air: q
   cloud_liquid_ice: qi
   cloud_liquid_water: ql
@@ -38,6 +39,5 @@ field io names:
   skin_temperature_at_surface: ts
   eastward_wind_at_surface: u10m
   northward_wind_at_surface: v10m
-  air_pressure_at_surface: ps
 # sea_surface_temperature: ts_found
 # mole_fraction_of_carbon_dioxide_in_air: co2

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
@@ -1,6 +1,8 @@
 datetime: '{{local_background_time_iso}}'
 filetype: cube sphere history
 provider: geos
+compute edge pressure from surface pressure: true
+max allowable geometry difference: 1e-3
 datapath: '{{cycle_dir}}'
 filenames: ['bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4',
             'fv3-jedi/bkg/geos.crtmsrf.{{horizontal_resolution}}.nc4']
@@ -8,8 +10,8 @@ state variables: &statevars
 - eastward_wind
 - northward_wind
 - air_temperature
-- air_pressure_thickness
 - air_pressure_at_surface
+- air_pressure_levels
 - water_vapor_mixing_ratio_wrt_moist_air
 - cloud_liquid_ice
 - cloud_liquid_water
@@ -50,7 +52,8 @@ field io names: &field_io_names
   eastward_wind: ua
   northward_wind: va
   air_temperature: t
-  air_pressure_thickness: delp
+  air_pressure_at_surface: ps
+  air_pressure_levels: pe
   water_vapor_mixing_ratio_wrt_moist_air: q
   cloud_liquid_ice: qi
   cloud_liquid_water: ql
@@ -79,6 +82,5 @@ field io names: &field_io_names
   skin_temperature_at_surface: ts
   eastward_wind_at_surface: u10m
   northward_wind_at_surface: v10m
-  air_pressure_at_surface: ps
 # sea_surface_temperature: ts_found
 # mole_fraction_of_carbon_dioxide_in_air: co2

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_ensemble.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_ensemble.yaml
@@ -4,6 +4,8 @@ members from template:
     datetime: '{{local_background_time_iso}}'
     filetype: cube sphere history
     provider: geos
+    compute edge pressure from surface pressure: true
+    max allowable geometry difference: 1e-3
     datapath: '.'
     filenames: ['ebkg/mem%mem%/geos.mem%mem%.%yyyy%mm%dd_%hh%MM%ssz.nc4',
                 'fv3-jedi/bkg/geos.crtmsrf.{{horizontal_resolution}}.nc4']
@@ -11,8 +13,8 @@ members from template:
     - eastward_wind
     - northward_wind
     - air_temperature
-    - air_pressure_thickness
     - air_pressure_at_surface
+    - air_pressure_levels
     - water_vapor_mixing_ratio_wrt_moist_air
     - cloud_liquid_ice
     - cloud_liquid_water
@@ -53,7 +55,8 @@ members from template:
       eastward_wind: ua
       northward_wind: va
       air_temperature: t
-      air_pressure_thickness: delp
+      air_pressure_at_surface: ps
+      air_pressure_levels: pe
       water_vapor_mixing_ratio_wrt_moist_air: q
       cloud_liquid_ice: qi
       cloud_liquid_water: ql
@@ -82,7 +85,6 @@ members from template:
       skin_temperature_at_surface: ts
       eastward_wind_at_surface: u10m
       northward_wind_at_surface: v10m
-      air_pressure_at_surface: ps
 #     sea_surface_temperature: ts_found
 #     mole_fraction_of_carbon_dioxide_in_air: co2
   pattern: '%mem%'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_error.yaml
@@ -27,6 +27,7 @@ saber outer blocks:
   state variables to inverse: &bvars [eastward_wind,
                                       northward_wind,air_temperature,
                                       air_pressure_at_surface,
+                                      air_pressure_levels,
                                       water_vapor_mixing_ratio_wrt_moist_air,
                                       cloud_liquid_ice,
                                       cloud_liquid_water,

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_block.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_block.yaml
@@ -3,14 +3,16 @@ members from template:
     datetime: '{{local_background_time_iso}}'
     filetype: cube sphere history
     provider: geos
+    compute edge pressure from surface pressure: true
+    max allowable geometry difference: 1e-3
     datapath: '{{cycle_dir}}'
     filename: 'ebkg/mem%mem%/geos.mem%mem%.%yyyy%mm%dd_%hh%MM%ssz.nc4'
     state variables: &statevars
     - eastward_wind
     - northward_wind
     - air_temperature
-    - air_pressure_thickness
     - air_pressure_at_surface
+    - air_pressure_levels
     - water_vapor_mixing_ratio_wrt_moist_air
     - cloud_liquid_ice
     - cloud_liquid_water
@@ -33,7 +35,8 @@ members from template:
       eastward_wind: ua
       northward_wind: va
       air_temperature: t
-      air_pressure_thickness: delp
+      air_pressure_at_surface: ps
+      air_pressure_levels: pe
       water_vapor_mixing_ratio_wrt_moist_air: q
       cloud_liquid_ice: qi
       cloud_liquid_water: ql
@@ -47,7 +50,6 @@ members from template:
       skin_temperature_at_surface: ts
       eastward_wind_at_surface: u10m
       northward_wind_at_surface: v10m
-      air_pressure_at_surface: ps
 #     sea_surface_temperature: ts_found
 #     mole_fraction_of_carbon_dioxide_in_air: co2
   pattern: '%mem%'

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_cube_mean_output.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_cube_mean_output.yaml
@@ -7,7 +7,7 @@
     eastward_wind: ua
     northward_wind: va
     air_temperature: t
-    air_pressure_thickness: delp
+    air_pressure_levels: pe
     water_vapor_mixing_ratio_wrt_moist_air: q
     cloud_liquid_ice: qi
     cloud_liquid_water: ql

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_cube_variance_output.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_cube_variance_output.yaml
@@ -7,7 +7,7 @@
     eastward_wind: ua
     northward_wind: va
     air_temperature: t
-    air_pressure_thickness: delp
+    air_pressure_levels: pe
     water_vapor_mixing_ratio_wrt_moist_air: q
     cloud_liquid_ice: qi
     cloud_liquid_water: ql

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_mean_increment_output.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_mean_increment_output.yaml
@@ -6,7 +6,8 @@ field io names:
   eastward_wind: ua
   northward_wind: va
   air_temperature: t
-  air_pressure_thickness: delp
+  air_pressure_at_surface: ps
+  air_pressure_levels: pe
   water_vapor_mixing_ratio_wrt_moist_air: q
   cloud_liquid_ice: qi
   cloud_liquid_water: ql

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_mean_output.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_mean_output.yaml
@@ -6,7 +6,7 @@ field io names:
   eastward_wind: ua
   northward_wind: va
   air_temperature: t
-  air_pressure_thickness: delp
+  air_pressure_levels: pe
   water_vapor_mixing_ratio_wrt_moist_air: q
   cloud_liquid_ice: qi
   cloud_liquid_water: ql

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_members_increment_output.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_members_increment_output.yaml
@@ -6,7 +6,8 @@ field io names:
   eastward_wind: ua
   northward_wind: va
   air_temperature: t
-  air_pressure_thickness: delp
+  air_pressure_at_surface: ps
+  air_pressure_levels: pe
   water_vapor_mixing_ratio_wrt_moist_air: q
   cloud_liquid_ice: qi
   cloud_liquid_water: ql

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_members_output.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/ensemble_members_output.yaml
@@ -6,7 +6,7 @@ field io names:
   eastward_wind: ua
   northward_wind: va
   air_temperature: t
-  air_pressure_thickness: delp
+  air_pressure_levels: pe
   water_vapor_mixing_ratio_wrt_moist_air: q
   cloud_liquid_ice: qi
   cloud_liquid_water: ql

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/pseudo-model.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/pseudo-model.yaml
@@ -2,6 +2,8 @@ name: PSEUDO
 tstep: {{background_frequency}}
 filetype: cube sphere history
 provider: geos
+compute edge pressure from surface pressure: true
+max allowable geometry difference: 1e-3
 datapath: '{{cycle_dir}}'
 filenames: ['bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4',
             'fv3-jedi/bkg/geos.crtmsrf.{{horizontal_resolution}}.nc4']
@@ -10,7 +12,8 @@ field io names:
   eastward_wind: ua
   northward_wind: va
   air_temperature: t
-  air_pressure_thickness: delp
+  air_pressure_at_surface: ps
+  air_pressure_levels: pe
   water_vapor_mixing_ratio_wrt_moist_air: q
   cloud_liquid_ice: qi
   cloud_liquid_water: ql
@@ -39,6 +42,5 @@ field io names:
   skin_temperature_at_surface: ts
   eastward_wind_at_surface: u10m
   northward_wind_at_surface: v10m
-  air_pressure_at_surface: ps
 # sea_surface_temperature: ts_found
 # mole_fraction_of_carbon_dioxide_in_air: co2

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/varincrement1.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/varincrement1.yaml
@@ -19,3 +19,4 @@ increment:
       geopotential_height_times_gravity_at_surface: phis
       skin_temperature_at_surface: ts
       air_pressure_at_surface: ps
+      air_pressure_levels: pe

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gps.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gps.yaml
@@ -21,10 +21,11 @@ obs operator:
   name: GnssroBndNBAM
   obs options:
     use_compress: 1
-    vertlayer: mass
+#   vertlayer: mass
+    vertlayer: full
     sr_steps: 2
     super_ref_qc: NBAM
-    GSI_version: GEOS
+#   GSI_version: GEOS
 obs filters:
 #---
 #0 Blacklist data from some satellites

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -10,6 +10,7 @@ analysis_variables:
   - air_temperature
   - water_vapor_mixing_ratio_wrt_moist_air
   - air_pressure_at_surface
+  - air_pressure_levels
   - cloud_liquid_ice
   - cloud_liquid_water
   - rain_water
@@ -24,8 +25,9 @@ analysis_variables:
   - eastward_wind
   - northward_wind
   - air_temperature
-  - water_vapor_mixing_ratio_wrt_moist_air
   - air_pressure_at_surface
+  - air_pressure_levels
+  - water_vapor_mixing_ratio_wrt_moist_air
   - cloud_liquid_ice
   - cloud_liquid_water
   - rain_water
@@ -152,10 +154,10 @@ local_ensemble_inflation_rtps:
   default_value: 0.5
 
 local_ensemble_solver:
-  default_value: LETKF
+  default_value: Deterministic LETKF
   options:
-  - LETKF
-  - GETKF
+  - Deterministic LETKF
+  - Deterministic GETKF
 
 local_ensemble_use_linear_observer:
   default_value: true

--- a/src/swell/configuration/jedi/oops/LocalEnsembleDA.yaml
+++ b/src/swell/configuration/jedi/oops/LocalEnsembleDA.yaml
@@ -10,7 +10,8 @@ increment variables:
   - eastward_wind
   - northward_wind
   - air_temperature
-  - air_pressure_thickness
+  - air_pressure_at_surface
+  - air_pressure_levels
   - water_vapor_mixing_ratio_wrt_moist_air
   - cloud_liquid_ice
   - cloud_liquid_water

--- a/src/swell/suites/localensembleda/suite_config.py
+++ b/src/swell/suites/localensembleda/suite_config.py
@@ -44,7 +44,7 @@ class SuiteConfig(QuestionContainer, Enum):
             qd.cycle_times(['T00']),
             qd.ensemble_num_members(16),
             qd.skip_ensemble_hofx(True),
-            qd.local_ensemble_solver("GETKF"),
+            qd.local_ensemble_solver("Deterministic GETKF"),
             qd.local_ensemble_use_linear_observer(True),
             qd.ensmean_only(False),
             qd.local_ensemble_save_posterior_mean(True),


### PR DESCRIPTION
## Description

These changes allow for use of 3d-pressure in the observation operators - this is particularly relevant for handling GNSSRO. 

This has been tested JEDI 18Jun2025.

The aim is to reset the pinned version to that of 18Jun2025.

## Dependencies

JEDI 18 Jun 2025

- [x] https://github.com/GEOS-ESM/jedi_bundle/pull/77 

In reality there is not true dependence on the PR above - but we should avoid multiple changes ... so it would be best to first approve the JEDI_BUNDLE PR above and build a 18 Jun version of JEDI that is consistent w/ the changes in the PR in the bundle.

## Impact

proper handling of UFO operators that depend on 3d (edge) pressures.
