### PR TITLE
Swell doc updates for offline installation of Swell and uv

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,7 +13,7 @@
   - **Discover**
     - [Installing Swell on SLES15](platforms/discover/installing_swell_discover_sles15.md)
     - [Installing Swell using `uv` and `venv`](platforms/discover/installing_swell_uv_venv.md)
-    - [Offline Intallation of SWELL and `uv`](platforms/discover/installing_swell_uv_offline.md)
+    - [Installing Swell with `uv` without internet access](platforms/discover/installing_swell_uv_offline.md)
     - [Configuring `cylc`](platforms/discover/configuring_cylc_discover.md)
 
 - Practical Examples

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -14,6 +14,7 @@
     - [Installing Swell on SLES15](platforms/discover/installing_swell_discover_sles15.md)
     - [Installing Swell using `uv` and `venv`](platforms/discover/installing_swell_uv_venv.md)
     - [Configuring `cylc`](platforms/discover/configuring_cylc_discover.md)
+    - [Offline Intallation of SWELL and `uv`](platforms/discover/installing_swell_uv_offline.md)
 
 - Practical Examples
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,8 +13,8 @@
   - **Discover**
     - [Installing Swell on SLES15](platforms/discover/installing_swell_discover_sles15.md)
     - [Installing Swell using `uv` and `venv`](platforms/discover/installing_swell_uv_venv.md)
-    - [Configuring `cylc`](platforms/discover/configuring_cylc_discover.md)
     - [Offline Intallation of SWELL and `uv`](platforms/discover/installing_swell_uv_offline.md)
+    - [Configuring `cylc`](platforms/discover/configuring_cylc_discover.md)
 
 - Practical Examples
 

--- a/docs/examples/soca/3dfgat_cycle.md
+++ b/docs/examples/soca/3dfgat_cycle.md
@@ -254,7 +254,7 @@ folder for GEOS restarts and experiment directory:
 `mom6` and `cice6` model interfaces are supported. `mom6` should always be active for `SOCA` however `cice6` is
 optional. If `cice6` model is not active one should take out sea-ice related observations and variables from the `experiment.yaml` and from the `analysis_variables`.
 
-- `mom6_iau`: This is optional, however highly recommended for model stability. See [MOM6 settings](../../configs/model_configurations/mom6.md) for details.
+- `mom6_iau`: This is optional, however highly recommended for model stability. See [MOM6 settings](configs/model_configurations/mom6.md) for details.
 
 - `obs_provider`: For marine observations, two providers are used `odas` (GMAO) and `gdas_marine` (NOAA-EMC). R2D2 will
 scan `Local` (as highlighted in `r2d2_local_path`) and `Shared` (GMAO-wide) locations for these two providers.
@@ -265,7 +265,7 @@ If you would like to change any of these parameters, it is suggested to copy `ex
 to `override.yaml` and make desired configuration changes. Afterwards, create the experiment again:
 
 ```bash
-swell create 3dvar -o override.yaml
+swell create 3dfgat_cycle -o override.yaml
 ```
 
 However, most of these settings, especially the ones pertaining the DA windows, are tied to the way

--- a/docs/examples/soca/3dfgat_cycle.md
+++ b/docs/examples/soca/3dfgat_cycle.md
@@ -25,7 +25,7 @@ experiment_id: fgat_test
 With this, the following experiment folder will be created:
 `/discover/nobackup/dardag/test_folder/fgat_test`
 
-Another critical input argument for `swell create` is  `-s slurmfile.yaml`. Please see [slurm config instructions](../../configs/slurm_configuration.md) for more details on how to use it for high resolution tests. Below `experiment.yaml` will show a 5-deg setup created with a 0.25-deg `slurmfile.yaml` to demonstrate the  proper use of `slurmfile.yaml` though 1 node configurations will suffice for a 5-deg cycle.
+Another critical input argument for `swell create` is  `-s slurmfile.yaml`. Please see [slurm config instructions](configs/slurm_configuration.md) for more details on how to use it for high resolution tests. Below `experiment.yaml` will show a 5-deg setup created with a 0.25-deg `slurmfile.yaml` to demonstrate the  proper use of `slurmfile.yaml` though 1 node configurations will suffice for a 5-deg cycle.
 
 Before launching the experiment, let's take a look at the `experiment.yaml`.
 

--- a/docs/platforms/discover/installing_swell_uv_offline.md
+++ b/docs/platforms/discover/installing_swell_uv_offline.md
@@ -33,6 +33,7 @@ We will download all the required packages on local with the corresponding pytho
     which pip3  # make sure that the path of pip3 is the one under your venv
 
     mkdir ../downloaded  # where offline packages will be saved to
+    pip3 download "setuptools>=40.8.0" -d ../downloaded
     pip3 download -r requirements.txt -d ../downloaded  
 ```
 3. Upload the packages under `downloaded` to a Discover directory, `[discover_offline_pkg_path]`
@@ -47,6 +48,11 @@ We will download all the required packages on local with the corresponding pytho
     ml purge
     python -m ensurepip --upgrade  # this installed pip & setuptools
     which pip3    # ensure pip3 points to the same dir as python under your venv
+    # (optional_start) run these if pip3 does not points to the one under your venv
+    deactivate
+    source .venv/bin/activate
+    which pip3    # ensure pip3 points to the same dir as python under your venv
+    # (optional_end)
     pip3 install --no-index --find-links=[discover_offline_pkg_path] -r requirements.txt
 ```
 5. Install SWELL in editable mode 

--- a/docs/platforms/discover/installing_swell_uv_offline.md
+++ b/docs/platforms/discover/installing_swell_uv_offline.md
@@ -1,4 +1,7 @@
-# Install `uv` & `Swell` on Discover with offline packages
+# Installing Swell with `uv` without internet access
+This page is only for the users **who have no outranet on Discover**. We show here:
+- How to install uv and Swell using offline packages;
+- How to synchronize your code between Discover and GitHub.
 
 #### Install uv
 1. get the installer `wget -c https://astral.sh/uv/install.sh`

--- a/docs/platforms/discover/installing_swell_uv_offline.md
+++ b/docs/platforms/discover/installing_swell_uv_offline.md
@@ -1,0 +1,62 @@
+# Install `uv` & `Swell` on Discover with offline packages
+
+#### Install uv
+1. get the installer `wget -c https://astral.sh/uv/install.sh`
+2. From `install.sh`, check the version `APP_VERSION`, and download the file `uv-x86_64-unknown-linux-gnu.tar.gz` with the corresponding `APP_VERSION` from `https://github.com/astral-sh/uv/releases`
+3. Upload both `install.sh` and `uv-x86_64-unknown-linux-gnu.tar.gz` to a directory under discover, `[discover_path]`
+4. Revise the installer script: under function `downloader`, replace the line `curl -sSfL "$1" -o "$2"` with `cp "$1" "$2"`.
+5. Now install the uv. Assume that you default shell is `bash`, run the following
+```bash
+    INSTALLER_DOWNLOAD_URL=[discover_path] ./install.sh
+```
+This will finish the uv installation. Then follow the Swell documentation to finish other uv settings
+
+#### Install Swell
+We will download all the required packages on local with the corresponding python version `` [python_version]`, and then install those packages on Discover.
+1. on a `x86_64` Linux machine (e.g., an AWS ec2 instance with Intel or AMD CPU, and with os=`sles15`), get all the required offline installation packages. 
+```bash
+    #install uv first
+
+    #assume you now have installed uv 
+    uv venv -p python[python_version] myenv 
+    source myenv/bin/activate
+
+    git clone https://github.com/GEOS-ESM/swell
+    cd swell    # your swell repo
+    uv pip install pip
+    which pip3  # make sure that the path of pip3 is the one under your venv
+
+    mkdir ../downloaded # where offline packages will be saved to
+    pip3 download setuptools>=40.8.0 -d ../downloaded
+    pip3 download -r requirements.txt -d ../downloaded  
+```
+3. Upload the packages under `downloaded` to a Discover directory, `[discover_offline_pkg_path]`
+4. Install the packages on Discover. 
+```bash
+pip3 install --no-index --find-links=[discover_offline_pkg_path] -r requirements.txt
+```
+
+
+#### Code synchronization when outranet is disabled on Discover
+The idea is to use the repo at local as a middle man, so that you can 
+`Discover ----> local ----> Github`, or `Github ----> local ---->  Discover`
+
+1. `git clone` the repo from the Github, and then tar the directory and transfer it to Discover under directory `[discover_path]` 
+2. On your local, do the following in a new directory
+```bash
+    git init
+    git remote add discover USER_NAME@discover.nccs.nasa.gov:[discover_path]
+    git pull discover [branch_name]
+    # or create local branches remapped to your desired remote branch
+```
+3. **Push codes from Discover to Github**
+	1. on local, create a local branch mapped to your remote branch
+	2. on local, at the mapped local branch: `git pull discover [branch_name]`
+	3. on local, at the mapped local branch: `git push [github_remote] [branch_name]`
+4. **Fetch codes from Github to Discover**
+	1. on local, at the mapped local branch: `git pull [github_remote] [branch_name]`
+	2. on Discover, **ensure you are at a branch other than `[branch_name]`**
+	3. on local, at the mapped local branch: `git push discover [branch_name]`
+	4. Check: on Discover, branch `[branch_name]` should now be synchronized as the local `[branch_name]`
+
+**In the worst scenario**, you can always do the dumb way: tar your repo from Discover, download to local, and then untar and sync. This approach with the opposite direction also works.

--- a/docs/platforms/discover/installing_swell_uv_offline.md
+++ b/docs/platforms/discover/installing_swell_uv_offline.md
@@ -22,7 +22,7 @@ We will download all the required packages on local with the corresponding pytho
     #install uv first
 
     git clone https://github.com/GEOS-ESM/swell
-    cd swell    # your swell repo
+    cd swell    # your SWELL repo
 
     #assume you now have installed uv 
     uv venv --python=python[python3_version]  # e.g., uv venv --python=python3.11.7
@@ -32,30 +32,38 @@ We will download all the required packages on local with the corresponding pytho
     uv pip install pip
     which pip3  # make sure that the path of pip3 is the one under your venv
 
-    mkdir ../downloaded # where offline packages will be saved to
-    pip3 download "setuptools>=40.8.0" -d ../downloaded
+    mkdir ../downloaded  # where offline packages will be saved to
     pip3 download -r requirements.txt -d ../downloaded  
 ```
 3. Upload the packages under `downloaded` to a Discover directory, `[discover_offline_pkg_path]`
-4. On Discover, install the packages by
+4. On a milan node from Discover, install the packages by
 ```bash
     # get into the swell directory
 
-    # load mod_swell
-
+    mod_swell
     uv venv
     source .venv/bin/activate
     which python  # ensure python points to the python under your venv
-
-    # include pip3 under the same venv
-    which pip3    # as you can see, now pip3 is outside of the venv
-    python -m ensurepip --upgrade
-    which pip3    # now pip3 points to the same dir as python under your venv
-
+    ml purge
+    python -m ensurepip --upgrade  # this installed pip & setuptools
+    which pip3    # ensure pip3 points to the same dir as python under your venv
     pip3 install --no-index --find-links=[discover_offline_pkg_path] -r requirements.txt
 ```
-5. Install SWELL in editable mode `python -m pip install -e .`
-
+5. Install SWELL in editable mode 
+```
+    deactivate 
+    mod_swell
+    source .venv/bin/activate
+    python -m pip install -e .
+```
+#### Reuse SWELL and launch SWELL jobs
+Log into a **Milan** node on Discover, run 
+```
+mod_swell
+cd swell  # your SWELL repo
+source .venv/bin/activate
+```
+Then use `swell create/launch [...]` to create/launch your SWELL jobs.
 
 #### Code synchronization when outranet is disabled on Discover
 The idea is to use the repo at local as a middle man, so that you can 

--- a/docs/platforms/discover/installing_swell_uv_offline.md
+++ b/docs/platforms/discover/installing_swell_uv_offline.md
@@ -1,6 +1,6 @@
-# Installing Swell with `uv` without internet access
+# Installing SWELL with `uv` without internet access
 This page is only for the users **who have no outranet on Discover**. We show here:
-- How to install uv and Swell using offline packages;
+- How to install uv and SWELL using offline packages;
 - How to synchronize your code between Discover and GitHub.
 
 #### Install uv
@@ -12,32 +12,49 @@ This page is only for the users **who have no outranet on Discover**. We show he
 ```bash
     INSTALLER_DOWNLOAD_URL=[discover_path] ./install.sh
 ```
-This will finish the uv installation. Then follow the Swell documentation to finish other uv settings
+This will finish the uv installation. Then follow the SWELL documentation to finish other uv settings
 
-#### Install Swell
-We will download all the required packages on local with the corresponding python version `` [python_version]`, and then install those packages on Discover.
-1. on a `x86_64` Linux machine (e.g., an AWS ec2 instance with Intel or AMD CPU, and with os=`sles15`), get all the required offline installation packages. 
+#### Install SWELL
+We will download all the required packages on local with the corresponding python version `[python_version]`, and then install those packages on Discover.
+1. Find the python version used by the JEDI module. On Discover, Load the `mod_swell` (see instructions [here](platforms/discover/installing_swell_uv_venv.md)). Then get the python version `[python_version]` by running `python --version`.
+2. On a `x86_64` Linux machine (e.g., an AWS ec2 instance with Intel or AMD CPU, and with os=`sles15`), get all the required offline installation packages. 
 ```bash
     #install uv first
 
-    #assume you now have installed uv 
-    uv venv -p python[python_version] myenv 
-    source myenv/bin/activate
-
     git clone https://github.com/GEOS-ESM/swell
     cd swell    # your swell repo
+
+    #assume you now have installed uv 
+    uv venv --python=python[python3_version]  # e.g., uv venv --python=python3.11.7
+    source .venv/bin/activate
+    python --version # check if this gives the same [python_version] as on Discover
+
     uv pip install pip
     which pip3  # make sure that the path of pip3 is the one under your venv
 
     mkdir ../downloaded # where offline packages will be saved to
-    pip3 download setuptools>=40.8.0 -d ../downloaded
+    pip3 download "setuptools>=40.8.0" -d ../downloaded
     pip3 download -r requirements.txt -d ../downloaded  
 ```
 3. Upload the packages under `downloaded` to a Discover directory, `[discover_offline_pkg_path]`
-4. Install the packages on Discover. 
+4. On Discover, install the packages by
 ```bash
-pip3 install --no-index --find-links=[discover_offline_pkg_path] -r requirements.txt
+    # get into the swell directory
+
+    # load mod_swell
+
+    uv venv
+    source .venv/bin/activate
+    which python  # ensure python points to the python under your venv
+
+    # include pip3 under the same venv
+    which pip3    # as you can see, now pip3 is outside of the venv
+    python -m ensurepip --upgrade
+    which pip3    # now pip3 points to the same dir as python under your venv
+
+    pip3 install --no-index --find-links=[discover_offline_pkg_path] -r requirements.txt
 ```
+5. Install SWELL in editable mode `python -m pip install -e .`
 
 
 #### Code synchronization when outranet is disabled on Discover

--- a/docs/platforms/platforms.md
+++ b/docs/platforms/platforms.md
@@ -4,7 +4,7 @@
 This section outlines platform specific instructions for installing and configuring SWELL.
 
 - Discover:
-  - [Cylc Instructions](discover/configuring_cylc_discover.md)
-  - [SWELL Installation with pip & modules](discover/installing_swell_discover_sles15.md)
-  - [SWELL Installation using `uv`](discover/installing_swell_uv_venv.md)
-  - [Offline Installation of `uv` & Swell ](discover/installing_swell_uv_offline.md)
+  - [Cylc Instructions](platforms/discover/configuring_cylc_discover.md)
+  - [SWELL Installation with pip & modules](platforms/discover/installing_swell_discover_sles15.md)
+  - [Offline Installation of `uv` & Swell ](platforms/discover/installing_swell_uv_offline.md)
+  - [SWELL Installation using `uv`](platforms/discover/installing_swell_uv_venv.md)

--- a/docs/platforms/platforms.md
+++ b/docs/platforms/platforms.md
@@ -7,3 +7,4 @@ This section outlines platform specific instructions for installing and configur
   - [Cylc Instructions](discover/configuring_cylc_discover.md)
   - [SWELL Installation with pip & modules](discover/installing_swell_discover_sles15.md)
   - [SWELL Installation using `uv`](discover/installing_swell_uv_venv.md)
+  - [Offline Installation of `uv` & Swell ](discover/installing_swell_uv_offline.md)

--- a/docs/platforms/platforms.md
+++ b/docs/platforms/platforms.md
@@ -6,5 +6,5 @@ This section outlines platform specific instructions for installing and configur
 - Discover:
   - [Cylc Instructions](platforms/discover/configuring_cylc_discover.md)
   - [SWELL Installation with pip & modules](platforms/discover/installing_swell_discover_sles15.md)
-  - [Offline Installation of `uv` & Swell ](platforms/discover/installing_swell_uv_offline.md)
   - [SWELL Installation using `uv`](platforms/discover/installing_swell_uv_venv.md)
+  - [SWELL Installation with `uv` without internet access](platforms/discover/installing_swell_uv_offline.md)


### PR DESCRIPTION
## Description
1. Add instructions for offline installation of Swell and uv.
2. Add instructions for code synchronization between Discover and GitHub if no outranet on Discover.
3. Fixes some broken links in the document which otherwise generates 404 error.

## Dependencies
None.

## Impact
Only changes the docs of Swell.

