### PR TITLE
compare_variational suite without flow.cylc changes

### DIFF
--- a/docs/examples/soca/comparison_workflows.md
+++ b/docs/examples/soca/comparison_workflows.md
@@ -1,0 +1,14 @@
+# Running comparison experiments within Swell
+
+Swell currently supports comparing variational experiments.
+
+Creating a comparison experiment within swell requires an override yaml with two experiments to be compared (default paths are not set automatically). These filepaths should point to the experiment.yaml for each suite.
+
+```yaml
+comparison_experiment_paths:
+  - /path/to/experiment1/experiment.yaml
+  - /path/to/experiment2/experiment.yaml
+```
+These experiments should have matching assimilation window parameters. By default in this suite, start and end cycle points are not specified, in which case Swell will parse the two experiments to find the matching cycle times between the two. Alternatively, start and end cycle points can be set manually.
+
+The experiment can then be created using `swell create compare_variational_marine -o override.yaml` or `swell create compare_variational_atmosphere -o override`, depending on the type of experiments being compared. Launching the experiment will run tasks analyzing the jedi log and generating plots using Eva for increments. Comparison of the log analysis will be placed under the comparison suite's directory in a file named `jedi_log_comparison.txt`, while the eva plots will be located under the cycle directory for each cycle.

--- a/src/swell/deployment/create_experiment.py
+++ b/src/swell/deployment/create_experiment.py
@@ -24,6 +24,7 @@ from swell.utilities.dictionary import add_comments_to_dictionary, dict_get
 from swell.utilities.jinja2 import template_string_jinja2
 from swell.utilities.logger import Logger, get_logger
 from swell.utilities.slurm import prepare_scheduling_dict
+from swell.utilities.check_da_params import check_da_params
 
 
 # --------------------------------------------------------------------------------------------------
@@ -115,6 +116,24 @@ def prepare_config(
     if 'models' in experiment_dict:
         experiment_dict['model_components'] = list(experiment_dict['models'].keys())
         comment_dict['model_components'] = 'List of models in this experiment'
+
+    # Overrides for comparison suites
+    start_cycle_point = experiment_dict['start_cycle_point']
+    final_cycle_point = experiment_dict['final_cycle_point']
+    if experiment_dict['start_cycle_point'] is None:
+        config_list = experiment_dict['comparison_experiment_paths']
+        for model in experiment_dict['model_components']:
+            cycle_times = experiment_dict['models'][model]['cycle_times']
+            start_cycle_point, final_cycle_point, cycle_times = check_da_params(
+                    config_list,
+                    model,
+                    start_cycle_point,
+                    final_cycle_point,
+                    cycle_times)
+
+            experiment_dict['start_cycle_point'] = start_cycle_point
+            experiment_dict['final_cycle_point'] = final_cycle_point
+            experiment_dict['models'][model]['cycle_times'] = cycle_times
 
     # Expand experiment dict with SLURM overrides.
     # NOTE: This is a bit of a hack. We should really either commit to using a

--- a/src/swell/suites/compare_variational/eva/comparison_increment-geos_atmosphere.yaml
+++ b/src/swell/suites/compare_variational/eva/comparison_increment-geos_atmosphere.yaml
@@ -1,0 +1,1907 @@
+datasets:
+- group: increment
+  type: LatLon
+  filename: {{increment_file_path_1}}
+  name: experiment_increment_1
+  variables: [ps, ua, va, t, q, lat, lon]
+- group: increment
+  type: LatLon
+  filename: {{increment_file_path_2}}
+  name: experiment_increment_2
+  variables: [ps, ua, va, t, q, lat, lon]
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  #map plot for surface pressure increment
+  - batch figure:
+      variables: [ps]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Surface Pressure Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ps
+          label: PS increment 1
+          colorbar: true
+          cmap: 'bwr'
+          vmin: &vmin_ps -100
+          vmax: &vmax_ps 100
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Surface Pressure Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::ps
+          label: PS increment 2
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -100
+          vmax: 100
+
+      # Experiment Diff (1-2)
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Surface Pressure Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ps_diff
+          label: PS increment Diff
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -100
+          vmax: 100
+
+  #map plot for temperature increment (lowest level)
+  - batch figure:
+      variables: [t]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_1000.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t
+            slices: '[71,...]'
+          label: T increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: &vmin_t -1
+          vmax: &vmax_t 1
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::t
+            slices: '[71,...]'
+          label: T increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+      # Experiment Diff (1-2)
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t_diff
+            slices: '[71,...]'
+          label: T increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+  #map plot for temperature increment
+  - batch figure:
+      variables: [t]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_850.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t
+            slices: '[62,...]'
+          label: T increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::t
+            slices: '[62,...]'
+          label: T increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+      # Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t_diff
+            slices: '[62,...]'
+          label: T increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+  #map plot for temperature increment
+  - batch figure:
+      variables: [t]
+    figure:
+      figure size: [20,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_500.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t
+            slices: '[49,...]'
+          label: T increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::t
+            slices: '[49,...]'
+          label: T increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t_diff
+            slices: '[49,...]'
+          label: T increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+  #map plot for temperature increment
+  - batch figure:
+      variables: [t]
+    figure:
+      figure size: [20,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_200.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t
+            slices: '[42,...]'
+          label: T increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::t
+            slices: '[42,...]'
+          label: T increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t_diff
+            slices: '[42,...]'
+          label: T increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+  #map plot for temperature increment
+  - batch figure:
+      variables: [t]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_10.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t
+            slices: '[24,...]'
+          label: T increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::t
+            slices: '[24,...]'
+          label: T increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t_diff
+            slices: '[24,...]'
+          label: T increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+  #map plot for temperature increment
+  - batch figure:
+      variables: [t]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_1.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t
+            slices: '[14,...]'
+          label: T increment (1 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::t
+            slices: '[14,...]'
+          label: T increment (1 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Temperature Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::t_diff
+            slices: '[14,...]'
+          label: T increment (1 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+  #map plot for Zonal Wind increment (lowest level)
+  - batch figure:
+      variables: [ua]
+    figure:
+      figure size: [20,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_1000.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua
+            slices: '[71,...]'
+          label: U increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: &vmin_ua -1
+          vmax: &vmax_ua 1
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::ua
+            slices: '[71,...]'
+          label: U increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment Diff (1-2)
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua_diff
+            slices: '[71,...]'
+          label: U increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+  #map plot for Zonal Wind increment
+  - batch figure:
+      variables: [ua]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_850.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua
+            slices: '[62,...]'
+          label: U increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::ua
+            slices: '[62,...]'
+          label: U increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua_diff
+            slices: '[62,...]'
+          label: U increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+  #map plot for Zonal Wind increment
+  - batch figure:
+      variables: [ua]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_500.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua
+            slices: '[49,...]'
+          label: U increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::ua
+            slices: '[49,...]'
+          label: U increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua_diff
+            slices: '[49,...]'
+          label: U increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+  #map plot for Zonal Wind increment
+  - batch figure:
+      variables: [ua]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_200.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua
+            slices: '[42,...]'
+          label: U increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::ua
+            slices: '[42,...]'
+          label: U increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua_diff
+            slices: '[42,...]'
+          label: U increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+  #map plot for Zonal Wind increment
+  - batch figure:
+      variables: [ua]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_10.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua
+            slices: '[24,...]'
+          label: U increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::ua
+            slices: '[24,...]'
+          label: U increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment Diff
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua_diff
+            slices: '[24,...]'
+          label: U increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+  #map plot for Zonal Wind increment
+  - batch figure:
+      variables: [ua]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_1.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua
+            slices: '[14,...]'
+          label: U increment (1 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::ua
+            slices: '[14,...]'
+          label: U increment (1 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+      # Experiment Diff (1-2)
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Zonal Wind Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::ua_diff
+            slices: '[14,...]'
+          label: U increment (1 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ua
+          vmax: 1
+
+  #map plot for Meridional Wind increment (lowest level)
+  - batch figure:
+      variables: [va]
+    figure:
+      figure size: [20,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_1000.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va
+            slices: '[71,...]'
+          label: V increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: &vmin_va -1
+          vmax: &vmax_va 1
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::va
+            slices: '[71,...]'
+          label: V increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_va
+          vmax: *vmax_va
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va_diff
+            slices: '[71,...]'
+          label: V increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_va
+          vmax: *vmax_va
+
+  #map plot for Meridional Wind increment
+  - batch figure:
+      variables: [va]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_850.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va
+            slices: '[62,...]'
+          label: V increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_va
+          vmax: *vmax_va
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::va
+            slices: '[62,...]'
+          label: V increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_va
+          vmax: *vmax_va
+
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va_diff
+            slices: '[62,...]'
+          label: V increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_va
+          vmax: *vmax_va
+
+  #map plot for Meridional Wind increment
+  - batch figure:
+      variables: [va]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_500.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va
+            slices: '[49,...]'
+          label: V increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_va
+          vmax: *vmax_va
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::va
+            slices: '[49,...]'
+          label: V increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_va
+          vmax: *vmax_va
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va_diff
+            slices: '[49,...]'
+          label: V increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_va
+          vmax: *vmax_va
+
+  #map plot for Meridional Wind increment
+  - batch figure:
+      variables: [va]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_200.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va
+            slices: '[42,...]'
+          label: V increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_va
+          vmax: *vmax_va
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::va
+            slices: '[42,...]'
+          label: V increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_va
+          vmax: *vmax_va
+
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va_diff
+            slices: '[42,...]'
+          label: V increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_va
+          vmax: *vmax_va
+
+  #map plot for Meridional Wind increment
+  - batch figure:
+      variables: [va]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_10.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va
+            slices: '[24,...]'
+          label: V increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::va
+            slices: '[24,...]'
+          label: V increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va_diff
+            slices: '[24,...]'
+          label: V increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+  #map plot for Meridional Wind increment
+  - batch figure:
+      variables: [va]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_1.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va
+            slices: '[14,...]'
+          label: V increment (1 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::va
+            slices: '[14,...]'
+          label: V increment (1 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Meridional Wind Increment Diff
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::va_diff
+            slices: '[14,...]'
+          label: V increment (1 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+
+  #map plot for Specific Humidity increment (lowest level)
+  - batch figure:
+      variables: [q]
+    figure:
+      figure size: [20,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_1000.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::q
+            slices: '[71,...]'
+          label: Q increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::q
+            slices: '[71,...]'
+          label: Q increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::q_diff
+            slices: '[71,...]'
+          label: Q increment (1000 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+  #map plot for Specific Humidity increment
+  - batch figure:
+      variables: [q]
+    figure:
+      figure size: [20,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_850.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::q
+            slices: '[62,...]'
+          label: Q increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::q
+            slices: '[62,...]'
+          label: Q increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::q_diff
+            slices: '[62,...]'
+          label: Q increment (850 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+  #map plot for Specific Humidity increment
+  - batch figure:
+      variables: [q]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_500.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::q
+            slices: '[49,...]'
+          label: Q increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::q
+            slices: '[49,...]'
+          label: Q increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+      # Experiment Diff (1-2)
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::q_diff
+            slices: '[49,...]'
+          label: Q increment (500 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+  #map plot for Specific Humidity increment
+  - batch figure:
+      variables: [q]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_200.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::q
+            slices: '[42,...]'
+          label: Q increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::q
+            slices: '[42,...]'
+          label: Q increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::q_diff
+            slices: '[42,...]'
+          label: Q increment (200 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+  #map plot for Specific Humidity increment
+  - batch figure:
+      variables: [q]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_10.png'
+    plots:
+      # Experiment 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::q
+            slices: '[24,...]'
+          label: Q increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+      # Experiment 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::q
+            slices: '[24,...]'
+          label: Q increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+      # Experiment Diff
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Specific Humidity Increment Diff (1-2)
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::q_diff
+            slices: '[24,...]'
+          label: Q increment (10 hPa)
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.001
+          vmax: 0.001
+
+transforms:
+- equals: experiment_increment_1::increment::ps-experiment_increment_2::increment::ps
+  for:
+    variable: ps
+  new name: experiment_increment_1::increment::ps_diff
+  transform: arithmetic
+
+- equals: experiment_increment_1::increment::t-experiment_increment_2::increment::t
+  for:
+    variable: t
+  new name: experiment_increment_1::increment::t_diff
+  transform: arithmetic
+
+- equals: experiment_increment_1::increment::ua-experiment_increment_2::increment::ua
+  for:
+    variable: ua
+  new name: experiment_increment_1::increment::ua_diff
+  transform: arithmetic
+
+- equals: experiment_increment_1::increment::va-experiment_increment_2::increment::va
+  for:
+    variable: va
+  new name: experiment_increment_1::increment::va_diff
+  transform: arithmetic
+
+- equals: experiment_increment_1::increment::q-experiment_increment_2::increment::q
+  for:
+    variable: q
+  new name: experiment_increment_1::increment::q_diff
+  transform: arithmetic

--- a/src/swell/suites/compare_variational/eva/comparison_increment-geos_marine.yaml
+++ b/src/swell/suites/compare_variational/eva/comparison_increment-geos_marine.yaml
@@ -1,0 +1,267 @@
+datasets:
+
+  - name: experiment_increment_1
+    type: SocaRestart
+    soca_filenames: {{increment_file_path_1}}
+    geometry_file: {{cycle_dir_1}}/INPUT/soca_gridspec.nc
+
+    variables: [Temp, Salt, ave_ssh]
+    coordinate variables: [lon, lat]
+
+  - name: experiment_increment_2
+    type: SocaRestart
+    soca_filenames: {{increment_file_path_2}}
+    geometry_file: {{cycle_dir_2}}/INPUT/soca_gridspec.nc
+
+    variables: [Temp, Salt, ave_ssh]
+    coordinate variables: [lon, lat]
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  - batch figure:
+      variables: [ave_ssh]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'SOCA Increment'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}.png'
+    
+    # ave_ssh plot 1
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SSH Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment_1::SOCAgrid::lat
+          data:
+            variable: experiment_increment_1::SOCAVars::ave_ssh
+          label: ave_ssh increment 1
+          colorbar: true
+          cmap: 'bwr'
+          vmin: &vmin_ave_ssh -0.25
+          vmax: &vmax_ave_ssh 0.25
+      
+      # ave_ssh plot 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SSH Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment_2::SOCAgrid::lat
+          data:
+            variable: experiment_increment_2::SOCAVars::ave_ssh
+          label: ave_ssh increment 2
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_ave_ssh
+          vmax: *vmax_ave_ssh
+
+      # ave_ssh diff plot
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SSH Increment (1-2) Diff
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment_1::SOCAgrid::lat
+          data:
+            variable: experiment_increment_1::SOCAVars::ave_ssh_diff
+          label: ave_ssh increment
+          colorbar: true
+          cmap: 'bwr'
+
+  - batch figure:
+      variables: [Temp]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Soca Increment'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}.png'
+    plots:
+      # Temp plot 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SST Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment_1::SOCAgrid::lat
+          data:
+            variable: experiment_increment_1::SOCAVars::Temp
+            slices: '[0,...]'
+          label: SST increment 1
+          colorbar: true
+          cmap: 'bwr'
+          vmin: &vmin_temp -3
+          vmax: &vmax_temp 3
+
+      # Temp plot 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SST Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment_2::SOCAgrid::lat
+          data:
+            variable: experiment_increment_2::SOCAVars::Temp
+            slices: '[0,...]'
+          label: SST increment 2
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_temp
+          vmax: *vmax_temp
+      
+      # Temp diff plot
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SST Increment (1-2) Diff
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment_1::SOCAgrid::lat
+          data:
+            variable: experiment_increment_1::SOCAVars::Temp_diff
+            slices: '[0,...]'
+          label: SST increment (1-2) Diff
+          colorbar: true
+          cmap: 'bwr'
+
+  - batch figure:
+      variables: [Salt]
+    figure:
+      figure size: [60,10]
+      layout: [3,1]
+      title: 'Soca Increment'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}.png'
+    plots:
+      # Salt plot 1
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SSS Increment 1
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment_1::SOCAgrid::lat
+          data:
+            variable: experiment_increment_1::SOCAVars::Salt
+            slices: '[0,...]'
+          label: SSS increment 1
+          colorbar: true
+          cmap: 'bwr'
+          vmin: &vmin_salt -1
+          vmax: &vmax_salt 1
+
+      # Salt plot 2
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SSS Increment 2
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment_2::SOCAgrid::lat
+          data:
+            variable: experiment_increment_2::SOCAVars::Salt
+            slices: '[0,...]'
+          label: SSS increment 2
+          colorbar: true
+          cmap: 'bwr'
+          vmin: *vmin_salt
+          vmax: *vmax_salt
+
+      # Salt Diff plot
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SSS Increment (1-2) Diff
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::SOCAgrid::lon
+          latitude:
+            variable: experiment_increment_1::SOCAgrid::lat
+          data:
+            variable: experiment_increment_1::SOCAVars::Salt_diff
+            slices: '[0,...]'
+          label: SSS increment (1-2) Diff
+          colorbar: true
+          cmap: 'bwr'
+
+# ssh diff
+transforms:
+- equals: experiment_increment_1::SOCAVars::ave_ssh-experiment_increment_2::SOCAVars::ave_ssh
+  for:
+    variable: ave_ssh
+  new name: experiment_increment_1::SOCAVars::ave_ssh_diff
+  transform: arithmetic
+
+# Temp diff
+- equals: experiment_increment_1::SOCAVars::Temp-experiment_increment_2::SOCAVars::Temp
+  for:
+    variable: Temp
+  new name: experiment_increment_1::SOCAVars::Temp_diff
+  transform: arithmetic
+
+# Salt diff
+- equals: experiment_increment_1::SOCAVars::Salt-experiment_increment_2::SOCAVars::Salt
+  for:
+    variable: Salt
+  new name: experiment_increment_1::SOCAVars::Salt_diff
+  transform: arithmetic

--- a/src/swell/suites/compare_variational/eva/comparison_jedi_log-geos_atmosphere.yaml
+++ b/src/swell/suites/compare_variational/eva/comparison_jedi_log-geos_atmosphere.yaml
@@ -1,0 +1,108 @@
+datasets:
+
+- type: JediLog
+  collection_name: JediLogTest_1
+  jedi_log_to_parse: '{{cycle_dir_1}}/jedi_variational_log.log'
+  data_to_parse:
+    convergence: true
+
+- type: JediLog
+  collection_name: JediLogTest_2
+  jedi_log_to_parse: '{{cycle_dir_2}}/jedi_variational_log.log'
+  data_to_parse:
+    convergence: true
+
+transforms:
+- transform: arithmetic
+  new name: JediLogTest_1::convergence::${variable}_log
+  equals: log(JediLogTest_1::convergence::${variable})
+  for:
+    variable: [residual_norm, norm_reduction]
+
+- transform: arithmetic
+  new name: JediLogTest_2::convergence::${variable}_log
+  equals: log(JediLogTest_2::convergence::${variable})
+  for:
+    variable: [residual_norm, norm_reduction]
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  - figure:
+      layout: [3,1]
+      figure size: [12,10]
+      title: 'Residual Norm and Norm Reduction Plots'
+      output name: '{{cycle_dir}}/eva/jedi_log/convergence/residual_norm_reduction.png'
+    plots:
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Residual norm'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: JediLogTest_1::convergence::total_iteration
+          y:
+            variable: JediLogTest_1::convergence::residual_norm
+          color: 'red'
+          label: 'Experiment 1'
+        - type: LinePlot
+          x:
+            variable: JediLogTest_2::convergence::total_iteration
+          y:
+            variable: JediLogTest_2::convergence::residual_norm
+          color: 'blue'
+          label: 'Experiment 2'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Log(norm reduction)'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: JediLogTest_1::convergence::total_iteration
+          y:
+            variable: JediLogTest_1::convergence::norm_reduction
+          color: 'red'
+          label: 'Experiment 1'
+        - type: LinePlot
+          x:
+            variable: JediLogTest_2::convergence::total_iteration
+          y:
+            variable: JediLogTest_2::convergence::norm_reduction
+          color: 'blue'
+          label: 'Experiment 2'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Log(reduction)'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: JediLogTest_1::convergence::total_iteration
+          y:
+            variable: JediLogTest_1::convergence::residual_norm_log
+          color: 'red'
+          label: 'Log(residual norm) 1'
+        - type: LinePlot
+          x:
+            variable: JediLogTest_2::convergence::total_iteration
+          y:
+            variable: JediLogTest_2::convergence::residual_norm_log
+          color: 'blue'
+          label: 'Log(residual norm) 2'
+        - type: LinePlot
+          x:
+            variable: JediLogTest_1::convergence::total_iteration
+          y:
+            variable: JediLogTest_1::convergence::norm_reduction_log
+          color: 'yellow'
+          label: 'Log norm reduction 1'
+        - type: LinePlot
+          x:
+            variable: JediLogTest_2::convergence::total_iteration
+          y:
+            variable: JediLogTest_2::convergence::norm_reduction_log
+          color: 'green'
+          label: 'Log norm reduction 2'

--- a/src/swell/suites/compare_variational/eva/comparison_jedi_log-geos_marine.yaml
+++ b/src/swell/suites/compare_variational/eva/comparison_jedi_log-geos_marine.yaml
@@ -1,0 +1,95 @@
+datasets:
+
+- type: JediLog
+  collection_name: jedi_log_test_1
+  jedi_log_to_parse: '{{cycle_dir_1}}/jedi_variational_log.log'
+  data_to_parse:
+    convergence: true
+
+- type: JediLog
+  collection_name: jedi_log_test_2
+  jedi_log_to_parse: '{{cycle_dir_2}}/jedi_variational_log.log'
+  data_to_parse:
+    convergence: true
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  - figure:
+      layout: [3,1]
+      figure size: [12,10]
+      title: 'Residual Norm and Norm Reduction Plots'
+      output name: '{{cycle_dir}}/eva/jedi_log/convergence/residual_norm_reduction.png'
+    plots:
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Residual norm'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test_1::convergence::total_iteration
+          y:
+            variable: jedi_log_test_1::convergence::residual_norm
+          color: 'red'
+          label: 'Experiment 1'
+        - type: LinePlot
+          x:
+            variable: jedi_log_test_2::convergence::total_iteration
+          y:
+            variable: jedi_log_test_2::convergence::residual_norm
+          color: 'blue'
+          label: 'Experiment 2'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Norm reduction'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test_1::convergence::total_iteration
+          y:
+            variable: jedi_log_test_1::convergence::norm_reduction
+          color: 'red'
+          label: 'Experiment 1'
+        - type: LinePlot
+          x:
+            variable: jedi_log_test_2::convergence::total_iteration
+          y:
+            variable: jedi_log_test_2::convergence::norm_reduction
+          color: 'blue'
+          label: 'Experiment 2'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Normalized Value'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test_1::convergence::total_iteration
+          y:
+            variable: jedi_log_test_1::convergence::residual_norm_normalized
+          color: 'red'
+          label: 'Normalized residual norm 1'
+        - type: LinePlot
+          x:
+            variable: jedi_log_test_2::convergence::total_iteration
+          y:
+            variable: jedi_log_test_2::convergence::residual_norm_normalized
+          color: 'blue'
+          label: 'Normalized residual norm 2'
+        - type: LinePlot
+          x:
+            variable: jedi_log_test_1::convergence::total_iteration
+          y:
+            variable: jedi_log_test_1::convergence::norm_reduction_normalized
+          color: 'yellow'
+          label: 'Normalized norm reduction 1'
+        - type: LinePlot
+          x:
+            variable: jedi_log_test_2::convergence::total_iteration
+          y:
+            variable: jedi_log_test_2::convergence::norm_reduction_normalized
+          color: 'green'
+          label: 'Normalized norm reduction 2'

--- a/src/swell/suites/compare_variational/flow.cylc
+++ b/src/swell/suites/compare_variational/flow.cylc
@@ -1,0 +1,75 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+# Cylc suite for running comparison tests on completed experiments
+
+
+
+# --------------------------------------------------------------------------------------------------
+
+[scheduler]
+    UTC mode = True
+    allow implicit tasks = False
+
+# --------------------------------------------------------------------------------------------------
+
+[scheduling]
+
+    initial cycle point = {{start_cycle_point}}
+    final cycle point = {{final_cycle_point}}
+    runahead limit = {{runahead_limit}}
+
+    [[graph]]
+        {% for cycle_time in cycle_times %}
+        {{cycle_time.cycle_time}} = """
+        {% for model_component in model_components %}
+        {% if cycle_time[model_component] %}
+            EvaComparisonIncrement-{{model_component}}
+            EvaComparisonJediLog-{{model_component}}
+            {% for path in comparison_experiment_paths %}
+            JediOopsLogParser-{{model_component}}-{{ loop.index0 }} => JediLogComparison-{{model_component}}
+            {% endfor %}
+        {% endif %}
+        {% endfor %}
+        """
+        {% endfor %}
+
+# --------------------------------------------------------------------------------------------------
+
+[runtime]
+
+    # Task defaults
+    # -------------
+
+    [[root]]
+        pre-script = """
+            source $CYLC_SUITE_DEF_PATH/modules
+        """
+
+        [[[environment]]]
+            datetime = $CYLC_TASK_CYCLE_POINT
+            config = $CYLC_SUITE_DEF_PATH/experiment.yaml
+
+    {% for model_component in model_components %}
+    [[EvaComparisonIncrement-{{model_component}}]]
+        script = "swell task EvaComparisonIncrement $config -d $datetime -m {{model_component}}"
+
+    [[EvaComparisonJediLog-{{model_component}}]]
+        script = "swell task EvaComparisonJediLog $config -d $datetime -m {{model_component}}"
+
+    {% for path in comparison_experiment_paths %}
+    [[JediOopsLogParser-{{model_component}}-{{ loop.index0 }}]]
+        script = "swell task JediOopsLogParser {{path}} -d $datetime -m {{model_component}}"
+    {% endfor %}
+
+    [[JediLogComparison-{{model_component}}]]
+        script = "swell task JediLogComparison $config -m {{model_component}}"
+    {% endfor %}
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/compare_variational/suite_config.py
+++ b/src/swell/suites/compare_variational/suite_config.py
@@ -1,0 +1,69 @@
+# --------------------------------------------------------------------------------------------------
+#  @package configuration
+#
+#  Class containing the configuration. This is a dictionary that is converted from
+#  an input yaml configuration file. Various function are included for interacting with the
+#  dictionary.
+#
+# --------------------------------------------------------------------------------------------------
+
+from swell.utilities.swell_questions import QuestionContainer, QuestionList, WidgetType
+from swell.utilities.question_defaults import QuestionDefaults as qd
+from swell.suites.suite_questions import SuiteQuestions as sq
+
+from enum import Enum
+
+# --------------------------------------------------------------------------------------------------
+
+
+class SuiteConfig(QuestionContainer, Enum):
+
+    # --------------------------------------------------------------------------------------------------
+
+    compare_variational = QuestionList(
+        list_name="compare",
+        questions=[
+            sq.all_suites,
+            qd.comparison_experiment_paths(),
+            qd.start_cycle_point(default_value=None, widget_type=WidgetType.STRING),
+            qd.final_cycle_point(default_value=None, widget_type=WidgetType.STRING),
+            qd.cycle_times(default_value=[None], widget_type=WidgetType.STRING_CHECK_LIST),
+            qd.model_components(),
+            qd.runahead_limit(),
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------
+
+    compare_variational_marine = QuestionList(
+        list_name="compare_variational_marine",
+        questions=[
+            compare_variational,
+            qd.comparison_log_type('variational'),
+            qd.model_components(['geos_marine']),
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------
+
+    compare_variational_atmosphere = QuestionList(
+        list_name="compare_variational_atmosphere",
+        questions=[
+            compare_variational,
+            qd.comparison_log_type('variational'),
+            qd.model_components(['geos_atmosphere']),
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------
+
+    compare_fgat_marine = QuestionList(
+        list_name="compare_fgat_marine",
+        questions=[
+            compare_variational,
+            qd.comparison_log_type('fgat'),
+            qd.model_components(['geos_marine']),
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/eva_comparison_increment.py
+++ b/src/swell/tasks/eva_comparison_increment.py
@@ -1,0 +1,137 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+import os
+import yaml
+import glob
+
+from eva.eva_driver import eva
+
+from swell.tasks.base.task_base import taskBase
+from swell.utilities.jinja2 import template_string_jinja2
+from swell.utilities.data_assimilation_window_params import DataAssimilationWindowParams
+
+# --------------------------------------------------------------------------------------------------
+
+
+class EvaComparisonIncrement(taskBase):
+
+    def window_info_from_config(self, path: str):
+
+        config_file = os.path.join(os.path.dirname(path), 'experiment.yaml')
+
+        with open(config_file, 'r') as f:
+            config_dict = yaml.safe_load(f)
+
+        window_type = config_dict['models'][self.get_model()]['window_type']
+        window_offset = config_dict['models'][self.get_model()]['window_offset']
+
+        return window_type, window_offset
+
+    def execute(self) -> None:
+
+        model = self.get_model()
+
+        # Open the eva configuration file
+        eva_path = os.path.join(self.experiment_path(), self.experiment_id()+'-suite', 'eva')
+        eva_config_file = os.path.join(eva_path, f'comparison_increment-{model}.yaml')
+        with open(eva_config_file, 'r') as eva_config_file_open:
+            eva_str_template = eva_config_file_open.read()
+
+        # Get the paths for the two experiments
+        experiment_paths = self.config.comparison_experiment_paths()
+
+        experiment_path_1 = experiment_paths[0]
+        experiment_path_2 = experiment_paths[1]
+
+        window_type, window_offset = self.window_info_from_config(experiment_path_1)
+
+        # Create the cycle dir for this experiment
+        cycle_dir = self.cycle_dir()
+
+        cycle_time_dto = self.cycle_time_dto()
+
+        da_window_params = DataAssimilationWindowParams(self.logger, cycle_time_dto.strftime(
+            '%Y-%m-%dT%H:%M:%SZ'))
+
+        window_begin_dto = da_window_params.window_begin(window_offset, dto=True)
+        window_begin = window_begin_dto.strftime('%Y%m%d_%H%M%Sz')
+
+        # Info to task log
+        info_string = 'Running Eva to plot from the increment file'
+        self.logger.info('')
+        self.logger.info(info_string)
+        self.logger.info('-'*len(info_string))
+
+        # Create time strings for eva_override directory
+        cycle_time_reformat = cycle_time_dto.strftime('%Y%m%d_%H%M%Sz')
+
+        # Define the increment filename and path
+        # For 3D-Var and 3D-FGAT, the increment file is in the middle of the DA window
+        # For 3D-FGAT atmos, the increment is at the beginning of the DA window. This
+        # is just a limited implementation of 4DVAR in SWELL by turning the linear operator off,
+        # where the cost-type is 4D-VAR in OOPS folder.
+        # TODO: This really complicates the increment file naming and path for now, this
+        # is a temporary solution (I'm refering to window type and atmos if statement)
+        # TODO: Increment iteration number may change according to outer iteration loops
+        # which is currenly manually set in varincrement1.yaml
+        # For now we are only plotting the first one
+        iter_no = 1
+        incr_file_1 = f'*.increment-iter{iter_no}.{cycle_time_reformat}.nc4'
+        incr_file_2 = f'*.increment-iter{iter_no}.{cycle_time_reformat}.nc4'
+
+        if window_type == '4D' and 'atmos' in self.suite_name():
+            incr_file_1 = f'*.increment-iter{iter_no}.{window_begin}.nc4'
+            incr_file_2 = f'*.increment-iter{iter_no}.{window_begin}.nc4'
+
+        # Create dictionary used to override the eva config
+        eva_override = {}
+
+        # Soca case
+        if model == 'geos_marine':
+            ocn_cycle_time = cycle_time_dto.strftime('%Y-%m-%dT%H:%M:%SZ')
+            incr_file_1 = f'ocn.*.incr.{ocn_cycle_time}.nc'
+            incr_file_2 = f'ocn.*.incr.{ocn_cycle_time}.nc'
+
+        cycle_dir_1 = os.path.join(os.path.dirname(experiment_path_1), '..', 'run',
+                                   self.__datetime__.string_directory(), self.get_model())
+        cycle_dir_2 = os.path.join(os.path.dirname(experiment_path_2), '..', 'run',
+                                   self.__datetime__.string_directory(), self.get_model())
+
+        # Files to fill the template in the config file
+        increment_file_path_1 = glob.glob(os.path.join(cycle_dir_1, incr_file_1))[0]
+        increment_file_path_2 = glob.glob(os.path.join(cycle_dir_2, incr_file_2))[0]
+
+        eva_override['cycle_dir'] = cycle_dir
+        eva_override['window_begin'] = window_begin
+
+        eva_override['cycle_dir_1'] = cycle_dir_1
+        eva_override['cycle_dir_2'] = cycle_dir_2
+
+        eva_override['cycle_time'] = cycle_time_reformat
+        eva_override['increment_file_path_1'] = increment_file_path_1
+        eva_override['increment_file_path_2'] = increment_file_path_2
+
+        # Override the eva dictionary
+        eva_str = template_string_jinja2(self.logger, eva_str_template, eva_override)
+        eva_dict = yaml.safe_load(eva_str)
+
+        # Write eva dictionary to file
+        # ----------------------------
+        conf_output = os.path.join(cycle_dir, 'eva', 'increment',
+                                   'comparison_increment_eva.yaml')
+
+        os.makedirs(os.path.dirname(conf_output), exist_ok=True)
+        with open(conf_output, 'w') as outfile:
+            yaml.dump(eva_dict, outfile, default_flow_style=False)
+
+        # Call eva
+        # --------
+        eva(eva_dict)

--- a/src/swell/tasks/eva_comparison_jedi_log.py
+++ b/src/swell/tasks/eva_comparison_jedi_log.py
@@ -1,0 +1,75 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+import os
+import yaml
+
+from eva.eva_driver import eva
+
+from swell.tasks.base.task_base import taskBase
+from swell.utilities.jinja2 import template_string_jinja2
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+class EvaComparisonJediLog(taskBase):
+
+    def execute(self) -> None:
+
+        # Get the model
+        # -------------
+        model = self.get_model()
+
+        # Read Eva template file into dictionary
+        # --------------------------------------
+        eva_path = os.path.join(self.experiment_path(), self.experiment_id()+'-suite', 'eva')
+        eva_config_file = os.path.join(eva_path, f'comparison_jedi_log-{model}.yaml')
+        with open(eva_config_file, 'r') as eva_config_file_open:
+            eva_str_template = eva_config_file_open.read()
+
+        # Get the paths for the two experiments
+        experiment_paths = self.config.comparison_experiment_paths()
+
+        experiment_path_1 = experiment_paths[0]
+        experiment_path_2 = experiment_paths[1]
+
+        cycle_dir_1 = os.path.join(os.path.dirname(experiment_path_1), '..', 'run',
+                                   self.__datetime__.string_directory(), self.get_model())
+        cycle_dir_2 = os.path.join(os.path.dirname(experiment_path_2), '..', 'run',
+                                   self.__datetime__.string_directory(), self.get_model())
+
+        # Info to task log
+        info_string = 'Running Eva to plot from the jedi_log file'
+        self.logger.info('')
+        self.logger.info(info_string)
+        self.logger.info('-'*len(info_string))
+
+        # Create dictionary used to override the eva config
+        eva_override = {}
+        eva_override['cycle_dir'] = self.cycle_dir()
+        eva_override['cycle_dir_1'] = cycle_dir_1
+        eva_override['cycle_dir_2'] = cycle_dir_2
+
+        # Override the eva dictionary
+        eva_str = template_string_jinja2(self.logger, eva_str_template, eva_override)
+        eva_dict = yaml.safe_load(eva_str)
+
+        # Write eva dictionary to file
+        # ----------------------------
+        conf_output = os.path.join(self.cycle_dir(), 'eva', 'jedi_log',
+                                   'comparison_jedi_log_eva.yaml')
+        os.makedirs(os.path.dirname(conf_output), exist_ok=True)
+        with open(conf_output, 'w') as outfile:
+            yaml.dump(eva_dict, outfile, default_flow_style=False)
+
+        # Call eva
+        # --------
+        eva(eva_dict)

--- a/src/swell/tasks/jedi_log_comparison.py
+++ b/src/swell/tasks/jedi_log_comparison.py
@@ -1,0 +1,153 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+import os
+import re
+import numpy as np
+
+from swell.tasks.base.task_base import taskBase
+
+# --------------------------------------------------------------------------------------------------
+
+comparison_fields = {'Residual norm': {'delimiter': '=', 'dtype': float}}
+
+# --------------------------------------------------------------------------------------------------
+
+
+class JediLogComparison(taskBase):
+
+    def execute(self):
+
+        tolerances = {}
+        for number in range(int(self.config.number_of_iterations()[0])):
+            tolerances[f'Residual norm ( {number})'] = 0.01
+
+        # Construct dictionary for all results from log file
+        all_results = {}
+
+        # Boolean for whether fields fall within tolerances
+        passed = True
+
+        experiment_paths = self.config.comparison_experiment_paths()
+        log_type = self.config.comparison_log_type()
+
+        for exp_num, experiment_path in enumerate(experiment_paths):
+
+            # Paths to cycle dirs
+            cycles_path = os.path.join(os.path.dirname(experiment_path), '..', 'run')
+
+            experiment_cycles = [dirname for dirname in os.listdir(cycles_path)
+                                 if re.match('[0-9]*T[0-9]*Z', dirname)]
+
+            for cycle in experiment_cycles:
+                if cycle not in all_results.keys():
+                    cycle_results = all_results[cycle] = {}
+
+                cycle_log_file = os.path.join(cycles_path, cycle, self.get_model(),
+                                              f'jedi_{log_type}_log.log')
+                with open(cycle_log_file, 'r') as f:
+                    lines = f.readlines()
+
+                for line in lines:
+                    for field_name in comparison_fields.keys():
+                        field = comparison_fields[field_name]
+                        if field_name in line:
+                            key_val = line.split(field['delimiter'])
+                            key = key_val[0].strip()
+                            val = key_val[1].strip()
+
+                            # val = field['dtype'](val)
+
+                            if key not in cycle_results.keys():
+                                cycle_results[key] = {f'exp{exp_num}': val}
+                            else:
+                                cycle_results[key][f'exp{exp_num}'] = val
+
+                for key in cycle_results.keys():
+                    for field_name in comparison_fields.keys():
+                        if field_name in key:
+                            dtype = comparison_fields[field_name]['dtype']
+
+                            if dtype == float:
+                                if 'exp0' in cycle_results[key] and 'exp1' in cycle_results[key]:
+                                    diff = float(cycle_results[key]['exp0']) - \
+                                            float(cycle_results[key]['exp1'])
+                                    cycle_results[key]['diff'] = str(diff)
+                                    if key in tolerances:
+                                        key_passed = np.abs(diff) < tolerances[key]
+                                        cycle_results[key]['pass'] = key_passed
+                                    else:
+                                        key_passed = True
+                                        cycle_results[key]['pass'] = ''
+
+                                    if not key_passed:
+                                        passed = False
+                            else:
+                                cycle_results[key]['diff'] = 'N/A'
+                                cycle_results[key]['pass'] = ''
+
+        widths = {'key': len(cycle), 'exp0': 0, 'exp1': 0, 'diff': 0, 'pass': 0}
+
+        for cycle, cycle_results in all_results.items():
+            for key in cycle_results:
+                if 'exp0' not in cycle_results[key]:
+                    cycle_results[key]['exp0'] = 'N/A'
+                if 'exp1' not in cycle_results[key]:
+                    cycle_results[key]['exp1'] = 'N/A'
+                if 'diff' not in cycle_results[key]:
+                    cycle_results[key]['diff'] = 'N/A'
+                if 'pass' not in cycle_results[key]:
+                    cycle_results[key]['pass'] = False
+                    passed = False
+
+                widths['key'] = max(widths['key'], len(key))
+                widths['exp0'] = max(widths['exp0'], len(cycle_results[key]['exp0']))
+                widths['exp1'] = max(widths['exp1'], len(cycle_results[key]['exp1']))
+                widths['diff'] = max(widths['diff'], len(str(cycle_results[key]['diff'])))
+
+        for key, val in widths.items():
+            widths[key] = val + 2
+
+        out_string = '\n'
+        out_string += f'exp0: {experiment_paths[0]}\n'
+        out_string += f'exp1: {experiment_paths[1]}\n'
+        out_string += '\n'
+
+        for cycle, cycle_results in all_results.items():
+            out_string += cycle + ' ' * (widths['key'] - len(cycle))
+            out_string += 'exp0' + ' ' * (widths['exp0'] - len('exp0'))
+            out_string += 'exp1' + ' ' * (widths['exp1'] - len('exp1'))
+            out_string += 'diff' + ' ' * (widths['diff'] - len('diff'))
+            out_string += 'pass' + ' ' * (widths['pass'] - len('pass'))
+
+            out_string += '\n'
+
+            for key in tolerances.keys():
+                val_dict = cycle_results[key]
+
+                out_string += key + ' ' * (widths['key'] - len(key))
+                out_string += val_dict['exp0'] + ' ' * (widths['exp0'] - len(val_dict['exp0']))
+                out_string += val_dict['exp1'] + ' ' * (widths['exp1'] - len(val_dict['exp1']))
+                out_string += val_dict['diff'] + ' ' * (widths['diff'] - len(val_dict['diff']))
+                out_string += str(val_dict['pass']) + ' ' * (
+                        widths['pass'] - len(str(val_dict['pass'])))
+                out_string += '\n'
+
+            out_string += '\n'
+
+        self.logger.info(out_string)
+
+        with open(os.path.join(self.experiment_path(), 'jedi_log_comparison.txt'), 'w') as f:
+            f.write(out_string)
+
+        if not passed:
+            self.logger.abort(f'Parameters not within tolerance')
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/jedi_oops_log_parser.py
+++ b/src/swell/tasks/jedi_oops_log_parser.py
@@ -1,0 +1,54 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+import os
+import subprocess
+
+from swell.tasks.base.task_base import taskBase
+
+# --------------------------------------------------------------------------------------------------
+
+
+class JediOopsLogParser(taskBase):
+
+    def fgrep_residual_norm(self, output_file):
+
+        cycle_dir = self.cycle_dir()
+
+        cycle_time = self.__datetime__.string_directory()
+        model = self.get_model()
+
+        # Build the command
+        command = ['fgrep', '"Residual norm"'] + [
+                os.path.join(cycle_dir, 'jedi_variational_log.log')]
+        command = ' '.join(command)
+
+        # Run the fgrep command
+        output = subprocess.run(command, capture_output=True, text=True, shell=True, check=True)
+        results = output.stdout
+
+        # Write the output file
+        with open(output_file, 'w') as f:
+            f.write(f'Residual norms output for experiment: {self.experiment_path()}:\n')
+            f.write(f'Model: {model}\n')
+            f.write(f'Cycle: {cycle_time}\n\n')
+            f.write(f'RESULTS:\n')
+            f.write(results)
+
+    def execute(self) -> None:
+
+        output_file = os.path.join(self.cycle_dir(), 'jedi_log_analysis.txt')
+
+        for parser_option in self.config.parser_options(['fgrep_residual_norm']):
+            if parser_option == 'fgrep_residual_norm':
+                self.fgrep_residual_norm(output_file)
+
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -422,6 +422,16 @@ class TaskQuestions(QuestionContainer, Enum):
 
     # --------------------------------------------------------------------------------------------------
 
+    JediLogComparison = QuestionList(
+        list_name="JediComparisonLog",
+        questions=[
+            qd.comparison_log_type(),
+            qd.number_of_iterations()
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------
+
     LinkGeosOutput = QuestionList(
         list_name="LinkGeosOutput",
         questions=[

--- a/src/swell/utilities/check_da_params.py
+++ b/src/swell/utilities/check_da_params.py
@@ -1,0 +1,126 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# --------------------------------------------------------------------------------------------------
+
+import yaml
+import os
+from typing import Optional
+from datetime import datetime
+
+from swell.utilities.logger import get_logger
+from swell.utilities.datetime_util import datetime_formats
+
+# --------------------------------------------------------------------------------------------------
+
+
+def check_da_params(config_list: list,
+                    model_component: str,
+                    start_cycle_point_in: Optional[str],
+                    final_cycle_point_in: Optional[str],
+                    cycle_times_in: Optional[str]) -> None:
+
+    # From two or more experiments, check that the window parameters are the same, and gather the
+    # common cycle times between the two. Returns times between the start and final cycle points,
+    # or pick automatically if set to None.
+
+    # Dictionary containing window and cycles for all experiments
+    cycle_dicts = {}
+
+    logger = get_logger('CheckDAParams')
+
+    for i, config_file in enumerate(config_list):
+
+        # Name the config after its index
+        cycle_dict = cycle_dicts[str(i)] = {}
+
+        # Abort if file not found
+        if not os.path.isfile(config_file):
+            logger.abort(f'Config file {config_file} does not exist.')
+
+        # Open the file for location and window information
+        with open(config_file, 'r') as f:
+            config_dict = yaml.safe_load(f)
+
+        # Window params
+        start_cycle_point = config_dict['start_cycle_point']
+        final_cycle_point = config_dict['final_cycle_point']
+
+        window_length = config_dict['models'][model_component]['window_length']
+        window_offset = config_dict['models'][model_component]['window_offset']
+        cycle_times = config_dict['models'][model_component]['cycle_times']
+
+        # Save the information
+        cycle_dict['start_cycle_dto'] = datetime.strptime(start_cycle_point,
+                                                          datetime_formats['iso_format'])
+        cycle_dict['final_cycle_dto'] = datetime.strptime(final_cycle_point,
+                                                          datetime_formats['iso_format'])
+
+        cycle_dict['window_length'] = window_length
+        cycle_dict['window_offset'] = window_offset
+        cycle_dict['cycle_times'] = cycle_times
+
+    start_cycle_dtos = []
+    final_cycle_dtos = []
+
+    window_lengths = []
+    window_offsets = []
+
+    # Gather all the window params into a list
+    for value in cycle_dicts.values():
+        start_cycle_dtos.append(value['start_cycle_dto'])
+        final_cycle_dtos.append(value['final_cycle_dto'])
+
+        window_lengths.append(value['window_length'])
+        window_offsets.append(value['window_offset'])
+
+    # Check to make sure the window params match
+    if len(set(window_lengths)) > 1 or len(set(window_offsets)) > 1:
+        logger.abort('The experiments specified have mismatched window parameters.')
+
+    # Iterate through all the cycle times and find the common ones.
+    common_cycle_times = None
+    for value in cycle_dicts.values():
+        cycle_times = value['cycle_times']
+
+        if common_cycle_times is not None:
+            common_cycle_times = list(set(cycle_times) & set(common_cycle_times))
+        else:
+            common_cycle_times = cycle_times
+
+    cycle_times_out = []
+
+    if cycle_times_in == [None] or cycle_times_in == 'None':
+        if common_cycle_times is None:
+            cycle_times_out = []
+        else:
+            cycle_times_out = common_cycle_times
+    else:
+        cycle_times_out = cycle_times_in
+
+    # Get the start cycle dto object, or set automatically
+    if start_cycle_point_in is None or start_cycle_point_in == 'None':
+        if len(start_cycle_dtos) > 0:
+            start_cycle_dto = max(start_cycle_dtos)
+            start_cycle_point_out = start_cycle_dto.strftime(datetime_formats['iso_format'])
+        else:
+            start_cycle_point_out = None
+    else:
+        start_cycle_point_out = start_cycle_point_in
+
+    # Get the final cycle dto object, or set automatically
+    if final_cycle_point_in is None or final_cycle_point_in == 'None':
+        if len(final_cycle_dtos) > 0:
+            final_cycle_dto = min(final_cycle_dtos)
+            final_cycle_point_out = final_cycle_dto.strftime(datetime_formats['iso_format'])
+        else:
+            final_cycle_point_out = None
+    else:
+        final_cycle_point_out = final_cycle_point_in
+
+    return start_cycle_point_out, final_cycle_point_out, cycle_times_out
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/utilities/question_defaults.py
+++ b/src/swell/utilities/question_defaults.py
@@ -25,6 +25,16 @@ class QuestionDefaults():
     # --------------------------------------------------------------------------------------------------
 
     @dataclass
+    class comparison_experiment_paths(SuiteQuestion):
+        default_value: list = mutable_field([])
+        question_name: str = "comparison_experiment_paths"
+        ask_question: bool = True
+        prompt: str = "Provide paths to two experiments to run comparison tests on."
+        widget_type: WType = WType.STRING_CHECK_LIST
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
     class cycle_times(SuiteQuestion):
         default_value: str = "defer_to_model"
         question_name: str = "cycle_times"
@@ -35,6 +45,19 @@ class QuestionDefaults():
         ])
         prompt: str = "Enter the cycle times for this model."
         widget_type: WType = WType.STRING_CHECK_LIST
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
+    class cycling_varbc(SuiteQuestion):
+        default_value: str = "defer_to_model"
+        question_name: str = "cycling_varbc"
+        ask_question: bool = True
+        models: List[str] = mutable_field([
+            "geos_atmosphere"
+        ])
+        prompt: str = "Do you want to use cycling VarBC option?"
+        widget_type: WType = WType.BOOLEAN
 
     # --------------------------------------------------------------------------------------------------
 
@@ -115,6 +138,17 @@ class QuestionDefaults():
         options: str = "defer_to_code"
         prompt: str = "Enter the model components for this model."
         widget_type: WType = WType.STRING_CHECK_LIST
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
+    class parser_options(SuiteQuestion):
+        default_value: list = mutable_field(['fgrep_residual_norm'])
+        question_name: str = "parser_options"
+        ask_question: bool = True
+        options: list = mutable_field(['fgrep_residual_norm'])
+        prompt: str = "List the test types to run on the JEDI oops log."
+        widget_type: WType = WType.STRING_DROP_LIST
 
     # --------------------------------------------------------------------------------------------------
 
@@ -290,6 +324,22 @@ class QuestionDefaults():
     # --------------------------------------------------------------------------------------------------
 
     @dataclass
+    class comparison_log_type(TaskQuestion):
+        default_value: str = "variational"
+        question_name: str = "comparison_log_type"
+        options: List[str] = mutable_field([
+            'variational',
+            'fgat',
+        ])
+        models: List[str] = mutable_field([
+            "all_models"
+        ])
+        prompt: str = "Provide the log naming convention (e.g. 'variational', 'fgat')."
+        widget_type: WType = WType.STRING
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
     class crtm_coeff_dir(TaskQuestion):
         default_value: str = "defer_to_platform"
         question_name: str = "crtm_coeff_dir"
@@ -298,19 +348,6 @@ class QuestionDefaults():
         ])
         prompt: str = "What is the path to the CRTM coefficient files?"
         widget_type: WType = WType.STRING
-
-    # --------------------------------------------------------------------------------------------------
-
-    @dataclass
-    class cycling_varbc(TaskQuestion):
-        default_value: str = "defer_to_model"
-        question_name: str = "cycling_varbc"
-        ask_question: bool = True
-        models: List[str] = mutable_field([
-            "geos_atmosphere"
-        ])
-        prompt: str = "Do you want to use cycling VarBC option?"
-        widget_type: WType = WType.BOOLEAN
 
     # --------------------------------------------------------------------------------------------------
 
@@ -989,6 +1026,18 @@ class QuestionDefaults():
     # --------------------------------------------------------------------------------------------------
 
     @dataclass
+    class obs_thinning_rej_fraction(TaskQuestion):
+        default_value: float = 0.75
+        question_name: str = "obs_thinning_rej_fraction"
+        models: List[str] = mutable_field([
+            "geos_atmosphere"
+        ])
+        prompt: str = "What is the rejection fraction for obs thinning?"
+        widget_type: WType = WType.FLOAT
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
     class observations(TaskQuestion):
         default_value: str = "defer_to_model"
         question_name: str = "observations"
@@ -1035,18 +1084,6 @@ class QuestionDefaults():
         ])
         prompt: str = "What is the path to the Swell formatted observing system records?"
         widget_type: WType = WType.STRING
-
-    # --------------------------------------------------------------------------------------------------
-
-    @dataclass
-    class obs_thinning_rej_fraction(TaskQuestion):
-        default_value: float = 0.75
-        question_name: str = "obs_thinning_rej_fraction"
-        models: List[str] = mutable_field([
-            "geos_atmosphere"
-        ])
-        prompt: str = "What is the rejection fraction for obs thinning?"
-        widget_type: WType = WType.FLOAT
 
     # --------------------------------------------------------------------------------------------------
 
@@ -1172,20 +1209,6 @@ class QuestionDefaults():
             "geos_atmosphere"
         ])
         prompt: str = "Is it a single-observation test?"
-        widget_type: WType = WType.BOOLEAN
-
-    # --------------------------------------------------------------------------------------------------
-
-    @dataclass
-    class skip_ensemble_hofx(TaskQuestion):
-        default_value: str = "defer_to_model"
-        question_name: str = "skip_ensemble_hofx"
-        ask_question: bool = True
-        options: str = "defer_to_model"
-        models: List[str] = mutable_field([
-            "geos_atmosphere"
-        ])
-        prompt: str = "Which local ensemble solver type should be implemented?"
         widget_type: WType = WType.BOOLEAN
 
     # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR adds the variational comparison suite that is part of #540, without the flow.cylc overhaul. We can potentially merge that one later, but I'm feeling like I may want to change some things about that PR and wanted to get this in sooner

It works basically the same way as before, docs are under docs/examples/soca/comparison_workflows.md