### PR TITLE
Retain YMAL content order for Local Ensemble DA

### DIFF
--- a/src/swell/tasks/run_jedi_local_ensemble_da_executable.py
+++ b/src/swell/tasks/run_jedi_local_ensemble_da_executable.py
@@ -194,7 +194,8 @@ class RunJediLocalEnsembleDaExecutable(taskBase):
         # Write the expanded dictionary to YAML file
         # ------------------------------------------
         with open(jedi_config_file, 'w') as jedi_config_file_open:
-            yaml.dump(jedi_config_dict, jedi_config_file_open, default_flow_style=False)
+            yaml.dump(jedi_config_dict, jedi_config_file_open,
+                      default_flow_style=False, sort_keys=False)
 
         # Get the JEDI interface metadata
         # -------------------------------


### PR DESCRIPTION
## Description

sort_keys=False in yaml.dump serves this purpose.

## Dependencies

## Impact

Once order of the keywords in the `observers` from the yaml input is restored, the LETKF run becomes faster.  It is possible this has a an effect on missing value counts for H(x) calculations. 
