### PR TITLE
Update to sync with sfcCorrected UFO changes

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfc.yaml
@@ -39,10 +39,10 @@ obs operator:
      - name: virtualTemperature
 
    # Surface pressure is handled using the correction scheme
-   - name: SfcPCorrected
+   - name: SfcCorrected
      variables:
      - name: stationPressure
-     da_psfc_scheme: GSI
+     correction scheme to use: GSL
      geovar_geomz: geopotential_height
      geovar_sfc_geomz: height_above_mean_sea_level_at_surface
      station_altitude: height

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfcship.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sfcship.yaml
@@ -37,10 +37,10 @@ obs operator:
      - name: virtualTemperature
 
    # Surface pressure is handled using the correction scheme
-   - name: SfcPCorrected
+   - name: SfcCorrected
      variables:
      - name: stationPressure
-     da_psfc_scheme: GSI
+     correction scheme to use: GSL
      geovar_geomz: geopotential_height
      geovar_sfc_geomz: height_above_mean_sea_level_at_surface
      station_altitude: height

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sondes.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/sondes.yaml
@@ -37,10 +37,10 @@ obs operator:
     - name: virtualTemperature
     - name: specificHumidity
 
-  - name: SfcPCorrected
+  - name: SfcCorrected
     variables:
     - name: stationPressure
-    da_psfc_scheme: GSI
+    correction scheme to use: GSL
     geovar_geomz: geopotential_height
     geovar_sfc_geomz: height_above_mean_sea_level_at_surface
     station_altitude: height

--- a/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
@@ -8,13 +8,13 @@ existing_geos_gcm_source_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.6.0/
 
 existing_jedi_build_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_09092025/build-intel-release/
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_10022025/build-intel-release/
 
 existing_jedi_build_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/build/
 
 existing_jedi_source_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_09092025
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_10022025
 
 existing_jedi_source_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles/current_pinned_jedi_bundle/source/

--- a/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
@@ -8,13 +8,13 @@ existing_geos_gcm_source_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.6.0/
 
 existing_jedi_build_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_09092025/build-intel-release/
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_10022025/build-intel-release/
 
 existing_jedi_build_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/build/
 
 existing_jedi_source_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_09092025
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_10022025
 
 existing_jedi_source_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/source/


### PR DESCRIPTION
## Description

This syncs develop with UFO's change:

https://github.com/JCSDA-internal/ufo/pull/3779

I find this change not to be zero diff; but the differences are roundoff.

<img width="986" height="486" alt="Untitled" src="https://github.com/user-attachments/assets/cde51105-5888-4c8a-8472-00aa1ee2a160" />


Yes - there are two curves of each in rhe plot above, but you can't see the diff. So I suppose that's acceptable as far as differences go.

## Dependencies

None

## Impact

It should be noted that the changes in UFO associated w/ this are troubled for some configuration of the yamls - ok for SWELL's configuration for now.


