### PR TITLE
SWELL now controls peripheral files

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage.yaml
@@ -1,8 +1,7 @@
 - link_files:
     directories:
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/GEOS_CRTM_Surface/geos.crtmsrf.{{horizontal_resolution}}.nc4', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/bkg/']
-      - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi/test/Data/fv3files/*', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/']
-      - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi-data/testinput_tier_1/inputs/fv3files/*', '{{cycle_dir}}/fv3-jedi/fv3files/']
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/fv3files/*', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/fv3files/']
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/1.0.1/gsi-coeffs-gmao-global-l{{vertical_resolution}}x{{gsibec_nlons}}y{{gsibec_nlats}}.nc4', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/gsibec/']
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/1.0.1/{{gsibec_configuration}}_l{{vertical_resolution}}x{{gsibec_nlons}}y{{gsibec_nlats}}.nml', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/gsibec/']
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/rcov/1.0.0/*', '{{experiment_root}}/{{experiment_id}}/stage/fv3-jedi/geos_atmosphere/rcov/']

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage_cycle.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/stage_cycle.yaml
@@ -1,8 +1,7 @@
 - link_files:
     directories:
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/GEOS_CRTM_Surface/geos.crtmsrf.{{horizontal_resolution}}.nc4', '{{cycle_dir}}/fv3-jedi/bkg/']
-      - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi/test/Data/fv3files/*', '{{cycle_dir}}/fv3-jedi/fv3files/']
-      - ['{{experiment_root}}/{{experiment_id}}/jedi_bundle/source/fv3-jedi-data/testinput_tier_1/inputs/fv3files/*', '{{cycle_dir}}/fv3-jedi/fv3files/']
+      - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/fv3files/*', '{{cycle_dir}}/fv3-jedi/fv3files/']
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec/1.0.1/gsi-coeffs-gmao-global-l{{vertical_resolution}}x{{gsibec_nlons}}y{{gsibec_nlats}}.nc4', '{{cycle_dir}}/fv3-jedi/gsibec/']
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/gsibec//1.0.1/{{gsibec_configuration}}_l{{vertical_resolution}}x{{gsibec_nlons}}y{{gsibec_nlats}}.nml', '{{cycle_dir}}/fv3-jedi/gsibec/']
       - ['{{swell_static_files}}/jedi/interfaces/geos_atmosphere/rcov/1.0.0/*', '{{cycle_dir}}/fv3-jedi/rcov/']


### PR DESCRIPTION
## Description

This is the permanent solution for what in PR #602  No more references to JEDI source code ... not sure if the ocean part has similar links to the source - if it does, I suggest that gets resolved in way similar to here - but in a separate PR.

Notice that the advantage of us controlling these files allowed me to easily - without the nightmare of approval process on JEDI - to get AKBK files for two new configurations of the model, look under:

/discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/interfaces/geos_atmosphere/fv3files/


## Dependencies

None

## Impact

SHouldn't be any.
