### PR TITLE
set `max allowable geometry difference` to high value to avoid fv3jedi geom code crash

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background.yaml
@@ -4,6 +4,7 @@ provider: geos
 datapath: '{{cycle_dir}}'
 filenames: ['bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4',
             'fv3-jedi/bkg/geos.crtmsrf.{{horizontal_resolution}}.nc4']
+max allowable geometry difference:    1.e15
 state variables: &statevars
 - eastward_wind
 - northward_wind

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_ensemble.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/background_ensemble.yaml
@@ -7,6 +7,7 @@ members from template:
     datapath: '.'
     filenames: ['ebkg/mem%mem%/geos.mem%mem%.%yyyy%mm%dd_%hh%MM%ssz.nc4',
                 'fv3-jedi/bkg/geos.crtmsrf.{{horizontal_resolution}}.nc4']
+    max allowable geometry difference:    1.e15
     state variables: &statevars
     - eastward_wind
     - northward_wind

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/pseudo-model.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/model/pseudo-model.yaml
@@ -5,6 +5,7 @@ provider: geos
 datapath: '{{cycle_dir}}'
 filenames: ['bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4',
             'fv3-jedi/bkg/geos.crtmsrf.{{horizontal_resolution}}.nc4']
+max allowable geometry difference:    1.e15
 #field io names: *field_io_names
 field io names:
   eastward_wind: ua


### PR DESCRIPTION
## Description

After FV3 PR:  https://github.com/JCSDA-internal/fv3-jedi/pull/1356, in geos when the resolution of the bkg file (CX1)  is different from that in the swell atmospheric setting (CX2):
models:
  geos_atmosphere:
    horizontal_resolution:  CX2

the fv3jedi geom subroutine will abort the code, because the array fields read into State is a mismatch, which is the right thing to do.   But setting `max allowable geometry difference` to infinity will allow the code to run, despite for example, C360 field (nf, ny=360, nx=360)  was read in C90 field (nf,ny=90,nx=90), at least to my understanding. 

Hence, this PR is a technical bypass, which I think is problematic. 

## Dependencies

- [ ] waiting on GEOS-ESM/repo/pull/<pr_number>
- [ ] waiting on GEOS-ESM/repo/pull/<pr_number>

## Impact

output:
OOPS_STATS ---------------------------------- Parallel Timing Statistics (   6 MPI tasks) -----------------------------------

OOPS_STATS Run end                                  - Runtime:     68.24 sec,  Memory: total:     9.17 Gb, per task: min =     1.49 Gb, max =     1.56 Gb
Run: Finishing oops::Variational<FV3JEDI, UFO and IODA observations> with status = 0
OOPS Ending   2025-09-10 11:58:58 (UTC-0600)
