### PR TITLE
Handle task aborts using exceptions

### DIFF
--- a/src/swell/tasks/base/task_base.py
+++ b/src/swell/tasks/base/task_base.py
@@ -193,8 +193,8 @@ class taskBase(ABC):
     def cycle_dir(self) -> str:
 
         # Check that model is set
-        self.assert_abort(self.__model__ is not None, 'In get_cycle_dir but this ' +
-                          'should not be called if the task does not receive model.')
+        self.logger.assert_abort(self.__model__ is not None, 'In get_cycle_dir but this ' +
+                                 'should not be called if the task does not receive model.')
 
         # Combine datetime string (directory format) with the model
         cycle_dir = os.path.join(self.experiment_path(), 'run',

--- a/src/swell/tasks/base/task_base.py
+++ b/src/swell/tasks/base/task_base.py
@@ -121,7 +121,7 @@ class taskBase(ABC):
             # Object for computing data assimilation window parameters
             self.da_window_params = DataAssimilationWindowParams(self.logger,
                                                                  self.__datetime__.string_iso())
-            
+
         # Set Swell exception types
         for exception_type in ExceptionTypes.get_all():
             setattr(self, exception_type.__name__, exception_type)
@@ -194,7 +194,7 @@ class taskBase(ABC):
 
         # Check that model is set
         self.assert_abort(self.__model__ is not None, 'In get_cycle_dir but this ' +
-                                 'should not be called if the task does not receive model.')
+                          'should not be called if the task does not receive model.')
 
         # Combine datetime string (directory format) with the model
         cycle_dir = os.path.join(self.experiment_path(), 'run',

--- a/src/swell/tasks/base/task_base.py
+++ b/src/swell/tasks/base/task_base.py
@@ -27,6 +27,7 @@ from swell.utilities.datetime_util import Datetime
 from swell.utilities.logger import get_logger
 from swell.utilities.render_jedi_interface_files import JediConfigRendering
 from swell.utilities.geos import Geos
+from swell.utilities.exceptions import ExceptionTypes
 
 
 # --------------------------------------------------------------------------------------------------
@@ -120,6 +121,10 @@ class taskBase(ABC):
             # Object for computing data assimilation window parameters
             self.da_window_params = DataAssimilationWindowParams(self.logger,
                                                                  self.__datetime__.string_iso())
+            
+        # Set Swell exception types
+        for exception_type in ExceptionTypes.get_all():
+            setattr(self, exception_type.__name__, exception_type)
 
     # ----------------------------------------------------------------------------------------------
 
@@ -188,7 +193,7 @@ class taskBase(ABC):
     def cycle_dir(self) -> str:
 
         # Check that model is set
-        self.logger.assert_abort(self.__model__ is not None, 'In get_cycle_dir but this ' +
+        self.assert_abort(self.__model__ is not None, 'In get_cycle_dir but this ' +
                                  'should not be called if the task does not receive model.')
 
         # Combine datetime string (directory format) with the model

--- a/src/swell/tasks/base/task_base.py
+++ b/src/swell/tasks/base/task_base.py
@@ -27,7 +27,6 @@ from swell.utilities.datetime_util import Datetime
 from swell.utilities.logger import get_logger
 from swell.utilities.render_jedi_interface_files import JediConfigRendering
 from swell.utilities.geos import Geos
-from swell.utilities.exceptions import ExceptionTypes
 
 
 # --------------------------------------------------------------------------------------------------
@@ -121,10 +120,6 @@ class taskBase(ABC):
             # Object for computing data assimilation window parameters
             self.da_window_params = DataAssimilationWindowParams(self.logger,
                                                                  self.__datetime__.string_iso())
-
-        # Set Swell exception types
-        for exception_type in ExceptionTypes.get_all():
-            setattr(self, exception_type.__name__, exception_type)
 
     # ----------------------------------------------------------------------------------------------
 

--- a/src/swell/tasks/get_obs_not_in_r2d2.py
+++ b/src/swell/tasks/get_obs_not_in_r2d2.py
@@ -75,7 +75,7 @@ class GetObsNotInR2d2(taskBase):
             command = ['ln', '-s', existing_path_file, existing_path_file_target]
 
             self.logger.info(f'Linking {existing_path_file} '
-                             f'to {existing_path_file_target}', wrap=False)
+                             f'to {existing_path_file_target}')
 
             # Copy the file
             # -------------

--- a/src/swell/tasks/gsi_ncdiag_to_ioda.py
+++ b/src/swell/tasks/gsi_ncdiag_to_ioda.py
@@ -116,7 +116,7 @@ class GsiNcdiagToIoda(taskBase):
         for gsi_type_to_process in gsi_types_to_process:
 
             log_str = f'Processing GSI file {gsi_type_to_process}'
-            self.logger.info('', wrap=False)
+            self.logger.info('')
             self.logger.info(log_str)
             self.logger.info('-'*len(log_str))
 
@@ -157,7 +157,7 @@ class GsiNcdiagToIoda(taskBase):
             Diag.toIODAobs(self.cycle_dir(), platforms=needed_platforms)
 
             if produce_geovals:
-                self.logger.info('', wrap=False)
+                self.logger.info('')
                 self.logger.info(f'Processing GeoVaLs from {gsi_type_to_process_actual}')
                 Diag.toGeovals(self.cycle_dir())
 
@@ -176,7 +176,7 @@ class GsiNcdiagToIoda(taskBase):
 
             # Logging
             log_str = f'Combining IODA files for {needed_ioda_type}'
-            self.logger.info('', wrap=False)
+            self.logger.info('')
             self.logger.info(log_str)
             self.logger.info('-'*len(log_str))
 

--- a/src/swell/tasks/stage_jedi.py
+++ b/src/swell/tasks/stage_jedi.py
@@ -12,6 +12,7 @@ import os
 
 from swell.tasks.base.task_base import taskBase
 from swell.utilities.filehandler import get_file_handler
+from swell.utilities.exceptions import SwellError
 from swell.utilities.file_system_operations import check_if_files_exist_in_path
 
 
@@ -82,5 +83,5 @@ class StageJedi(taskBase):
                 self.logger.abort('One or more files not ready')
             else:
                 fh.get()
-        except self.SwellError as e:
+        except SwellError as e:
             self.logger.abort(str(e))

--- a/src/swell/tasks/stage_jedi.py
+++ b/src/swell/tasks/stage_jedi.py
@@ -11,8 +11,7 @@
 import os
 
 from swell.tasks.base.task_base import taskBase
-from swell.utilities.filehandler import *
-from swell.utilities.exceptions import *
+from swell.utilities.filehandler import get_file_handler
 from swell.utilities.file_system_operations import check_if_files_exist_in_path
 
 
@@ -83,5 +82,5 @@ class StageJedi(taskBase):
                 self.logger.abort('One or more files not ready')
             else:
                 fh.get()
-        except SWELLError as e:
+        except self.SwellError as e:
             self.logger.abort(str(e))

--- a/src/swell/test/code_tests/test_generate_observing_system.py
+++ b/src/swell/test/code_tests/test_generate_observing_system.py
@@ -3,6 +3,7 @@ import unittest
 import subprocess
 from datetime import datetime as dt
 from swell.utilities.logger import get_logger
+from swell.utilities.exceptions import SwellError
 from swell.utilities.get_channels import get_channels
 from swell.test.code_tests.testing_utilities import suppress_stdout
 from swell.utilities.observing_system_records import ObservingSystemRecords
@@ -49,7 +50,7 @@ class GenerateObservingSystemTest(unittest.TestCase):
                         "Missing active channels for cris-fsr_npp, " + \
                         "Confirm that you are using the right version of GEOSmksi"
 
-        with self.assertRaises(Exception) as abort, suppress_stdout():
+        with self.assertRaises(SwellError) as abort, suppress_stdout():
             log_level = self.logger.level
             # Set logger priority to 60. This number sets the minimum level of message
             # that the logger can register (Where message criticality ascends from 0 to 50).

--- a/src/swell/test/code_tests/test_generate_observing_system.py
+++ b/src/swell/test/code_tests/test_generate_observing_system.py
@@ -49,7 +49,7 @@ class GenerateObservingSystemTest(unittest.TestCase):
                         "Missing active channels for cris-fsr_npp, " + \
                         "Confirm that you are using the right version of GEOSmksi"
 
-        with self.assertRaises(SystemExit) as abort, suppress_stdout():
+        with self.assertRaises(Exception) as abort, suppress_stdout():
             log_level = self.logger.level
             # Set logger priority to 60. This number sets the minimum level of message
             # that the logger can register (Where message criticality ascends from 0 to 50).

--- a/src/swell/test/code_tests/test_pinned_versions.py
+++ b/src/swell/test/code_tests/test_pinned_versions.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import subprocess
 from swell.utilities.logger import get_logger
+from swell.utilities.exceptions import SwellError
 from swell.test.code_tests.testing_utilities import suppress_stdout
 from swell.utilities.pinned_versions.check_hashes import check_hashes
 
@@ -26,7 +27,7 @@ class PinnedVersionsTest(unittest.TestCase):
                        stdout=subprocess.DEVNULL)
         abort_message = "Wrong commit hashes found for these repositories in jedi_bundle: [oops]"
         # Run check hash (expect abort)
-        with self.assertRaises(Exception) as abort, suppress_stdout():
+        with self.assertRaises(SwellError) as abort, suppress_stdout():
             log_level = logger.level
             # Set logger priority to 60. This number sets the minimum level of message
             # that the logger can register (Where message criticality ascends from 0 to 50).

--- a/src/swell/test/code_tests/test_pinned_versions.py
+++ b/src/swell/test/code_tests/test_pinned_versions.py
@@ -17,14 +17,16 @@ class PinnedVersionsTest(unittest.TestCase):
         # Clone oops repository in jedi_bundle (develop hash)
         if not os.path.exists(jedi_bundle_dir + "oops"):
             cmd = ["git", "clone", "https://github.com/JCSDA/oops.git"]
+            wd = jedi_bundle_dir
         else:
-            cmd = ["git", "checkout", "develop"]
+            cmd = ["git", "switch", "develop"]
+            wd = os.path.join(jedi_bundle_dir, 'oops')
 
-        subprocess.run(cmd, cwd=jedi_bundle_dir, stderr=subprocess.DEVNULL,
+        subprocess.run(cmd, cwd=wd, stderr=subprocess.DEVNULL,
                        stdout=subprocess.DEVNULL)
         abort_message = "Wrong commit hashes found for these repositories in jedi_bundle: [oops]"
         # Run check hash (expect abort)
-        with self.assertRaises(SystemExit) as abort, suppress_stdout():
+        with self.assertRaises(Exception) as abort, suppress_stdout():
             log_level = logger.level
             # Set logger priority to 60. This number sets the minimum level of message
             # that the logger can register (Where message criticality ascends from 0 to 50).

--- a/src/swell/utilities/exceptions.py
+++ b/src/swell/utilities/exceptions.py
@@ -3,51 +3,11 @@
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-# -----------------------------------------------------------------------------
 
-from enum import Enum
 
-# -----------------------------------------------------------------------------
-
+# --------------------------------------------------------------------------------------------------
 
 class SwellError(Exception):
     pass
 
-# -----------------------------------------------------------------------------
-
-
-class SwellFileError(SwellError):
-    pass
-
-# -----------------------------------------------------------------------------
-
-
-class SwellConfigError(SwellError):
-    pass
-
-# -----------------------------------------------------------------------------
-
-
-class ExceptionTypes(Enum):
-
-    SwellError = SwellError
-    SwellFileError = SwellFileError
-    SwellConfigError = SwellConfigError
-
-    # -----------------------------------------------------------------------------
-
-    @classmethod
-    def get_type(cls, name: str):
-        return cls[name].value
-
-    # -----------------------------------------------------------------------------
-
-    @classmethod
-    def get_all(cls) -> list:
-        member_list = []
-        for name in cls._member_names_:
-            member_list.append(cls.get_type(name))
-
-        return member_list
-
-# -----------------------------------------------------------------------------
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/utilities/exceptions.py
+++ b/src/swell/utilities/exceptions.py
@@ -5,36 +5,45 @@
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 # -----------------------------------------------------------------------------
 
-from typing import Optional
-from logging import Logger as pyLogger
-
-
-class SWELLError(Exception):
-
-    def __init__(
-        self,
-        message: str,
-        logger: Optional[pyLogger] = None
-    ) -> None:
-
-        self.message = message
-        super().__init__(message)
-
-        if logger:
-            logger(message)
+from enum import Enum, member
 
 # -----------------------------------------------------------------------------
 
 
-class SWELLFileError(SWELLError):
+class ExceptionTypes(Enum):
 
-    pass
+    # -----------------------------------------------------------------------------
 
-# -----------------------------------------------------------------------------
+    @member
+    class SwellError(Exception):
+        pass
 
+    # -----------------------------------------------------------------------------
 
-class SWELLConfigError(SWELLError):
+    @member
+    class SwellFileError(SwellError):
+        pass
 
-    pass
+    # -----------------------------------------------------------------------------
 
-# -----------------------------------------------------------------------------
+    @member
+    class SwellConfigError(SwellError):
+        pass
+
+    # -----------------------------------------------------------------------------
+
+    @classmethod
+    def get_type(cls, name: str):
+        return cls.name.value
+
+    # -----------------------------------------------------------------------------
+
+    @classmethod
+    def get_all(cls) -> list:
+        member_list = []
+        for name in cls._member_names_:
+            member_list.append(cls.get_type(name))
+
+        return member_list
+
+    # -----------------------------------------------------------------------------

--- a/src/swell/utilities/exceptions.py
+++ b/src/swell/utilities/exceptions.py
@@ -5,30 +5,34 @@
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 # -----------------------------------------------------------------------------
 
-from enum import Enum, member
+from enum import Enum
+
+# -----------------------------------------------------------------------------
+
+
+class SwellError(Exception):
+    pass
+
+# -----------------------------------------------------------------------------
+
+
+class SwellFileError(SwellError):
+    pass
+
+# -----------------------------------------------------------------------------
+
+
+class SwellConfigError(SwellError):
+    pass
 
 # -----------------------------------------------------------------------------
 
 
 class ExceptionTypes(Enum):
 
-    # -----------------------------------------------------------------------------
-
-    @member
-    class SwellError(Exception):
-        pass
-
-    # -----------------------------------------------------------------------------
-
-    @member
-    class SwellFileError(SwellError):
-        pass
-
-    # -----------------------------------------------------------------------------
-
-    @member
-    class SwellConfigError(SwellError):
-        pass
+    SwellError = SwellError
+    SwellFileError = SwellFileError
+    SwellConfigError = SwellConfigError
 
     # -----------------------------------------------------------------------------
 
@@ -46,4 +50,4 @@ class ExceptionTypes(Enum):
 
         return member_list
 
-    # -----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------

--- a/src/swell/utilities/exceptions.py
+++ b/src/swell/utilities/exceptions.py
@@ -34,7 +34,7 @@ class ExceptionTypes(Enum):
 
     @classmethod
     def get_type(cls, name: str):
-        return cls.name.value
+        return cls[name].value
 
     # -----------------------------------------------------------------------------
 

--- a/src/swell/utilities/filehandler.py
+++ b/src/swell/utilities/filehandler.py
@@ -271,7 +271,7 @@ class StageFileHandler(FileHandler):
                     filelist = glob.glob(src)
 
                     if not filelist and self.strict:
-                        raise Exception('Source inputs not found "'
+                        raise FileNotFound('Source inputs not found "'
                                         + src + '"')
 
                     for srcfile in filelist:

--- a/src/swell/utilities/filehandler.py
+++ b/src/swell/utilities/filehandler.py
@@ -221,7 +221,7 @@ class FileHandler(object):
         if os.path.islink(dst):
             os.remove(dst)
         if os.path.isfile(dst):
-            raise Exception('File exists where link expected: "' + dst + '"')
+            raise ValueError('File exists where link expected: "' + dst + '"')
         if not os.path.isfile(dst):
             os.symlink(src, dst)
 
@@ -271,8 +271,8 @@ class StageFileHandler(FileHandler):
                     filelist = glob.glob(src)
 
                     if not filelist and self.strict:
-                        raise Exception('Source inputs not found "'
-                                        + src + '"')
+                        raise FileNotFoundError('Source inputs not found "'
+                                                + src + '"')
 
                     for srcfile in filelist:
                         bname = os.path.basename(srcfile)

--- a/src/swell/utilities/filehandler.py
+++ b/src/swell/utilities/filehandler.py
@@ -65,10 +65,8 @@ import datetime as dt
 from shutil import copyfile
 from typing import Union, Optional, Any
 
-from swell.utilities.exceptions import ExceptionTypes
+from swell.utilities.exceptions import SwellFileError, SwellConfigError
 
-SwellFileError = ExceptionTypes.SwellFileError.value
-SwellConfigError = ExceptionTypes.SwellConfigError.value
 
 def get_file_handler(config: list, **kwargs) -> Union[StageFileHandler, GetDataFileHandler]:
     """Factory for determining the file handler type for retrieving data.

--- a/src/swell/utilities/filehandler.py
+++ b/src/swell/utilities/filehandler.py
@@ -65,8 +65,10 @@ import datetime as dt
 from shutil import copyfile
 from typing import Union, Optional, Any
 
-from swell.utilities.exceptions import *
+from swell.utilities.exceptions import ExceptionTypes
 
+SwellFileError = ExceptionTypes.SwellFileError.value
+SwellConfigError = ExceptionTypes.SwellConfigError.value
 
 def get_file_handler(config: list, **kwargs) -> Union[StageFileHandler, GetDataFileHandler]:
     """Factory for determining the file handler type for retrieving data.
@@ -90,7 +92,7 @@ def get_file_handler(config: list, **kwargs) -> Union[StageFileHandler, GetDataF
 
     strict = kwargs.get('strict', True)
     if not isinstance(config, list):
-        raise SWELLConfigError(config)
+        raise SwellConfigError(config)
 
     group = config[0]
     collection = group.get('copy_files', {}).get('directories', [])
@@ -180,7 +182,7 @@ class FileHandler(object):
             try:
                 os.makedirs(dir, 0o755, exist_ok=True)
             except Exception as e:
-                raise SWELLFileError(str(e))
+                raise SwellFileError(str(e))
 
             if fc.link:
                 self.link(srcfile, dstfile)
@@ -202,12 +204,12 @@ class FileHandler(object):
         """
 
         if not os.path.isfile(src):
-            raise SWELLFileError('Source file does not exist: "' + src + '"')
+            raise SwellFileError('Source file does not exist: "' + src + '"')
 
         try:
             copyfile(src, dst)
         except Exception as e:
-            raise SWELLFileError(str(e))
+            raise SwellFileError(str(e))
 
 # ---------------------------------------------------------------------------
 
@@ -224,17 +226,17 @@ class FileHandler(object):
         """
 
         if not os.path.isfile(src):
-            raise SWELLFileError('Source file does not exist: "' + src + '"')
+            raise SwellFileError('Source file does not exist: "' + src + '"')
 
         try:
             if os.path.islink(dst):
                 os.remove(dst)
             if os.path.isfile(dst):
-                raise SWELLFileError('File exists where link expected: "' + dst + '"')
+                raise SwellFileError('File exists where link expected: "' + dst + '"')
             if not os.path.isfile(dst):
                 os.symlink(src, dst)
         except Exception as e:
-            raise SWELLFileError(str(e))
+            raise SwellFileError(str(e))
 
 # ---------------------------------------------------------------------------
 
@@ -282,7 +284,7 @@ class StageFileHandler(FileHandler):
                     filelist = glob.glob(src)
 
                     if not filelist and self.strict:
-                        raise SWELLConfigError('Source inputs not found "'
+                        raise SwellConfigError('Source inputs not found "'
                                                + src + '"')
 
                     for srcfile in filelist:
@@ -371,7 +373,7 @@ class GetDataFileHandler(FileHandler):
                         fc.update(srcfile, dstfile)
 
                 if not found and self.strict:
-                    raise SWELLConfigError('Source inputs not found "' +
+                    raise SwellConfigError('Source inputs not found "' +
                                            srcfile + '"')
 
             listing.append(fc)

--- a/src/swell/utilities/filehandler.py
+++ b/src/swell/utilities/filehandler.py
@@ -65,8 +65,6 @@ import datetime as dt
 from shutil import copyfile
 from typing import Union, Optional, Any
 
-from swell.utilities.exceptions import SwellFileError, SwellConfigError
-
 
 def get_file_handler(config: list, **kwargs) -> Union[StageFileHandler, GetDataFileHandler]:
     """Factory for determining the file handler type for retrieving data.
@@ -90,7 +88,7 @@ def get_file_handler(config: list, **kwargs) -> Union[StageFileHandler, GetDataF
 
     strict = kwargs.get('strict', True)
     if not isinstance(config, list):
-        raise SwellConfigError(config)
+        raise TypeError(config)
 
     group = config[0]
     collection = group.get('copy_files', {}).get('directories', [])
@@ -177,10 +175,7 @@ class FileHandler(object):
 
             dir = os.path.dirname(dstfile)
 
-            try:
-                os.makedirs(dir, 0o755, exist_ok=True)
-            except Exception as e:
-                raise SwellFileError(str(e))
+            os.makedirs(dir, 0o755, exist_ok=True)
 
             if fc.link:
                 self.link(srcfile, dstfile)
@@ -202,12 +197,9 @@ class FileHandler(object):
         """
 
         if not os.path.isfile(src):
-            raise SwellFileError('Source file does not exist: "' + src + '"')
+            raise FileNotFoundError('Source file does not exist: "' + src + '"')
 
-        try:
-            copyfile(src, dst)
-        except Exception as e:
-            raise SwellFileError(str(e))
+        copyfile(src, dst)
 
 # ---------------------------------------------------------------------------
 
@@ -224,17 +216,14 @@ class FileHandler(object):
         """
 
         if not os.path.isfile(src):
-            raise SwellFileError('Source file does not exist: "' + src + '"')
+            raise FileNotFoundError('Source file does not exist: "' + src + '"')
 
-        try:
-            if os.path.islink(dst):
-                os.remove(dst)
-            if os.path.isfile(dst):
-                raise SwellFileError('File exists where link expected: "' + dst + '"')
-            if not os.path.isfile(dst):
-                os.symlink(src, dst)
-        except Exception as e:
-            raise SwellFileError(str(e))
+        if os.path.islink(dst):
+            os.remove(dst)
+        if os.path.isfile(dst):
+            raise Exception('File exists where link expected: "' + dst + '"')
+        if not os.path.isfile(dst):
+            os.symlink(src, dst)
 
 # ---------------------------------------------------------------------------
 
@@ -282,8 +271,8 @@ class StageFileHandler(FileHandler):
                     filelist = glob.glob(src)
 
                     if not filelist and self.strict:
-                        raise SwellConfigError('Source inputs not found "'
-                                               + src + '"')
+                        raise Exception('Source inputs not found "'
+                                        + src + '"')
 
                     for srcfile in filelist:
                         bname = os.path.basename(srcfile)
@@ -371,8 +360,8 @@ class GetDataFileHandler(FileHandler):
                         fc.update(srcfile, dstfile)
 
                 if not found and self.strict:
-                    raise SwellConfigError('Source inputs not found "' +
-                                           srcfile + '"')
+                    raise FileNotFoundError('Source inputs not found "' +
+                                            srcfile + '"')
 
             listing.append(fc)
 

--- a/src/swell/utilities/filehandler.py
+++ b/src/swell/utilities/filehandler.py
@@ -221,7 +221,7 @@ class FileHandler(object):
         if os.path.islink(dst):
             os.remove(dst)
         if os.path.isfile(dst):
-            raise Exception('File exists where link expected: "' + dst + '"')
+            raise ValueError('File exists where link expected: "' + dst + '"')
         if not os.path.isfile(dst):
             os.symlink(src, dst)
 

--- a/src/swell/utilities/filehandler.py
+++ b/src/swell/utilities/filehandler.py
@@ -271,8 +271,8 @@ class StageFileHandler(FileHandler):
                     filelist = glob.glob(src)
 
                     if not filelist and self.strict:
-                        raise FileNotFound('Source inputs not found "'
-                                        + src + '"')
+                        raise FileNotFoundError('Source inputs not found "'
+                                                + src + '"')
 
                     for srcfile in filelist:
                         bname = os.path.basename(srcfile)

--- a/src/swell/utilities/get_channels.py
+++ b/src/swell/utilities/get_channels.py
@@ -13,6 +13,7 @@ from datetime import datetime as dt
 from itertools import groupby
 from typing import Tuple, Optional
 
+from swell.utilities.exceptions import SwellError
 from swell.utilities.logger import Logger
 
 # --------------------------------------------------------------------------------------------------
@@ -96,11 +97,13 @@ def get_channels(
 
         if available_channels is None:
             logger.abort(f'Missing available channels for {observation}, '
-                         'Confirm that you are using the right version of GEOSmksi')
+                         'Confirm that you are using the right version of GEOSmksi',
+                         exception=SwellError)
 
         if active_channels is None:
             logger.abort(f'Missing active channels for {observation}, '
-                         'Confirm that you are using the right version of GEOSmksi')
+                         'Confirm that you are using the right version of GEOSmksi',
+                         exception=SwellError)
 
         available_channels_list = process_channel_lists(available_channels)
         available_range_string = create_range_string(available_channels_list)

--- a/src/swell/utilities/logger.py
+++ b/src/swell/utilities/logger.py
@@ -112,7 +112,7 @@ class Logger(logging.Logger):
 
     # ----------------------------------------------------------------------------------------------
 
-    def abort(self, msg: str, wrap: bool = True, exception: Exception = SwellError, *args, **kwargs) -> None:
+    def abort(self, msg: str, wrap: bool = True, exception: Exception = Exception, *args, **kwargs) -> None:
         formatted_msg = red + msg + end
         formatted_msg = self.format_message(formatted_msg, wrap, 'ABORT')
         super().critical(formatted_msg)

--- a/src/swell/utilities/logger.py
+++ b/src/swell/utilities/logger.py
@@ -8,9 +8,7 @@
 
 
 import os
-import sys
 import textwrap
-import traceback
 import logging
 from typing import Optional
 

--- a/src/swell/utilities/logger.py
+++ b/src/swell/utilities/logger.py
@@ -117,7 +117,7 @@ class Logger(logging.Logger):
     def abort(self, msg: str, wrap: bool = True, exception: Exception = SwellError, *args, **kwargs) -> None:
         formatted_msg = red + msg + end
         formatted_msg = self.format_message(formatted_msg, wrap, 'ABORT')
-        super().critical(msg)
+        super().critical(formatted_msg)
 
         raise exception(msg)
 

--- a/src/swell/utilities/logger.py
+++ b/src/swell/utilities/logger.py
@@ -14,6 +14,7 @@ import traceback
 import logging
 from typing import Optional
 
+from swell.utilities.exceptions import ExceptionTypes
 
 # --------------------------------------------------------------------------------------------------
 #  @package logger
@@ -22,6 +23,8 @@ from typing import Optional
 #
 # --------------------------------------------------------------------------------------------------
 
+
+SwellError = ExceptionTypes.get_type('SwellError')
 
 red = '\033[91m'
 blue = '\033[94m'
@@ -111,20 +114,12 @@ class Logger(logging.Logger):
 
     # ----------------------------------------------------------------------------------------------
 
-    def abort(self, msg: str, wrap: bool = True, *args, **kwargs) -> None:
-        msg = red + msg + end
-        msg = self.format_message(msg, wrap, 'ABORT')
+    def abort(self, msg: str, wrap: bool = True, exception: Exception = SwellError, *args, **kwargs) -> None:
+        formatted_msg = red + msg + end
+        formatted_msg = self.format_message(formatted_msg, wrap, 'ABORT')
         super().critical(msg)
 
-        # Get traceback stack (without logger.py lines)
-        filtered_stack = [line for line in traceback.format_stack() if 'logger.py' not in line]
-
-        # Remove everything after 'logger.assert_abort' in last element of filtered_stack
-        filtered_stack[-1] = filtered_stack[-1].split('logger.assert_abort')[0]
-
-        traceback_str = '\n'.join(filtered_stack)
-
-        sys.exit('\nHERE IS THE TRACEBACK: \n----------------------\n\n' + traceback_str)
+        raise exception(msg)
 
     # ----------------------------------------------------------------------------------------------
 

--- a/src/swell/utilities/logger.py
+++ b/src/swell/utilities/logger.py
@@ -8,113 +8,22 @@
 
 
 import os
-import textwrap
 import logging
 from typing import Optional
-
-from swell.utilities.exceptions import SwellError
-
-# --------------------------------------------------------------------------------------------------
-#  @package logger
-#
-#  Class containing a logger for tasks.
-#
-# --------------------------------------------------------------------------------------------------
-
-
-red = '\033[91m'
-blue = '\033[94m'
-cyan = '\033[96m'
-green = '\033[92m'
-end = '\033[0m'
-
-under = '\033[4m'
-
 
 # --------------------------------------------------------------------------------------------------
 
 
 class Logger(logging.Logger):
 
-    def __init__(self, name: Optional[str] = None, **kwargs) -> None:
-        self.__maxlen__ = 100
-        super().__init__(name, **kwargs)
+    # --------------------------------------------------------------------------------------------------
 
-    # ----------------------------------------------------------------------------------------------
+    def abort(self, msg: str,
+              exception: Exception = Exception, *args, **kwargs) -> None:
 
-    def format_message(self, msg: str, wrap: bool, level: Optional[str] = None) -> str:
-        # Wrap the message if needed
-        if wrap:
-            message_items = textwrap.wrap(msg, self.__maxlen__, break_long_words=True)
-            for i in range(0, len(message_items)-1):
-                message_items[i] = message_items[i] + ' ...\n'
-        else:
-            message_items = []
-            message_items.append(msg)
+        formatted_msg = '  Swell called ABORT: ' + msg
 
-        # Include level in the message
-        level_show = ''
-        if level != 'BLANK':
-            level_show = level_show+' '+self.name+': '
-
-        if level == 'ABORT':
-            task_name = under + self.name + end
-            level_show = red + 'ABORT IN ' + end + task_name + ': '
-
-        color = end
-        if level == 'ABORT':
-            color = red
-
-        msg = ''
-        if level == 'ABORT':
-            msg = '\n' + msg
-        first_line = True
-        for message_item in message_items:
-            if not first_line:
-                message_item = ' ' + color + message_item + end
-            msg = msg + level_show + message_item
-            first_line = False
-
-        return msg
-
-    # ----------------------------------------------------------------------------------------------
-
-    def critical(self, msg: str, wrap: bool = True, *args, **kwargs) -> None:
-        msg = self.format_message(msg, wrap)
-        super().critical(msg, *args, **kwargs)
-
-    # ----------------------------------------------------------------------------------------------
-
-    def error(self, msg: str, wrap: bool = True, *args, **kwargs) -> None:
-        msg = self.format_message(msg, wrap)
-        super().error(msg, **args, **kwargs)
-
-    # ----------------------------------------------------------------------------------------------
-
-    def info(self, msg: str, wrap: bool = True, *args, **kwargs) -> None:
-        msg = self.format_message(msg, wrap)
-        super().info(msg, *args, **kwargs)
-
-    # ----------------------------------------------------------------------------------------------
-
-    def blank(self, msg: str, wrap: bool = True, *args, **kwargs) -> None:
-        # blank has severity of INFO, does not output task name
-        msg = self.format_message(msg, wrap, 'BLANK')
-        super().info(msg, *args, **kwargs)
-
-    # ----------------------------------------------------------------------------------------------
-
-    def debug(self, msg: str, wrap: bool = True, *args, **kwargs) -> None:
-        msg = self.format_message(msg, wrap)
-        super().debug(msg, *args, **kwargs)
-
-    # ----------------------------------------------------------------------------------------------
-
-    def abort(self, msg: str, wrap: bool = True,
-              exception: Exception = SwellError, *args, **kwargs) -> None:
-        formatted_msg = red + msg + end
-        formatted_msg = self.format_message(formatted_msg, wrap, 'ABORT')
-        super().critical(formatted_msg)
+        super().critical(formatted_msg, *args, **kwargs)
 
         raise exception(msg)
 
@@ -156,7 +65,7 @@ def get_logger(name: Optional[str] = None) -> Logger:
     if name is None:
         name = ''
 
-    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    logging.basicConfig(level=logging.INFO, format='%(name)s: %(message)s')
     logging.setLoggerClass(Logger)
 
     logger = logging.Logger.manager.getLogger(name)

--- a/src/swell/utilities/logger.py
+++ b/src/swell/utilities/logger.py
@@ -12,7 +12,7 @@ import textwrap
 import logging
 from typing import Optional
 
-from swell.utilities.exceptions import ExceptionTypes
+from swell.utilities.exceptions import SwellError
 
 # --------------------------------------------------------------------------------------------------
 #  @package logger
@@ -21,8 +21,6 @@ from swell.utilities.exceptions import ExceptionTypes
 #
 # --------------------------------------------------------------------------------------------------
 
-
-SwellError = ExceptionTypes.get_type('SwellError')
 
 red = '\033[91m'
 blue = '\033[94m'
@@ -112,7 +110,8 @@ class Logger(logging.Logger):
 
     # ----------------------------------------------------------------------------------------------
 
-    def abort(self, msg: str, wrap: bool = True, exception: Exception = Exception, *args, **kwargs) -> None:
+    def abort(self, msg: str, wrap: bool = True,
+              exception: Exception = SwellError, *args, **kwargs) -> None:
         formatted_msg = red + msg + end
         formatted_msg = self.format_message(formatted_msg, wrap, 'ABORT')
         super().critical(formatted_msg)

--- a/src/swell/utilities/pinned_versions/check_hashes.py
+++ b/src/swell/utilities/pinned_versions/check_hashes.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 import importlib.resources
 from swell.utilities.logger import Logger
+from swell.utilities.exceptions import SwellError
 
 
 def get_pinned_vers_path() -> Path:
@@ -40,4 +41,4 @@ def check_hashes(jedi_bundle_loc: str, logger: Logger) -> None:
     # If there are incorrect hashes, logger abort
     if incorrect_hash:
         logger.abort("Wrong commit hashes found for these repositories "
-                     f"in jedi_bundle: {incorrect_hash}")
+                     f"in jedi_bundle: {incorrect_hash}", exception=SwellError)

--- a/src/swell/utilities/welcome_message.py
+++ b/src/swell/utilities/welcome_message.py
@@ -8,7 +8,6 @@
 
 
 from swell import __version__
-from swell.utilities.logger import get_logger
 
 
 # --------------------------------------------------------------------------------------------------
@@ -16,12 +15,10 @@ from swell.utilities.logger import get_logger
 
 def write_welcome_message() -> None:
 
-    logger = get_logger('')
-
-    logger.blank(f"                  _ _ ", False)  # noqa
-    logger.blank(f" _____      _____| | |  Swell workflow deployment manager", False)  # noqa
-    logger.blank(f"/ __\ \ /\ / / _ \ | |  NASA Global Modeling and Assimilation Office", False)  # noqa
-    logger.blank(f"\__ \\\ V  V /  __/ | |  Version {__version__}", False)  # noqa
-    logger.blank(f"|___/ \_/\_/ \___|_|_|  \x1B[4m\x1B[34mhttps://geos-esm.github.io/swell\033[0m", False)  # noqa
-    logger.blank(f"                                         ", False)  # noqa
-    logger.blank('', False)  # noqa
+    print("                  _ _ ")
+    print(" _____      _____| | |  Swell workflow deployment manager")
+    print("/ __\ \ /\ / / _ \ | |  NASA Global Modeling and Assimilation Office")  # noqa
+    print("\__ \\\ V  V /  __/ | |  Version {__version__}".format(__version__=__version__))  # noqa
+    print("|___/ \_/\_/ \___|_|_|  Source code located at: https://geos-esm.github.io/swell")  # noqa
+    print()
+    print()


### PR DESCRIPTION
## Description

This PR removes the use of `sys.exit` from the `Logger.abort` method, instead opting to raise exceptions. I personally like this better from the standpoint of allowing the user to catch specific exception types. It can potentially allow more dynamic handling of exception messaging. It's also more direct, being able to natively handle tracebacks.

This PR also fixes a bug where the pinned version test would switch Swell to develop, rather than jedi

`Logger.abort` now has an parameter to throw any type of exception. I chose to have it expand the use of the niche `SwellError` exception