### PR TITLE
Adding cloud seeding option to all-sky radiance yaml files

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/amsr2_gcom-w1.yaml
@@ -19,6 +19,7 @@ obs operator:
   Absorbers: [H2O,O3,CO2]
   Clouds: [Water, Ice, Rain, Snow]
   Cloud_Fraction: 1.0
+  Cloud_Seeding: true  
   obs options:
     Sensor_ID: &Sensor_ID amsr2_gcom-w1
     EndianType: little_endian

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/gmi_gpm.yaml
@@ -19,6 +19,7 @@ obs operator:
   Absorbers: [H2O,O3,CO2]
   Clouds: [Water, Ice, Rain, Snow]
   Cloud_Fraction: 1.0
+  Cloud_Seeding: true
   obs options:
     Sensor_ID: &Sensor_ID gmi_gpm
     EndianType: little_endian

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-b.yaml
@@ -19,6 +19,7 @@ obs operator:
   Absorbers: [H2O,O3,CO2]
   Clouds: [Water, Ice, Rain, Snow]
   Cloud_Fraction: 1.0
+  Cloud_Seeding: true
   obs options:
     Sensor_ID: &Sensor_ID mhs_metop-b
     EndianType: little_endian

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_metop-c.yaml
@@ -19,6 +19,7 @@ obs operator:
   Absorbers: [H2O,O3,CO2]
   Clouds: [Water, Ice, Rain, Snow]
   Cloud_Fraction: 1.0
+  Cloud_Seeding: true
   obs options:
     Sensor_ID: &Sensor_ID mhs_metop-c
     EndianType: little_endian

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mhs_n19.yaml
@@ -19,6 +19,7 @@ obs operator:
   Absorbers: [H2O,O3,CO2]
   Clouds: [Water, Ice, Rain, Snow]
   Cloud_Fraction: 1.0
+  Cloud_Seeding: true
   obs options:
     Sensor_ID: &Sensor_ID mhs_n19
     EndianType: little_endian


### PR DESCRIPTION
The current all-sky microwave yaml files don't have cloud seeding option. UFO codes have been evolving. Based on the July UFO version, it is seen that the cloud seeding option is not needed when geovals are produced from GSI runs, but this option is needed for all-sky radiances when geovals are generated on the fly.  GMI and AMSR2 are used in all-sky conditions in GEOS, so this PR is adding this option to their yaml files.  