### PR TITLE
Fix for non-captured CI test output

### DIFF
--- a/src/swell/cylc_swell.py
+++ b/src/swell/cylc_swell.py
@@ -69,7 +69,7 @@ def execute_cylc(argv=sys.argv) -> None:
 
         env = configure_cylc_environment(append_env)
 
-        subprocess.run(cylc_command, env=env)
+        subprocess.run(cylc_command, env=env, check=True)
 
     # Try just calling cylc from the path
     else:
@@ -80,6 +80,6 @@ def execute_cylc(argv=sys.argv) -> None:
 
         env = configure_cylc_environment()
 
-        subprocess.run(cylc_command, env=env)
+        subprocess.run(cylc_command, env=env, check=True)
 
 # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Makes it so that CI tests properly return non-zero exit status upon failure (this is so simple I can't believe I missed it)