### PR TITLE
A different way of executing GEOS from SWELL

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_marine/model/background_error.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/model/background_error.yaml
@@ -12,9 +12,12 @@ saber central block:
     - sea_surface_height_above_geoid
   read:
     groups:
-    - variables: [sea_water_potential_temperature, sea_water_salinity]
+    - variables:
+      - sea_water_potential_temperature
+      - sea_water_salinity
       horizontal:
-        filepath: 'background_error_model/hz_rossby'
+        filepath: 'background_error_model/new_corr_1p0'
+        # filepath: 'background_error_model/hz_rossby'
       vertical:
         levels: {{vertical_resolution}}
         filepath: 'background_error_model/vt.{{local_background_time}}'
@@ -26,7 +29,8 @@ saber central block:
       - sea_ice_snow_thickness
     {% endif %}
       horizontal:
-        filepath: 'background_error_model/hz_rossby_1p5'
+        # filepath: 'background_error_model/hz_rossby_1p5'
+        filepath: 'background_error_model/new_corr_1p5'
 
 date: '{{local_background_time_iso}}'
 
@@ -43,6 +47,8 @@ saber outer blocks:
         variable: sst_bgerr
     unbalanced salinity: {} # use default values
     unbalanced ssh: {} # use default values
+    # save diagnostics:
+    #   filepath: parametric_ocean_stddev_diags
 
 linear variable change:
   input variables: {{analysis_variables}}

--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/icec_amsr2_north.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/icec_amsr2_north.yaml
@@ -35,7 +35,9 @@ obs filters:
   action:
     name: inflate error
     inflation factor: 2.0
-- filter: Domain Check
-  where:
-  - variable: {name: GeoVaLs/distance_from_coast}
-    minvalue: 100e3
+- filter: Gaussian Thinning
+  horizontal_mesh: 25  #km
+  use_reduced_horizontal_grid: true
+  select_median: true
+  action:
+    name: reduce obs space

--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/icec_amsr2_south.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/icec_amsr2_south.yaml
@@ -37,7 +37,9 @@ obs filters:
   action:
     name: inflate error
     inflation factor: 2.0
-- filter: Domain Check
-  where:
-  - variable: {name: GeoVaLs/distance_from_coast}
-    minvalue: 100e3
+- filter: Gaussian Thinning
+  horizontal_mesh: 25  #km
+  use_reduced_horizontal_grid: true
+  select_median: true
+  action:
+    name: reduce obs space

--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/sst_avhrrf_mb_l3u.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/sst_avhrrf_mb_l3u.yaml
@@ -1,13 +1,13 @@
 obs space:
-  name: sst_avhrr_ma_l3u
+  name: sst_avhrrf_mb_l3u
   obsdatain:
     engine:
       type: H5File
-      obsfile: '{{cycle_dir}}/sst_avhrr_ma_l3u.{{window_begin}}.nc4'
+      obsfile: '{{cycle_dir}}/sst_avhrrf_mb_l3u.{{window_begin}}.nc4'
   obsdataout:
     engine:
       type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.sst_avhrr_ma_l3u.{{window_begin}}.nc4'
+      obsfile: '{{cycle_dir}}/{{experiment_id}}.sst_avhrrf_mb_l3u.{{window_begin}}.nc4'
   simulated variables: [seaSurfaceTemperature]
 get values:
   time interpolation: linear

--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/sst_avhrrf_mc_l3u.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/sst_avhrrf_mc_l3u.yaml
@@ -1,13 +1,13 @@
 obs space:
-  name: sst_avhrr_mb_l3u
+  name: sst_avhrrf_mc_l3u
   obsdatain:
     engine:
       type: H5File
-      obsfile: '{{cycle_dir}}/sst_avhrr_mb_l3u.{{window_begin}}.nc4'
+      obsfile: '{{cycle_dir}}/sst_avhrrf_mc_l3u.{{window_begin}}.nc4'
   obsdataout:
     engine:
       type: H5File
-      obsfile: '{{cycle_dir}}/{{experiment_id}}.sst_avhrr_mb_l3u.{{window_begin}}.nc4'
+      obsfile: '{{cycle_dir}}/{{experiment_id}}.sst_avhrrf_mc_l3u.{{window_begin}}.nc4'
   simulated variables: [seaSurfaceTemperature]
 get values:
   time interpolation: linear

--- a/src/swell/configuration/jedi/observation_ioda_names.yaml
+++ b/src/swell/configuration/jedi/observation_ioda_names.yaml
@@ -214,11 +214,11 @@ ioda instrument names:
   - ioda name: sst_amsr2_l3u
     full name: AMSR2 (SST)
     inst type: conventional
-  - ioda name: sst_avhrr_ma_l3u
-    full name: Metop-A (SST)
-    inst type: avhrr (IR)
-  - ioda name: sst_avhrr_mb_l3u
+  - ioda name: sst_avhrrf_mb_l3u
     full name: Metop-B (SST)
+    inst type: avhrr (IR)
+  - ioda name: sst_avhrrf_mc_l3u
+    full name: Metop-C (SST)
     inst type: avhrr (IR)
   - ioda name: sst_gmi_l3u
     full name: GPM (GMI) (SST)

--- a/src/swell/deployment/create_experiment.py
+++ b/src/swell/deployment/create_experiment.py
@@ -210,7 +210,8 @@ def create_experiment_directory(
     # resolve the templates and write the suite file to the experiment suite directory.
     # --------------------------------------------------------------------------------------------
     swell_suite_path = os.path.join(get_swell_path(), 'suites', suite)
-    prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experiment_dict, platform)
+    prepare_cylc_suite_jinja2(logger, swell_suite_path, exp_suite_path, experiment_dict,
+                              platform, exp_path)
 
     # Copy suite and platform files to experiment suite directory
     # -----------------------------------------------------------
@@ -404,7 +405,8 @@ def prepare_cylc_suite_jinja2(
     swell_suite_path: str,
     exp_suite_path: str,
     experiment_dict: dict,
-    platform: str
+    platform: str,
+    experiment_path: str
 ) -> None:
 
     # Open suite file from swell
@@ -415,6 +417,10 @@ def prepare_cylc_suite_jinja2(
     # Copy the experiment dictionary to the rendering dictionary
     # ----------------------------------------------------------
     render_dictionary = copy.deepcopy(experiment_dict)
+
+    # Add experiment path to the rendering dictionary
+    # ----------------------------------------------------
+    render_dictionary['experiment_path'] = experiment_path
 
     # Get unique list of cycle times with model flags to render dictionary
     # --------------------------------------------------------------------

--- a/src/swell/deployment/launch_experiment.py
+++ b/src/swell/deployment/launch_experiment.py
@@ -88,7 +88,7 @@ class DeployWorkflow():
             self.logger.info(' ', False)
 
             # Launch the job monitor
-            self.logger.critical('Launching the TUI, press \'q\' at any time to exit the TUI')
+            self.logger.critical('Press any key to launch the TUI. To exit TUI, press \'q\' at any time.')
             input()
             self.logger.info(' ', False)
             self.logger.info('TUI can be relaunched with:')

--- a/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
@@ -2,10 +2,10 @@ crtm_coeff_dir:
   default_value: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1/
 
 existing_geos_gcm_build_path:
-  default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.6.0/install-SLES15
+  default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-GCMv12-rc12/install
 
 existing_geos_gcm_source_path:
-  default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.6.0/
+  default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-GCMv12-rc12/
 
 existing_jedi_build_directory:
   default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_07042025/build-intel-release/
@@ -18,6 +18,9 @@ existing_jedi_source_directory:
 
 existing_jedi_source_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/source/
+
+geos_homdir:
+  default_value: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/geos/homdirs/coupled_025deg
 
 geos_experiment_directory:
   default_value: 5deg_0701

--- a/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
@@ -20,7 +20,7 @@ existing_jedi_source_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/source/
 
 geos_homdir:
-  default_value: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/geos/homdirs/coupled_025deg
+  default_value: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/geos/homdirs/coupled_5deg
 
 geos_experiment_directory:
   default_value: 5deg_0701

--- a/src/swell/suites/3dfgat_coupled_cycle/eva/increment-geos_marine.yaml
+++ b/src/swell/suites/3dfgat_coupled_cycle/eva/increment-geos_marine.yaml
@@ -1,0 +1,170 @@
+datasets:
+
+  - name: ocean_increment
+    type: SocaRestart
+    soca_filenames: {{increment_file_path}}
+    geometry_file: {{cycle_dir}}/INPUT/soca_gridspec.nc
+    variables: [Temp, Salt, ave_ssh]
+    coordinate variables: [lon, lat]
+
+{% if 'cice6' in marine_models %}
+  - name: seaice_increment
+    type: SocaRestart
+    soca_filenames: {{ice_increment_file_path}}
+    geometry_file: {{cycle_dir}}/INPUT/soca_gridspec.nc
+    variables: [aice_h]
+    coordinate variables: [lon, lat]
+{% endif %}
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  - batch figure:
+      variables: [ave_ssh]
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'SOCA Increment'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SSH Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: ocean_increment::SOCAgrid::lon
+          latitude:
+            variable: ocean_increment::SOCAgrid::lat
+          data:
+            variable: ocean_increment::SOCAVars::ave_ssh
+          label: ave_ssh increment
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -0.25
+          vmax: 0.25
+
+  - batch figure:
+      variables: [Temp]
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'Soca Increment'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SST Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: ocean_increment::SOCAgrid::lon
+          latitude:
+            variable: ocean_increment::SOCAgrid::lat
+          data:
+            variable: ocean_increment::SOCAVars::Temp
+            slices: '[0,...]'
+          label: SST increment
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -3
+          vmax: 3
+
+  - batch figure:
+      variables: [Salt]
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'Soca Increment'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: SSS Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: ocean_increment::SOCAgrid::lon
+          latitude:
+            variable: ocean_increment::SOCAgrid::lat
+          data:
+            variable: ocean_increment::SOCAVars::Salt
+            slices: '[0,...]'
+          label: SSS increment
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+
+{% if 'cice6' in marine_models %}
+  - batch figure:
+      variables: [aice_h]
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_s_${variable}.png'
+    plots:
+      - mapping:
+          projection: spstere
+          domain: south
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Sea-ice Concentration Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: seaice_increment::SOCAgrid::lon
+          latitude:
+            variable: seaice_increment::SOCAgrid::lat
+          data:
+            variable: seaice_increment::SOCAVars::aice_h
+          label: Sea ice concentration increment
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+  - batch figure:
+      variables: [aice_h]
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_n_${variable}.png'
+    plots:
+      - mapping:
+          projection: npstere
+          domain: north
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Sea-ice Concentration Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: seaice_increment::SOCAgrid::lon
+          latitude:
+            variable: seaice_increment::SOCAgrid::lat
+          data:
+            variable: seaice_increment::SOCAVars::aice_h
+          label: Sea-ice concentration increment
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1
+          vmax: 1
+{% endif %}

--- a/src/swell/suites/3dfgat_coupled_cycle/eva/jedi_log-geos_marine.yaml
+++ b/src/swell/suites/3dfgat_coupled_cycle/eva/jedi_log-geos_marine.yaml
@@ -1,0 +1,57 @@
+datasets:
+
+- type: JediLog
+  collection_name: jedi_log_test
+  jedi_log_to_parse: '{{cycle_dir}}/jedi_fgat_log.log'
+  data_to_parse:
+    convergence: true
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  - figure:
+      layout: [3,1]
+      figure size: [12,10]
+      title: 'Residual Norm and Norm Reduction Plots'
+      output name: '{{cycle_dir}}/eva/jedi_log/convergence/residual_norm_reduction.png'
+    plots:
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Residual norm'
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::residual_norm
+          color: 'black'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Norm reduction'
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::norm_reduction
+          color: 'black'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Normalized Value'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::residual_norm_normalized
+          color: 'red'
+          label: 'Normalized residual norm'
+        - type: LinePlot
+          x:
+            variable: jedi_log_test::convergence::total_iteration
+          y:
+            variable: jedi_log_test::convergence::norm_reduction_normalized
+          color: 'blue'
+          label: 'Normalized norm reduction'

--- a/src/swell/suites/3dfgat_coupled_cycle/eva/observations-geos_marine.yaml
+++ b/src/swell/suites/3dfgat_coupled_cycle/eva/observations-geos_marine.yaml
@@ -1,0 +1,426 @@
+datasets:
+
+- name: experiment
+  type: IodaObsSpace
+  filenames:
+    - {{obs_path_file}}
+  groups:
+    - name: ObsValue
+      variables: &variables {{simulated_variables}}
+    - name: hofx0
+    - name: hofx1
+    - name: ombg
+    - name: oman
+    - name: MetaData
+    - name: EffectiveQC0
+    - name: EffectiveQC1
+
+transforms:
+
+# Generate Increment for JEDI
+- transform: arithmetic
+  new name: experiment::increment::${variable}
+  equals: experiment::ombg::${variable}-experiment::oman::${variable}
+  for:
+    variable: *variables
+
+# Generate hofx0 that passed QC for JEDI
+- transform: accept where
+  new name: experiment::hofx0PassedQc::${variable}
+  starting field: experiment::hofx0::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate hofx1 that passed QC for JEDI
+- transform: accept where
+  new name: experiment::hofx1PassedQc::${variable}
+  starting field: experiment::hofx1::${variable}
+  where:
+    - experiment::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate ombg that passed QC for JEDI
+- transform: accept where
+  new name: experiment::ombgPassedQc::${variable}
+  starting field: experiment::ombg::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate oman that passed QC for JEDI
+- transform: accept where
+  new name: experiment::omanPassedQc::${variable}
+  starting field: experiment::oman::${variable}
+  where:
+    - experiment::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate passivated ombg that passed QC for JEDI
+- transform: accept where
+  new name: experiment::PassiveombgPassedQc::${variable}
+  starting field: experiment::ombg::${variable}
+  where:
+    - experiment::EffectiveQC1::${variable} == 1
+  for:
+    variable: *variables
+
+# Generate passivated oman that passed QC for JEDI
+- transform: accept where
+  new name: experiment::PassiveomanPassedQc::${variable}
+  starting field: experiment::oman::${variable}
+  where:
+    - experiment::EffectiveQC1::${variable} == 1
+  for:
+    variable: *variables
+
+# Generate obs that passed QC for JEDI
+- transform: accept where
+  new name: experiment::ObsValuePassedQc::${variable}
+  starting field: experiment::ObsValue::${variable}
+  where:
+    - experiment::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  # Correlation scatter plots
+  # -------------------------
+
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}/jedi_hofx_vs_obs_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Observation Value'
+        add_ylabel: 'JEDI h(x)'
+        add_grid:
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofx0PassedQc::${variable}
+          markersize: 5
+          color: 'black'
+          label: 'JEDI h(x) versus obs (all obs)'
+        - type: Scatter
+          x:
+            variable: experiment::ObsValue::${variable}
+          y:
+            variable: experiment::hofx1::${variable}
+          markersize: 5
+          color: 'red'
+          label: 'JEDI h(x) versus obs (passed QC in JEDI)'
+
+  # Histogram plots
+  # ---------------
+
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: histogram_bins
+        data variable: experiment::omanPassedQc::${variable}
+        number of bins rule: 'rice'
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/histogram/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Difference'
+        add_ylabel: 'Count'
+        set_xlim: [-3, 3]
+        add_legend:
+          loc: 'upper left'
+        statistics:
+          fields:
+            - field_name: experiment::omanPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.10
+              kwargs:
+                color: 'blue'
+                fontsize: 8
+                fontfamily: monospace
+            - field_name: experiment::ombgPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.13
+              kwargs:
+                color: 'red'
+                fontsize: 8
+                fontfamily: monospace
+          statistics_variables:
+          - n
+          - min
+          - mean
+          - max
+          - std
+
+        layers:
+        - type: Histogram
+          data:
+            variable: experiment::ombgPassedQc::${variable}
+          color: 'red'
+          label: 'observations minus background '
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+        - type: Histogram
+          data:
+            variable: experiment::omanPassedQc::${variable}
+          color: 'blue'
+          label: 'observations minus analysis'
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+
+  # Passivated OmBg and OmA
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: histogram_bins
+        data variable: experiment::PassiveomanPassedQc::${variable}
+        number of bins rule: 'rice'
+    figure:
+      layout: [1,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/histogram/${variable}/pass_ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Difference'
+        add_ylabel: 'Count'
+        set_xlim: [-3, 3]
+        add_legend:
+          loc: 'upper left'
+        statistics:
+          fields:
+            - field_name: experiment::PassiveomanPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.10
+              kwargs:
+                color: 'blue'
+                fontsize: 8
+                fontfamily: monospace
+            - field_name: experiment::PassiveombgPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.13
+              kwargs:
+                color: 'red'
+                fontsize: 8
+                fontfamily: monospace
+          statistics_variables:
+          - n
+          - min
+          - mean
+          - max
+          - std
+
+        layers:
+        - type: Histogram
+          data:
+            variable: experiment::PassiveombgPassedQc::${variable}
+          color: 'red'
+          label: 'observations minus background '
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+        - type: Histogram
+          data:
+            variable: experiment::PassiveomanPassedQc::${variable}
+          color: 'blue'
+          label: 'observations minus analysis'
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+
+  # Map plots
+  # ---------
+  # Increment
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::ombgPassedQc::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [2,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: {{map_projection}}
+          domain: {{domain}}
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::ombgPassedQc::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+      - mapping:
+          projection: {{map_projection}}
+          domain: {{domain}}
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::omanPassedQc::${variable}
+          markersize: 2
+          label: OmBg
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::EffectiveQC1::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/effectiveQC_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: {{map_projection}}
+          domain: {{domain}}
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: EffectiveQC1
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::EffectiveQC1::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::increment::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/increment_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: {{map_projection}}
+          domain: {{domain}}
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: Increment (OmBg - OmAn)
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::increment::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  # Passivate
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::PassiveombgPassedQc::${variable}
+    figure:
+      figure size: [20,10]
+      layout: [2,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/passive_ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: {{map_projection}}
+          domain: {{domain}}
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::PassiveombgPassedQc::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+      - mapping:
+          projection: {{map_projection}}
+          domain: {{domain}}
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment::MetaData::longitude
+          latitude:
+            variable: experiment::MetaData::latitude
+          data:
+            variable: experiment::PassiveomanPassedQc::${variable}
+          markersize: 2
+          label: OmBg
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}

--- a/src/swell/suites/3dfgat_coupled_cycle/flow.cylc
+++ b/src/swell/suites/3dfgat_coupled_cycle/flow.cylc
@@ -174,7 +174,6 @@
 
     [[GetCoupledGeosRestart]]
         script = "swell task GetCoupledGeosRestart $config -d $datetime"
-        execution retry delays = 2*PT10S
 
     {% for model_component in model_components %}
 

--- a/src/swell/suites/3dfgat_coupled_cycle/flow.cylc
+++ b/src/swell/suites/3dfgat_coupled_cycle/flow.cylc
@@ -1,0 +1,259 @@
+# (C) Copyright 2023 United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# --------------------------------------------------------------------------------------------------
+
+# Cylc suite for executing Geos forecast
+
+# --------------------------------------------------------------------------------------------------
+
+[scheduler]
+    UTC mode = True
+    allow implicit tasks = False
+
+# --------------------------------------------------------------------------------------------------
+
+[scheduling]
+
+    initial cycle point = {{start_cycle_point}}
+    final cycle point = {{final_cycle_point}}
+    runahead limit = {{runahead_limit}}
+
+    [[graph]]
+        R1 = """
+            # Triggers for non cycle time dependent tasks
+            # -------------------------------------------
+            # Clone Geos source code
+            CloneGeos
+
+            # Clone JEDI source code
+            CloneJedi
+
+            # Build Geos source code by linking
+            CloneGeos => BuildGeosByLinking?
+
+            # Build JEDI source code by linking
+            CloneJedi => BuildJediByLinking?
+
+            # If not able to link to build create the build
+            BuildGeosByLinking:fail? => BuildGeos
+
+            # If not able to link to build create the build
+            BuildJediByLinking:fail? => BuildJedi
+
+            # Need first set of restarts to run model
+            GetCoupledGeosRestart => PrepCoupledGeosRunDir
+
+            # Model cannot run without code
+            BuildGeosByLinking? | BuildGeos => RunGeos
+
+            {% for model_component in model_components %}
+
+            # JEDI cannot run without code
+            BuildJediByLinking? | BuildJedi => RunJediFgatExecutable-{{model_component}}
+
+            # Stage JEDI static files
+            CloneJedi => StageJedi-{{model_component}} => RunJediFgatExecutable-{{model_component}}
+
+            {% endfor %}
+        """
+
+        {% for cycle_time in cycle_times %}
+        {{cycle_time.cycle_time}} = """
+        {% for model_component in model_components %}
+
+            # Model preperation
+            # Run the forecast through two windows (need to output restarts at the end of the
+            # first window and backgrounds for the second window)
+            MoveEraseDaRestart-{{model_component}}[-{{models[model_component]["window_length"]}}] => PrepCoupledGeosRunDir
+            PrepCoupledGeosRunDir => RunGeos
+
+            # Run the analysis
+            RunGeos => LinkCoupledGeosOutput-{{model_component}}
+            LinkCoupledGeosOutput-{{model_component}} => GenerateBClimatology-{{model_component}}
+
+            # Data assimilation preperation
+            GetObservations-{{model_component}}
+
+            LinkCoupledGeosOutput-{{model_component}} => RunJediFgatExecutable-{{model_component}}
+            StageJediCycle-{{model_component}} => RunJediFgatExecutable-{{model_component}}
+            GenerateBClimatology-{{model_component}} => RunJediFgatExecutable-{{model_component}}
+            GetObservations-{{model_component}} => RunJediFgatExecutable-{{model_component}}
+
+            # Run analysis diagnostics
+            RunJediFgatExecutable-{{model_component}} => EvaObservations-{{model_component}}
+            RunJediFgatExecutable-{{model_component}} => EvaJediLog-{{model_component}}
+            EvaIncrement-{{model_component}} => PrepareAnalysis-{{model_component}}
+
+            # Prepare analysis for next forecast
+            RunJediFgatExecutable-{{model_component}} => EvaIncrement-{{model_component}}
+            {% if 'cice6' in models[model_component]["marine_models"] %}
+            PrepareAnalysis-{{model_component}} => RunJediConvertStateSoca2ciceExecutable-{{model_component}}
+            RunJediConvertStateSoca2ciceExecutable-{{model_component}} => SaveRestart-{{model_component}}
+            RunJediConvertStateSoca2ciceExecutable-{{model_component}} => CleanCycle-{{model_component}}
+            {% else %}
+            PrepareAnalysis-{{model_component}} => SaveRestart-{{model_component}}
+            {% endif %}
+
+            # Move restart to next cycle and then erase current forecast folder
+            SaveRestart-{{model_component}} => MoveEraseDaRestart-{{model_component}}
+
+            # Save analysis output
+            # RunJediFgatExecutable-{{model_component}} => SaveAnalysis-{{model_component}}
+            RunJediFgatExecutable-{{model_component}} => SaveObsDiags-{{model_component}}
+
+            # Save model output
+            # MoveBackground-{{model_component}} => StoreBackground-{{model_component}}
+
+            # Clean up large files
+            EvaObservations-{{model_component}} & EvaJediLog-{{model_component}} & EvaIncrement-{{model_component}} & SaveObsDiags-{{model_component}} =>
+            CleanCycle-{{model_component}}
+        {% endfor %}
+        """
+        {% endfor %}
+# --------------------------------------------------------------------------------------------------
+
+[runtime]
+
+    # Task defaults
+    # -------------
+    [[root]]
+        pre-script = "source $CYLC_SUITE_DEF_PATH/modules"
+
+        [[[environment]]]
+            datetime = $CYLC_TASK_CYCLE_POINT
+            config   = $CYLC_SUITE_DEF_PATH/experiment.yaml
+
+    # Tasks
+    # -----
+    [[CloneGeos]]
+        script = "swell task CloneGeos $config"
+
+    [[BuildGeosByLinking]]
+        script = "swell task BuildGeosByLinking $config"
+
+    [[BuildGeos]]
+        script = "swell task BuildGeos $config"
+        platform = {{platform}}
+        execution time limit = {{scheduling["BuildGeos"]["execution_time_limit"]}}
+        [[[directives]]]
+        {%- for key, value in scheduling["BuildGeos"]["directives"]["all"].items() %}
+            --{{key}} = {{value}}
+        {%- endfor %}
+
+    [[CloneJedi]]
+        script = "swell task CloneJedi $config"
+
+    [[BuildJediByLinking]]
+        script = "swell task BuildJediByLinking $config"
+
+    [[BuildJedi]]
+        script = "swell task BuildJedi $config"
+        platform = {{platform}}
+        execution time limit = {{scheduling["BuildJedi"]["execution_time_limit"]}}
+        [[[directives]]]
+        {%- for key, value in scheduling["BuildJedi"]["directives"]["all"].items() %}
+            --{{key}} = {{value}}
+        {%- endfor %}
+
+    [[RunGeos]]
+        script = "{{experiment_path}}/forecast/gcm_run.j"
+        platform = {{platform}}
+        [[[job]]]
+            shell = /bin/csh
+        [[[directives]]]
+        {%- for key, value in scheduling["RunGeos"]["directives"]["all"].items() %}
+            --{{key}} = {{value}}
+        {%- endfor %}
+
+    [[PrepCoupledGeosRunDir]]
+        script = "swell task PrepCoupledGeosRunDir $config -d $datetime"
+
+    [[GetCoupledGeosRestart]]
+        script = "swell task GetCoupledGeosRestart $config -d $datetime"
+        execution retry delays = 2*PT10S
+
+    {% for model_component in model_components %}
+
+    [[LinkCoupledGeosOutput-{{model_component}}]]
+        script = "swell task LinkCoupledGeosOutput $config -d $datetime -m {{model_component}}"
+
+    [[MoveEraseDaRestart-{{model_component}}]]
+        script = "swell task MoveEraseDaRestart $config -d $datetime -m {{model_component}}"
+
+    [[SaveRestart-{{model_component}}]]
+        script = "swell task SaveRestart $config -d $datetime -m {{model_component}}"
+
+    [[StageJedi-{{model_component}}]]
+        script = "swell task StageJedi $config -m {{model_component}}"
+
+    [[StageJediCycle-{{model_component}}]]
+        script = "swell task StageJedi $config -d $datetime -m {{model_component}}"
+
+    [[GetObservations-{{model_component}}]]
+        script = "swell task GetObservations $config -d $datetime -m {{model_component}}"
+
+    [[GenerateBClimatology-{{model_component}}]]
+        script = "swell task GenerateBClimatology $config -d $datetime -m {{model_component}}"
+        platform = {{platform}}
+        execution time limit = {{scheduling["GenerateBClimatology"]["execution_time_limit"]}}
+        [[[directives]]]
+        {%- for key, value in scheduling["GenerateBClimatology"]["directives"][model_component].items() %}
+            --{{key}} = {{value}}
+        {%- endfor %}
+
+    {% if 'cice6' in models["geos_marine"]["marine_models"] %}
+
+    [[RunJediConvertStateSoca2ciceExecutable-{{model_component}}]]
+        script = "swell task RunJediConvertStateSoca2ciceExecutable $config -d $datetime -m {{model_component}}"
+        platform = {{platform}}
+        execution time limit = {{scheduling["RunJediConvertStateSoca2ciceExecutable"]["execution_time_limit"]}}
+        [[[directives]]]
+        {%- for key, value in scheduling["RunJediConvertStateSoca2ciceExecutable"]["directives"][model_component].items() %}
+            --{{key}} = {{value}}
+        {%- endfor %}
+
+    {% endif %}
+
+    [[RunJediFgatExecutable-{{model_component}}]]
+        script = "swell task RunJediFgatExecutable $config -d $datetime -m {{model_component}}"
+        platform = {{platform}}
+        execution time limit = {{scheduling["RunJediFgatExecutable"]["execution_time_limit"]}}
+        execution retry delays = 1*PT10M
+        [[[directives]]]
+        {%- for key, value in scheduling["RunJediFgatExecutable"]["directives"][model_component].items() %}
+            --{{key}} = {{value}}
+        {%- endfor %}
+
+    [[EvaJediLog-{{model_component}}]]
+        script = "swell task EvaJediLog $config -d $datetime -m {{model_component}}"
+
+    [[EvaIncrement-{{model_component}}]]
+        script = "swell task EvaIncrement $config -d $datetime -m {{model_component}}"
+
+    [[EvaObservations-{{model_component}}]]
+        script = "swell task EvaObservations $config -d $datetime -m {{model_component}}"
+        platform = {{platform}}
+        execution time limit = {{scheduling["EvaObservations"]["execution_time_limit"]}}
+        [[[directives]]]
+        {%- for key, value in scheduling["EvaObservations"]["directives"][model_component].items() %}
+            --{{key}} = {{value}}
+        {%- endfor %}
+
+    [[SaveRestart-{{model_component}}]]
+        script = "swell task SaveRestart $config -d $datetime -m {{model_component}}"
+
+    [[SaveObsDiags-{{model_component}}]]
+        script = "swell task SaveObsDiags $config -d $datetime -m {{model_component}}"
+
+    [[PrepareAnalysis-{{model_component}}]]
+        script = "swell task PrepareAnalysis $config -d $datetime -m {{model_component}}"
+
+    [[CleanCycle-{{model_component}}]]
+        script = "swell task CleanCycle $config -d $datetime -m {{model_component}}"
+    {% endfor %}
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/3dfgat_coupled_cycle/suite_config.py
+++ b/src/swell/suites/3dfgat_coupled_cycle/suite_config.py
@@ -31,7 +31,7 @@ class SuiteConfig(QuestionContainer, Enum):
             qd.jedi_build_method("use_existing"),
             qd.geos_build_method("use_existing"),
             qd.model_components(['geos_marine']),
-            qd.geos_expdir_different(True),
+            qd.geos_expdir_different(False),
         ],
         geos_marine=[
             qd.cycle_times([

--- a/src/swell/suites/3dfgat_coupled_cycle/suite_config.py
+++ b/src/swell/suites/3dfgat_coupled_cycle/suite_config.py
@@ -1,0 +1,100 @@
+# --------------------------------------------------------------------------------------------------
+#  @package configuration
+#
+#  Class containing the configuration. This is a dictionary that is converted from
+#  an input yaml configuration file. Various function are included for interacting with the
+#  dictionary.
+#
+# --------------------------------------------------------------------------------------------------
+
+
+from swell.utilities.swell_questions import QuestionContainer, QuestionList
+from swell.utilities.question_defaults import QuestionDefaults as qd
+from swell.suites.suite_questions import SuiteQuestions as sq
+
+from enum import Enum
+
+
+# --------------------------------------------------------------------------------------------------
+
+class SuiteConfig(QuestionContainer, Enum):
+
+    # --------------------------------------------------------------------------------------------------
+
+    _3dfgat_coupled_cycle_tier1 = QuestionList(
+        list_name="3dfgat_coupled_cycle",
+        questions=[
+            sq.marine,
+            qd.start_cycle_point("2021-07-02T06:00:00Z"),
+            qd.final_cycle_point("2021-07-02T12:00:00Z"),
+            qd.runahead_limit("P2"),
+            qd.jedi_build_method("use_existing"),
+            qd.geos_build_method("use_existing"),
+            qd.model_components(['geos_marine']),
+            qd.geos_expdir_different(True),
+        ],
+        geos_marine=[
+            qd.cycle_times([
+                "T00",
+                "T06",
+                "T12",
+                "T18"
+            ]),
+            qd.analysis_variables([
+                "sea_water_salinity",
+                "sea_water_potential_temperature",
+                "sea_surface_height_above_geoid",
+                "sea_water_cell_thickness",
+                "sea_ice_area_fraction",
+                "sea_ice_thickness",
+                "sea_ice_snow_thickness"
+            ]),
+            qd.window_length("PT6H"),
+            qd.window_offset("PT3H"),
+            qd.window_type("4D"),
+            qd.horizontal_resolution("72x36"),
+            qd.vertical_resolution("50"),
+            qd.total_processors(6),
+            qd.observations([
+                "adt_cryosat2n",
+                "adt_jason3",
+                "adt_saral",
+                "adt_sentinel3a",
+                "adt_sentinel3b",
+                "insitu_profile_argo",
+                "icec_amsr2_north",
+                "icec_amsr2_south",
+                "icec_nsidc_nh",
+                "icec_nsidc_sh",
+                "sst_ostia",
+                "sss_smos",
+                "sss_smapv5",
+                "sst_abi_g16_l3c",
+                "sst_gmi_l3u",
+                "sst_viirs_n20_l3u",
+                "temp_profile_xbt"
+            ]),
+            qd.number_of_iterations([10]),
+            qd.obs_provider(['odas', 'gdas_marine']),
+            qd.mom6_iau(True),
+            qd.analysis_forecast_window_offset("-PT3H"),
+            qd.background_time_offset("PT9H"),
+            qd.clean_patterns([
+                "*.nc4",
+                "*.txt",
+                "*.rc",
+                "*.bin"
+            ]),
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------
+
+    _3dfgat_coupled_cycle = QuestionList(
+        list_name="3dfgat_coupled_cycle",
+        questions=[
+            _3dfgat_coupled_cycle_tier1
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/3dfgat_cycle/flow.cylc
+++ b/src/swell/suites/3dfgat_cycle/flow.cylc
@@ -78,11 +78,10 @@
 
             # Data assimilation preperation
             GetObservations-{{model_component}}
-            GenerateBClimatologyByLinking-{{model_component}} :fail? => GenerateBClimatology-{{model_component}}
 
             LinkGeosOutput-{{model_component}} => RunJediFgatExecutable-{{model_component}}
             StageJediCycle-{{model_component}} => RunJediFgatExecutable-{{model_component}}
-            GenerateBClimatologyByLinking-{{model_component}}? | GenerateBClimatology-{{model_component}} => RunJediFgatExecutable-{{model_component}}
+            GenerateBClimatology-{{model_component}} => RunJediFgatExecutable-{{model_component}}
             GetObservations-{{model_component}} => RunJediFgatExecutable-{{model_component}}
 
             # Run analysis diagnostics
@@ -213,9 +212,6 @@
             --{{key}} = {{value}}
         {%- endfor %}
 
-    [[GenerateBClimatologyByLinking-{{model_component}}]]
-        script = "swell task GenerateBClimatologyByLinking $config -d $datetime -m {{model_component}}"
-
     {% if 'cice6' in models["geos_marine"]["marine_models"] %}
 
     [[RunJediConvertStateSoca2ciceExecutable-{{model_component}}]]
@@ -233,6 +229,7 @@
         script = "swell task RunJediFgatExecutable $config -d $datetime -m {{model_component}}"
         platform = {{platform}}
         execution time limit = {{scheduling["RunJediFgatExecutable"]["execution_time_limit"]}}
+        execution retry delays = 1*PT5M
         [[[directives]]]
         {%- for key, value in scheduling["RunJediFgatExecutable"]["directives"][model_component].items() %}
             --{{key}} = {{value}}

--- a/src/swell/suites/3dvar/flow.cylc
+++ b/src/swell/suites/3dvar/flow.cylc
@@ -54,7 +54,6 @@
             GetObservations-{{model_component}}
 
             # GenerateBClimatology, for ocean it is cycle dependent
-            GenerateBClimatologyByLinking-{{model_component}} :fail? => GenerateBClimatology-{{model_component}}
             GetBackground-{{model_component}} => GenerateBClimatology-{{model_component}}
 
             # Perform staging that is cycle dependent
@@ -65,7 +64,7 @@
             StageJedi-{{model_component}}[^] => RunJediVariationalExecutable-{{model_component}}
             StageJediCycle-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GetBackground-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
-            GenerateBClimatologyByLinking-{{model_component}}? | GenerateBClimatology-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
+            GenerateBClimatology-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GetObservations-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
 
             # EvaObservations

--- a/src/swell/suites/3dvar_cycle/flow.cylc
+++ b/src/swell/suites/3dvar_cycle/flow.cylc
@@ -77,11 +77,10 @@
 
             # Data assimilation things
             GetObservations-{{model_component}}
-            GenerateBClimatologyByLinking-{{model_component}} :fail? => GenerateBClimatology-{{model_component}}
 
             LinkGeosOutput-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             StageJediCycle-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
-            GenerateBClimatologyByLinking-{{model_component}}? | GenerateBClimatology-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
+            GenerateBClimatology-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GetObservations-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
 
             # Run analysis diagnostics
@@ -213,9 +212,6 @@
             --{{key}} = {{value}}
         {%- endfor %}
 
-    [[GenerateBClimatologyByLinking-{{model_component}}]]
-        script = "swell task GenerateBClimatologyByLinking $config -d $datetime -m {{model_component}}"
-
     {% if 'cice6' in models["geos_marine"]["marine_models"] %}
 
     [[RunJediConvertStateSoca2ciceExecutable-{{model_component}}]]
@@ -232,6 +228,7 @@
     [[RunJediVariationalExecutable-{{model_component}}]]
         script = "swell task RunJediVariationalExecutable $config -d $datetime -m {{model_component}}"
         platform = {{platform}}
+        execution retry delays = 1*PT5M
         execution time limit = {{scheduling["RunJediVariationalExecutable"]["execution_time_limit"]}}
         [[[directives]]]
         {%- for key, value in scheduling["RunJediVariationalExecutable"]["directives"][model_component].items() %}

--- a/src/swell/suites/3dvar_cycle/suite_config.py
+++ b/src/swell/suites/3dvar_cycle/suite_config.py
@@ -83,4 +83,25 @@ class SuiteConfig(QuestionContainer, Enum):
         ]
     )
 
+    # -------------------------------------------------------------------------------------------------
+
+    _3dvar_cycle_tier2 = QuestionList(
+        list_name="3dvar_cycle",
+        questions=[
+            sq.marine,
+            qd.start_cycle_point("2021-07-02T06:00:00Z"),
+            qd.final_cycle_point("2021-07-02T12:00:00Z"),
+            qd.runahead_limit("P2"),
+            qd.jedi_build_method("use_existing"),
+            qd.geos_build_method("use_existing"),
+            qd.model_components(['geos_marine']),
+            qd.forecast_duration("P2D")
+        ],
+        geos_marine=[
+            qd.window_length("P1D")
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------
+
     # --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/forecast_geos/flow.cylc
+++ b/src/swell/suites/forecast_geos/flow.cylc
@@ -46,16 +46,11 @@
 
             # Run Geos Executable
             PrepGeosRunDir => RunGeosExecutable
-            MoveForecastRestart[-PT6H] => PrepGeosRunDir
+            MoveEraseForecastRestart[-PT6H] => PrepGeosRunDir
 
             # Move restart to next cycle
-            RunGeosExecutable => MoveForecastRestart
+            RunGeosExecutable => MoveEraseForecastRestart
 
-            # Save restarts if requested
-            # MoveForecastRestart[-PT6H] => SaveRestart
-
-            # Remove Run Directory
-            MoveForecastRestart => RemoveForecastDir
         """
         {% endfor %}
 
@@ -92,20 +87,17 @@
     [[PrepGeosRunDir]]
         script = "swell task PrepGeosRunDir $config -d $datetime"
 
-    [[RemoveForecastDir]]
-        script = "swell task RemoveForecastDir $config -d $datetime"
-
     [[GetGeosRestart]]
         script = "swell task GetGeosRestart $config -d $datetime"
 
-    [[MoveForecastRestart]]
-        script = "swell task MoveForecastRestart $config -d $datetime"
+    [[MoveEraseForecastRestart]]
+        script = "swell task MoveEraseForecastRestart $config -d $datetime"
 
     [[SaveRestart]]
         script = "swell task SaveRestart $config -d $datetime"
 
     [[RunGeosExecutable]]
-        script = "swell task RunGeosExecutable $config -d $datetime"
+        script = "{{experiment_path}}/forecast/gcm_run.j"
         platform = {{platform}}
         execution time limit = {{scheduling["RunGeosExecutable"]["execution_time_limit"]}}
         [[[directives]]]

--- a/src/swell/tasks/base/task_base.py
+++ b/src/swell/tasks/base/task_base.py
@@ -90,14 +90,17 @@ class taskBase(ABC):
         self.__model_components__ = self.config.__model_components__
 
         # Create cycle and forecast directories
+        # Forecast directories (forecast and next_forecast) are now on the experiment level. This 
+        # allows time independent templating in flow.cylc.
         # -------------------------------------
         cycle_dir = None
-        self.cycle_forecast_dir = None
+        self.str_forecast_dir = None
+        self.str_next_forecast_dir = None
 
         if datetime_input is not None:
-            # Name of directory where cycle forecast files will be staged
-            self.cycle_forecast_dir = os.path.join(self.experiment_path(), 'run',
-                                                   self.__datetime__.string_directory(), 'forecast')
+            # Name of directory where forecast files are staged
+            self.str_forecast_dir = os.path.join(self.experiment_path(), 'forecast')
+            self.str_next_forecast_dir = os.path.join(self.experiment_path(), 'next_forecast')
 
             if model is not None:
                 cycle_dir = self.cycle_dir()
@@ -109,9 +112,9 @@ class taskBase(ABC):
                                                   self.__experiment_id__, cycle_dir,
                                                   self.__datetime__, self.__model__)
 
-        # Add GEOS utils
+        # Add methods to GEOS utils
         # --------------
-        self.geos = Geos(self.logger, self.cycle_forecast_dir)
+        self.geos = Geos(self.logger, self.str_forecast_dir)
 
         # Create some extra helpers available when the datetime is present
         # ----------------------------------------------------------------
@@ -202,13 +205,14 @@ class taskBase(ABC):
 
     def forecast_dir(self, paths: Union[str, list[str]] = []) -> Optional[str]:
 
+        '''
+        Method to provide "forecast" directory to geos class
+        If paths are provided, it is combined with the forecast directory and returned
+        '''
+
         # Make sure forecast directory exists
         # -----------------------------------
-        os.makedirs(self.cycle_forecast_dir, 0o755, exist_ok=True)
-
-        # Combine datetime string (directory format) with the model
-        # ------------------------------------------------------
-        forecast_dir = self.cycle_forecast_dir
+        os.makedirs(self.str_forecast_dir, 0o755, exist_ok=True)
 
         if len(paths) > 0:
             # If paths (which should be a list) is not empty, combine with forecast_dir
@@ -216,11 +220,30 @@ class taskBase(ABC):
             if isinstance(paths, str):
                 paths = [paths]
 
-            # Combining list of paths with forecast dir for code brevity
-            # ---------------------------------------------------------
-            forecast_dir = os.path.join(forecast_dir, *paths)
+        # Combine list of paths with forecast dir for code brevity
+        return os.path.join(self.str_forecast_dir, *paths)
 
-        return forecast_dir
+    # ----------------------------------------------------------------------------------------------
+
+    def next_forecast_dir(self, paths: Union[str, list[str]] = []) -> Optional[str]:
+
+        '''
+        Method to provide "next forecast" directory to geos class
+        If paths are provided, it is combined with the next forecast directory and returned
+        '''
+
+        # Make sure forecast directory exists
+        # -----------------------------------
+        os.makedirs(self.str_next_forecast_dir, 0o755, exist_ok=True)
+
+        if len(paths) > 0:
+            # If paths (which should be a list) is not empty, combine with str_next_forecast_dir
+            # -------------------------------------------------------------------------
+            if isinstance(paths, str):
+                paths = [paths]
+
+        # Combine list of paths with str_next_forecast_dir for code brevity
+        return os.path.join(self.str_next_forecast_dir, *paths)
 
     # ----------------------------------------------------------------------------------------------
 

--- a/src/swell/tasks/generate_b_climatology.py
+++ b/src/swell/tasks/generate_b_climatology.py
@@ -18,6 +18,81 @@ from swell.utilities.file_system_operations import check_if_files_exist_in_path
 
 class GenerateBClimatology(taskBase):
 
+    def execute(self) -> None:
+        """ Creates B Matrix files for background error model(s):
+
+            - BUMP:
+             Creates bump files in 'cycle_dir' that depend upon the number of total
+             processors and active model components (sea-ice or no sea-ice).
+
+            - EXPLICIT_DIFFUSION:
+             Uses the methodology described in Weaver et al. (20xx). This requires
+             creating horizontal (offline) and vertical diffusion (online with irregular
+             frequency) parameter files. With SOCA implementation, it is also required
+             to have horizontal length scales defined beforehand.
+
+        Parameters
+        ----------
+            All inputs are extracted from the JEDI experiment file configuration.
+            See the taskBase constructor for more information.
+        """
+
+        # Parse configuration
+        # -------------------
+        window_offset = self.config.window_offset()
+        window_type = self.config.window_type()
+        background_error_model = self.config.background_error_model()
+
+        swell_static_files_user = self.config.swell_static_files_user(None)
+        self.swell_static_files = self.config.swell_static_files()
+
+        # Use static_files_user if present in config and contains files
+        # -------------------------------------------------------------
+        if swell_static_files_user is not None and swell_static_files_user != 'None':
+            self.logger.info('swell_static_files_user specified, checking for files')
+            if check_if_files_exist_in_path(self.logger, swell_static_files_user):
+                self.logger.info(f'Using swell static files in {swell_static_files_user}')
+                self.swell_static_files = swell_static_files_user
+
+        self.horizontal_resolution = self.config.horizontal_resolution()
+        self.vertical_resolution = self.config.vertical_resolution()
+        self.generate_yaml_and_exit = self.config.generate_yaml_and_exit(False)
+
+        # Get the JEDI interface for this model component
+        # -----------------------------------------------
+        self.jedi_rendering.add_key('npx_proc', self.config.npx_proc(None))
+        self.jedi_rendering.add_key('npy_proc', self.config.npy_proc(None))
+        self.jedi_rendering.add_key('total_processors', self.config.total_processors(None))
+        self.jedi_rendering.add_key('analysis_variables', self.config.analysis_variables())
+        self.jedi_rendering.add_key('background_error_model', self.config.background_error_model())
+        self.jedi_rendering.add_key('marine_models', self.config.marine_models(None))
+
+        # Compute data assimilation window parameters
+        # -------------------------------------------
+        local_background_time = self.da_window_params.local_background_time(window_offset,
+                                                                            window_type)
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
+                                                                                    window_type)
+
+        # Background
+        # ----------
+        self.jedi_rendering.add_key('local_background_time', local_background_time)
+        self.jedi_rendering.add_key('local_background_time_iso', local_background_time_iso)
+
+        model_component_meta = self.jedi_rendering.render_interface_meta()
+        self.jedi_interface = model_component_meta['jedi_interface']
+
+        # Compute number of processors
+        # ----------------------------
+        self.np = eval(str(model_component_meta['total_processors']))
+
+        # Obtain and initialize proper error model
+        # ----------------------------------------
+        self.background_error_model = background_error_model
+        self.initialize_background()
+
+    # ----------------------------------------------------------------------------------------------
+
     def jedi_dictionary_iterator(self, jedi_config_dict: dict) -> None:
 
         # Loop over dictionary and replace if value is a dictionary
@@ -211,79 +286,5 @@ class GenerateBClimatology(taskBase):
 
         else:
             self.logger.info('YAML generated, now exiting.')
-
-    # ----------------------------------------------------------------------------------------------
-
-    def execute(self) -> None:
-        """ Creates B Matrix files for background error model(s):
-
-            - BUMP:
-             Creates bump files in 'cycle_dir' that depend upon the number of total
-             processors and active model components (sea-ice or no sea-ice).
-
-            - EXPLICIT_DIFFUSION:
-             Uses the methodology described in Weaver et al. (20xx). This requires
-             creating horizontal (offline) and vertical diffusion (online with irregular
-             frequency) parameter files. With SOCA, implementation, it is also required
-             to have horizontal length scales defined beforehand.
-
-        Parameters
-        ----------
-            All inputs are extracted from the JEDI experiment file configuration.
-            See the taskBase constructor for more information.
-        """
-
-        # Parse configuration
-        # -------------------
-        window_offset = self.config.window_offset()
-        window_type = self.config.window_type()
-        background_error_model = self.config.background_error_model()
-
-        swell_static_files_user = self.config.swell_static_files_user(None)
-        self.swell_static_files = self.config.swell_static_files()
-
-        # Use static_files_user if present in config and contains files
-        # -------------------------------------------------------------
-        if swell_static_files_user is not None and swell_static_files_user != 'None':
-            self.logger.info('swell_static_files_user specified, checking for files')
-            if check_if_files_exist_in_path(self.logger, swell_static_files_user):
-                self.logger.info(f'Using swell static files in {swell_static_files_user}')
-                self.swell_static_files = swell_static_files_user
-
-        self.horizontal_resolution = self.config.horizontal_resolution()
-        self.vertical_resolution = self.config.vertical_resolution()
-        self.generate_yaml_and_exit = self.config.generate_yaml_and_exit(False)
-
-        # Get the JEDI interface for this model component
-        # -----------------------------------------------
-        self.jedi_rendering.add_key('npx_proc', self.config.npx_proc(None))
-        self.jedi_rendering.add_key('npy_proc', self.config.npy_proc(None))
-        self.jedi_rendering.add_key('total_processors', self.config.total_processors(None))
-        self.jedi_rendering.add_key('analysis_variables', self.config.analysis_variables())
-        self.jedi_rendering.add_key('background_error_model', self.config.background_error_model())
-        self.jedi_rendering.add_key('marine_models', self.config.marine_models(None))
-        # Compute data assimilation window parameters
-        # -------------------------------------------
-        local_background_time = self.da_window_params.local_background_time(window_offset,
-                                                                            window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
-                                                                                    window_type)
-
-        # Background
-        # ----------
-        self.jedi_rendering.add_key('local_background_time', local_background_time)
-        self.jedi_rendering.add_key('local_background_time_iso', local_background_time_iso)
-
-        model_component_meta = self.jedi_rendering.render_interface_meta()
-        self.jedi_interface = model_component_meta['jedi_interface']
-
-        # Compute number of processors
-        # ----------------------------
-        self.np = eval(str(model_component_meta['total_processors']))
-
-        # Obtain and initialize proper error model
-        # ----------------------------------------
-        self.background_error_model = background_error_model
-        self.initialize_background()
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/get_coupled_geos_restart.py
+++ b/src/swell/tasks/get_coupled_geos_restart.py
@@ -1,0 +1,129 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+import os
+import glob
+
+from swell.tasks.base.task_base import taskBase
+from swell.utilities.file_system_operations import copy_to_dst_dir, check_if_files_exist_in_path
+
+# --------------------------------------------------------------------------------------------------
+
+
+class GetCoupledGeosRestart(taskBase):
+
+    # ----------------------------------------------------------------------------------------------
+
+    def execute(self) -> None:
+
+        """
+        Copies GEOS restart files from geos_expdir to the cycle forecast directory, which are:
+
+        - *_rst files (including the atmosphere restart file)
+        - iced.nc (CICE6 restart, mandatory)
+        - MOM.res.nc (MOM6 restart, mandatory)
+        - mom6_increment.nc (optional)
+
+        geos_expdir can be different from geos_homdir, in which case must be specified in the config
+        file. Not it can be absolute path, however MOM6 and CICE6 restarts are expected to be in
+        the RESTART subdirectory of geos_expdir.
+
+        xx) Creates HOMDIR and EXPDIR in the experiment/GEOSgcm directory
+        xx) Obtains files from geos_homdir OR geos_expdir according to user input
+        """
+
+        self.logger.info('Obtaining GEOS restarts for a coupled simulation')
+
+        # Get experiment directory where GEOS HOMDIR and EXPDIR will be cloned/linked
+        # ---------------------------------------------------
+        swell_exp_path = self.experiment_path()
+
+        # Obtain GEOS HOMDIR and EXPDIR from user input
+        self.geos_homdir = self.config.geos_homdir()
+        self.geos_expdir = self.geos_homdir
+
+        expdir_different = self.config.geos_expdir_different()
+
+        geos_homdir_path = os.path.join(swell_exp_path, 'GEOSgcm', 'GEOS_homdir')
+        if os.path.exists(self.geos_homdir):
+            self.logger.info('Linking GEOS HOMDIR to ' + geos_homdir_path)
+            # Check if link already exists, unlink first if it does
+            if os.path.lexists(geos_homdir_path):
+                os.unlink(geos_homdir_path)
+            os.symlink(self.geos_homdir, geos_homdir_path)
+            geos_expdir_path = geos_homdir_path
+        else:
+            self.logger.abort('GEOS_homdir directory does not exist: ' + self.geos_homdir)
+
+        # If expdir is set to be different to homdir, create a link to expdir and fail if it does not exist
+        if expdir_different:
+            self.expdir = self.config.geos_expdir()
+
+        if expdir_different and os.path.exists(self.geos_expdir):
+            geos_expdir_path = os.path.join(swell_exp_path, 'GEOSgcm', 'GEOS_expdir')
+            # Check if link already exists, unlink first if it does
+            if os.path.lexists(geos_expdir_path):
+                os.unlink(geos_expdir_path)
+            self.logger.info('Linking GEOS EXPDIR to ' + geos_expdir_path)
+            os.symlink(self.expdir, geos_expdir_path)
+        elif expdir_different and not os.path.exists(self.expdir):
+            self.logger.abort('GEOS_expdir directory does not exist: ' + self.expdir)
+
+        # Create forecast_dir and RESTART
+        # ----------------------------
+        if not os.path.exists(self.forecast_dir('RESTART')):
+            os.makedirs(self.forecast_dir('RESTART'), 0o755, exist_ok=True)
+
+        # Restarts should be in the EXPDIR or HOMDIR
+        # -----------------------------------------
+        self.initial_restarts(geos_expdir_path)
+
+    # ----------------------------------------------------------------------------------------------
+
+    def initial_restarts(self, geos_expdir_path: str) -> None:
+
+        # GEOS forecast checkpoint files are created in advance
+        # -------------------------------------------------------------------
+        self.logger.info('GEOS restarts are copied')
+
+        src = os.path.join(geos_expdir_path, '*_rst')
+
+        for filepath in list(glob.glob(src)):
+            filename = os.path.basename(filepath)
+            copy_to_dst_dir(self.logger, filepath, self.forecast_dir(filename))
+
+        # Create a dictionary of src/dst for the single files
+        # Special handling of CICE6 and MOM6 outputs
+        # ---------------------------------------------------
+        src_dst = {'RESTART/iced.nc': '',
+                   }
+
+        # Create a dictionary for optional src/dst for the single files, and combine them with the
+        # src_dst dictionary if they exist
+        src_dst_optional = {'RESTART/mom6_increment.nc': ''
+                            }
+
+        for src, dst in src_dst_optional.items():
+            if os.path.isfile(os.path.join(geos_expdir_path, src)):
+                self.logger.info(' Found optional file: ' + src)
+                src_dst.update({src: dst})
+
+        for src, dst in src_dst.items():
+            dst = os.path.join(dst, src)
+            copy_to_dst_dir(self.logger, os.path.join(geos_expdir_path, src), self.forecast_dir(dst))
+
+        # Consider the case of multiple MOM restarts
+        # -------------------------------------------
+        src = os.path.join(geos_expdir_path, 'RESTART', 'MOM.res*nc')
+
+        for filepath in list(glob.glob(src)):
+            filename = os.path.basename(filepath)
+            copy_to_dst_dir(self.logger, filepath, self.forecast_dir(['RESTART', filename]))
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/get_coupled_geos_restart.py
+++ b/src/swell/tasks/get_coupled_geos_restart.py
@@ -48,6 +48,9 @@ class GetCoupledGeosRestart(taskBase):
         self.geos_homdir = self.config.geos_homdir()
         self.geos_expdir = self.geos_homdir
 
+        # Create GEOSgcm directory in the experiment folder if it does not exist yet
+        os.makedirs(os.path.join(swell_exp_path, 'GEOSgcm'), 0o755, exist_ok=True)
+
         expdir_different = self.config.geos_expdir_different()
 
         geos_homdir_path = os.path.join(swell_exp_path, 'GEOSgcm', 'GEOS_homdir')

--- a/src/swell/tasks/get_observations.py
+++ b/src/swell/tasks/get_observations.py
@@ -377,23 +377,22 @@ class GetObservations(taskBase):
     # Get the target data from the netcdf file
     # ----------------------------------------
     def get_data(self, input_file: str, group: str, var_name: str) -> object:
-        with nc.Dataset(input_file, 'r') as ds:
-            return ds[group][var_name][:]
+        """Returns None if group or variable doesn't exist"""
+        try:
+            with nc.Dataset(input_file, 'r') as ds:
+                if group in ds.groups and var_name in ds[group].variables:
+                    return ds[group][var_name][:]
+                return None
+        except Exception as e:
+            self.logger.warning(f"Error reading {var_name} from {group} in {input_file}: {e}")
+            return None
 
     # ----------------------------------------------------------------------------------------------
 
     def read_and_combine(self, input_filenames: list, output_filename: str) -> None:
         '''
         Combines multiple IODA v3 netcdf input files into a single output.
-        Combining multiple files require final (total) location dimension size to be
-        calculated in advance.
-
-        Basically, this function creates an output file that duplicates the first
-        input file's attributes and then fills with appended data from the input files.
-
-        Channel dimension shows up as a second dimension and sometimes as a single
-        dimension. Both cases require special handling and introduces additional
-        exceptions to the code. Final channel dimension size remains the same.
+        Handles missing variables gracefully by only combining variables present in at least one file.
         '''
 
         # Create a new file for writing, remove the file if it already exists
@@ -406,10 +405,24 @@ class GetObservations(taskBase):
         # -------------------------------------------------------------
         existing_files = [f for f in input_filenames if os.path.exists(f)]
         input_filenames = existing_files
+        
+        if not input_filenames:
+            self.logger.error("No valid input files found")
+            return
 
-        # Loop through the input files and get the total dimension size for each dimension
-        # Location requires special handling to get the cumulative sum of the dimension size
-        # ---------------------------------------------------------------------------------
+        # Collect all unique variables across all files
+        # ----------------------------------------------
+        all_variables = {}  # {group_name: set of variable names}
+        
+        for input_filename in input_filenames:
+            with nc.Dataset(input_filename, 'r') as ds:
+                for group_name in ds.groups.keys():
+                    if group_name not in all_variables:
+                        all_variables[group_name] = set()
+                    all_variables[group_name].update(ds[group_name].variables.keys())
+
+        # Loop through the input files and get the total dimension size
+        # --------------------------------------------------------------
         out_dim_size = {'Location': 0}
         for input_filename in input_filenames:
             with nc.Dataset(input_filename, 'r') as ds:
@@ -420,15 +433,13 @@ class GetObservations(taskBase):
                         out_dim_size[dim_name] = dim.size
 
         with nc.Dataset(output_filename, 'w') as out_ds:
-            # Open the input NetCDF files for reading
-            # ---------------------------------------
-            self.logger.info(f"Combining files {input_filenames} ")
+            self.logger.info(f"Combining files {input_filenames}")
 
             # Create an output file template based on the first input file
             # ------------------------------------------------------------
             with nc.Dataset(input_filenames[0], 'r') as ds:
-                # Access groups and create dimensions
-                # -----------------------------------
+                # Create dimensions
+                # ----------------
                 input_groups = ds.groups.keys()
 
                 for dim_name, dim in ds.dimensions.items():
@@ -437,52 +448,90 @@ class GetObservations(taskBase):
                 # Loop through groups and process variables
                 # -----------------------------------------
                 for group_name in input_groups:
-                    group = ds[group_name]
-
                     # Create the groups in output file
                     # --------------------------------
                     out_group = out_ds.createGroup(group_name)
 
-                    # Access variables within a group
-                    # -------------------------------
-                    variables_in_group = group.variables.keys()
-
-                    # Loop over variables from input files, combine, and write to the new file
-                    # ------------------------------------------------------------------------
-                    for var_name in variables_in_group:
+                    # Process all variables that exist in ANY file for this group
+                    # -----------------------------------------------------------
+                    for var_name in all_variables.get(group_name, []):
                         list_data = []
+                        var_dims = None
+                        var_dtype = None
+                        fill_value = None
+                        attributes = {}
 
-                        # Get the dimensions of the variable
-                        # ----------------------------------
-                        var_dims = group[var_name].dimensions
-
-                        # Loop over all the files and combine the variable data into a list
-                        # Channel dimensions remain the same, so we can break the loop
-                        # ----------------------------------------------------------------
+                        # Find the first file that has this variable to get metadata
+                        # ----------------------------------------------------------
+                        reference_file = None
                         for input_file in input_filenames:
-                            list_data.append(self.get_data(input_file, group_name, var_name))
+                            with nc.Dataset(input_file, 'r') as check_ds:
+                                if group_name in check_ds.groups and var_name in check_ds[group_name].variables:
+                                    reference_file = input_file
+                                    ref_var = check_ds[group_name][var_name]
+                                    var_dims = ref_var.dimensions
+                                    var_dtype = ref_var.dtype
+                                    if hasattr(ref_var, '_FillValue'):
+                                        fill_value = ref_var.getncattr('_FillValue')
+                                    for attr_name in ref_var.ncattrs():
+                                        if attr_name != '_FillValue':
+                                            attributes[attr_name] = ref_var.getncattr(attr_name)
+                                    break
+
+                        if reference_file is None:
+                            self.logger.warning(f"Variable {var_name} not found in any file for group {group_name}")
+                            continue
+
+                        # Collect data from all files
+                        # ---------------------------
+                        for input_file in input_filenames:
+                            data = self.get_data(input_file, group_name, var_name)
+
+                            if data is not None:
+                                list_data.append(data)
+                            else:
+                                # Create masked array of appropriate size with all values masked
+                                with nc.Dataset(input_file, 'r') as ds:
+                                    if 'Location' in ds.dimensions:
+                                        loc_size = ds.dimensions['Location'].size
+                                        # Create appropriately shaped masked array
+                                        if len(var_dims) == 1:
+                                            masked_data = np.ma.masked_all(loc_size, dtype=var_dtype)
+                                        else:
+                                            # Handle multi-dimensional variables
+                                            shape = [loc_size] + [ds.dimensions[d].size for d in var_dims[1:]]
+                                            masked_data = np.ma.masked_all(shape, dtype=var_dtype)
+                                        list_data.append(masked_data)
+
                             # Only break if the first dimension is Channel
                             if var_dims[0] == 'Channel':
                                 break
 
-                        # Concatenate the masked arrays along the first dimension
-                        # --------------------------------------------------------
-                        variable_data = np.ma.concatenate(list_data, axis=0)
+                        if not list_data:
+                            self.logger.warning(f"No data collected for {var_name} in {group_name}")
+                            continue
 
-                        # Fill value needs to be assigned while creating variables
-                        # --------------------------------------------------------
+                        # Concatenate the masked arrays
+                        # -----------------------------
+                        try:
+                            variable_data = np.ma.concatenate(list_data, axis=0)
+                        except Exception as e:
+                            self.logger.error(f"Error concatenating {var_name}: {e}")
+                            continue
+
+                        # Create variable in output file
+                        # ------------------------------
                         subset_var = out_group.createVariable(var_name,
-                                                              variable_data.dtype,
-                                                              var_dims,
-                                                              fill_value=group[var_name].
-                                                              getncattr('_FillValue'))
-                        for attr_name in group[var_name].ncattrs():
-                            if attr_name == '_FillValue':
-                                continue
-                            subset_var.setncattr(attr_name, group[var_name].getncattr(attr_name))
+                                                            variable_data.dtype,
+                                                            var_dims,
+                                                            fill_value=fill_value)
 
-                        # Write subset data to the new file
-                        # --------------------------------
+                        # Set attributes
+                        for attr_name, attr_value in attributes.items():
+                            subset_var.setncattr(attr_name, attr_value)
+
+                        # Write data to the new file
+                        # --------------------------
                         subset_var[:] = variable_data
-
+                        self.logger.info(f"Combined {var_name} from {len(list_data)} files")
 # ----------------------------------------------------------------------------------------------

--- a/src/swell/tasks/link_coupled_geos_output.py
+++ b/src/swell/tasks/link_coupled_geos_output.py
@@ -1,0 +1,252 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+from datetime import datetime as dt
+import isodate
+import os
+from netCDF4 import Dataset
+import numpy as np
+import xarray as xr
+from typing import Tuple
+
+from swell.utilities.datetime_util import datetime_formats
+from swell.tasks.base.task_base import taskBase
+
+# --------------------------------------------------------------------------------------------------
+
+
+class LinkCoupledGeosOutput(taskBase):
+
+    # ----------------------------------------------------------------------------------------------
+
+    def execute(self) -> None:
+
+        """
+        Linking proper GEOS output files for JEDI to ingest and produce analysis.
+        This will depend on the model type (ocean and sea-ice), model output
+        type (history vs. restart), DA method, and window length.
+        """
+
+        # Parse configuration
+        # -------------------
+        self.marine_models = self.config.marine_models(None) or []
+        self.window_type = self.config.window_type()
+        self.window_length = self.config.window_length()
+        self.window_offset = self.config.window_offset()
+        self.window_begin_iso = self.da_window_params.window_begin_iso(self.window_offset)
+
+        if self.window_type == '4D' or 'fgat' in self.suite_name():
+            self.background_frequency = self.config.background_frequency()
+
+        self.bkgr_time_iso, self.bkgr_time_dto = self.da_window_params.local_background_time(
+            self.window_offset,
+            self.window_type,
+            dto=True)
+
+        # Create source and destination files for linking model output to cycle directories
+        # -----------------------------------------------------------------------------------
+        self.src_dst_dict = {}
+
+        if self.get_model() in ('geos_marine'):
+            if self.window_type == '4D' or 'fgat' in self.suite_name():
+                self.link_mom6_history_4d()
+            else:
+                self.link_mom6_history_3d()
+
+            if 'cice6' in self.marine_models:
+                if self.window_type == '4D' or 'fgat' in self.suite_name():
+                    self.link_cice6_history_4d()
+                else:
+                    self.link_cice6_history_3d()
+
+                # Generic CICE6 rst file format for SOCA, this file will be
+                # used for the SOCA2CICE task
+                # TODO: Could use the proper background time for iced.nc with the
+                # checkpoint dumps
+                # ------------------------------------------------------
+                src = self.forecast_dir(['scratch', 'RESTART', 'iced.nc'])
+                dst = 'iced.res.' + self.bkgr_time_iso + '.nc'
+                self.src_dst_dict[src] = dst
+
+        # Loop through the dictionary and create links
+        for src, dst in self.src_dst_dict.items():
+            self.geos.linker(src, dst, self.cycle_dir())
+
+    # ----------------------------------------------------------------------------------------------
+
+    def link_mom6_history_4d(self) -> None:
+        # Creating links to GEOS history, MOM6, for SOCA inputs
+        # Depending on the DA type, there could be multiple state files to link
+        # -----------------------------------------------------------------------
+        states = self.geos.states_generator(self.background_frequency, self.window_length,
+                                            self.window_begin_iso, self.get_model(),
+                                            self.marine_models)
+
+        # Get date information from the states dictionary, and use ocn_filename to get the
+        # destination file name
+        for state in states:
+            date = dt.strptime(state['date'], datetime_formats['iso_format'])
+            src = self.forecast_dir('scratch/his_' + date.strftime('%Y_%m_%d_%H') + '.nc')
+            dst = state['ocn_filename']
+            self.src_dst_dict[src] = dst
+
+        # Add the background (beginning of the window) file
+        src = self.forecast_dir('scratch/his_' + self.bkgr_time_dto.strftime('%Y_%m_%d_%H') + '.nc')
+        dst = 'MOM6.res.' + self.bkgr_time_iso + '.nc'
+
+        # Append dst to the dictionary
+        self.src_dst_dict[src] = dst
+
+    # ----------------------------------------------------------------------------------------------
+
+    def link_mom6_history_3d(self) -> None:
+        # Using a 3D window and hence the background is a single file, in the
+        # middle of the DA window
+        src = self.forecast_dir('scratch/his_' + self.bkgr_time_dto.strftime('%Y_%m_%d_%H') + '.nc')
+        dst = 'MOM6.res.' + self.bkgr_time_iso + '.nc'
+
+        # Append dst to the dictionary
+        self.src_dst_dict[src] = dst
+
+    # ----------------------------------------------------------------------------------------------
+
+    def cice6_history_formatter(self,
+                                src_date: dt,
+                                hour_prefix: str,
+                                ) -> str:
+
+        # Extract the date part and calculate seconds for the src_history format
+        date_str = src_date.strftime('%Y-%m-%d')
+        seconds = src_date.hour * 3600 + src_date.minute * 60 + src_date.second
+
+        return self.forecast_dir(f'scratch/iceh_{hour_prefix}.{date_str}-{seconds:05d}.nc')
+
+    # ----------------------------------------------------------------------------------------------
+
+    def cice6_history_hour_prefix(self,
+                                  background_frequency: str = 'PT3H',
+                                  ) -> str:
+        # There is no background_frequency for 3D window so we set PT3H
+        # as the default. This is defined in CICE6 input file, ice_in
+        # -------------------------------------------------------------------
+        # TODO: A safer alternative would be to get this information from ice_in (nml)
+        # but the format is not consistent and varies according to output frequency
+        # histfreq       = 'h','x','x','x','x'
+        # histfreq_n     =  3 , 1 , 1 , 1 , 1
+
+        # Convert background frequency to 02d format
+        duration = isodate.parse_duration(background_frequency)
+        hist_hours, remainder = divmod(duration.total_seconds(), 60*60)
+
+        return f'{int(hist_hours):02d}h'
+
+    # ----------------------------------------------------------------------------------------------
+
+    def link_cice6_history_4d(self) -> None:
+        # Creating links to GEOS history, CICE6, for SOCA inputs
+        # Depending on the DA type, there could be multiple state files to link
+        # -----------------------------------------------------------------------
+        states = self.geos.states_generator(self.background_frequency, self.window_length,
+                                            self.window_begin_iso, self.get_model(),
+                                            self.marine_models)
+
+        hour_prefix = self.cice6_history_hour_prefix(self.background_frequency)
+
+        # Get date information from the states dictionary, and use ocn_filename to get the
+        # destination file name
+        for state in states:
+            src_date = dt.strptime(state['date'], datetime_formats['iso_format'])
+            src_history = self.cice6_history_formatter(src_date, hour_prefix)
+            dst_history = os.path.join(self.cycle_dir(), state['ice_filename'])
+            self.prepare_cice6_history(src_history, dst_history)
+
+        # Using a 4D window; CICE6 background is at the beginning of the window
+        src_history = self.cice6_history_formatter(self.bkgr_time_dto, hour_prefix)
+        dst_history = os.path.join(self.cycle_dir(), 'cice.res.' + self.bkgr_time_iso + '.nc')
+
+        self.prepare_cice6_history(src_history, dst_history)
+
+    # ----------------------------------------------------------------------------------------------
+
+    def link_cice6_history_3d(self) -> None:
+        # Using a 3D window; CICE6 background is in the middle of the window
+        hour_prefix = self.cice6_history_hour_prefix()
+        src_history = self.cice6_history_formatter(self.bkgr_time_dto, hour_prefix)
+        dst_history = os.path.join(self.cycle_dir(), 'cice.res.' + self.bkgr_time_iso + '.nc')
+
+        self.prepare_cice6_history(src_history, dst_history)
+
+    # ----------------------------------------------------------------------------------------------
+
+    def prepare_cice6_history(self,
+                              src_history: str,
+                              dst_history: str,
+                              ) -> None:
+
+        # Since history already has the aggregated variables, we just need to rename
+        # the dimensions and variables to match SOCA requirements
+        ds = xr.open_dataset(src_history)
+
+        # rename the dimensions to xaxis_1 and yaxis_1 and rename the variables
+        ds = ds.rename({'ni': 'xaxis_1', 'nj': 'yaxis_1'})
+        ds = ds.rename({'aice': 'aice_h', 'hi': 'hi_h', 'hs': 'hs_h'})
+
+        # Save as a new file
+        ds.to_netcdf(dst_history, mode='w')
+
+    # ----------------------------------------------------------------------------------------------
+
+    def prepare_cice6_restart(self) -> Tuple[str, str]:
+        # CICE6 input in SOCA requires aggregation of multiple variables and
+        # time dimension added to the dataset.
+        # SOCA needs icea area (aicen), ice volume (vicen), and snow area (vsnon)
+        # --------------------------------------------------------------------
+        soca2cice_vars = {'aice_h': 'aicen',
+                          'hi_h': 'vicen',
+                          'hs_h': 'vsnon'}
+
+        # read CICE6 restart
+        # -----------------
+        ds = xr.open_dataset(self.forecast_dir(['scratch', 'RESTART', 'iced.nc']))
+        nj = np.shape(ds['aicen'])[1]
+        ni = np.shape(ds['aicen'])[2]
+
+        # populate xarray with aggregated quantities
+        # ------------------------------------------
+        aggds = xr.merge(xr.DataArray(
+                        name=varname,
+                        data=np.reshape(np.sum(ds[soca2cice_vars[varname]].values, axis=0),
+                                        (1, nj, ni)),
+                        dims=['time', 'yaxis_1', 'xaxis_1']) for varname in soca2cice_vars.keys())
+
+        # remove fill value
+        # -----------------
+        encoding = {varname: {'_FillValue': False} for varname in soca2cice_vars.keys()}
+
+        fname_out = os.path.join(self.cycle_dir(), 'cice.res.' + self.bkgr_time_iso + '.nc')
+
+        # save datasets
+        # -------------
+        aggds.to_netcdf(fname_out, format='NETCDF4', unlimited_dims='time', encoding=encoding)
+
+        # xarray doesn't allow variables and dim that have the same name, switch to netCDF4
+        # ---------------------------------------------------------------------------------
+        ncf = Dataset(fname_out, 'a')
+        t = ncf.createVariable('time', 'f8', ('time'))
+        t[:] = 1.0
+        ncf.close()
+
+        # Generic CICE6 rst file source format for SOCA
+        # ---------------------------------------
+        src = self.forecast_dir(['scratch', 'RESTART', 'iced.nc'])
+        dst = 'iced.res.' + self.bkgr_time_iso + '.nc'
+
+        return src, dst
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/move_erase_da_restart.py
+++ b/src/swell/tasks/move_erase_da_restart.py
@@ -8,8 +8,10 @@
 # --------------------------------------------------------------------------------------------------
 
 import glob
+import isodate
 import os
 import re
+import shutil
 from typing import Union
 
 from swell.tasks.base.task_base import taskBase
@@ -18,7 +20,7 @@ from swell.utilities.file_system_operations import move_files
 # --------------------------------------------------------------------------------------------------
 
 
-class MoveDaRestart(taskBase):
+class MoveEraseDaRestart(taskBase):
 
     # ----------------------------------------------------------------------------------------------
 
@@ -40,33 +42,24 @@ class MoveDaRestart(taskBase):
         # ----------------------
         self.mom6_iau = self.config.mom6_iau()
 
-        # Next forecast directory
-        # -----------------------
-        self.next_forecast_dir = self.geos.adjacent_cycle(self.config.window_length())
-
-        # Create cycle_dir and INPUT
+        # Create cycle_dir and RESTART
         # ----------------------------
-        if not os.path.exists(self.at_next_fcst_dir('INPUT')):
-            os.makedirs(self.at_next_fcst_dir('INPUT'), 0o755, exist_ok=True)
+        if not os.path.exists(self.next_forecast_dir('RESTART')):
+            os.makedirs(self.next_forecast_dir('RESTART'), 0o755, exist_ok=True)
 
-        # Move and rename files
-        # ----------------------
+        # Move and rename files in the next forecast directory
+        # ----------------------------------------------
         self.cycling_restarts()
-        self.geos.rename_checkpoints(self.next_forecast_dir)
+        self.geos.rename_checkpoints(self.next_forecast_dir())
 
-    # ----------------------------------------------------------------------------------------------
-
-    def at_next_fcst_dir(self, paths: Union[str, list]) -> str:
-
-        # Ensure what we have is a list (paths should be a list)
-        # ------------------------------------------------------
-        if isinstance(paths, str):
-            paths = [paths]
-
-        # Combining list of paths with cycle dir for script brevity
-        # ---------------------------------------------------------
-        full_path = os.path.join(self.next_forecast_dir, *paths)
-        return full_path
+        # Remove forecast_dir and rename next_forecast_dir to forecast_dir
+        self.logger.info('Erasing current forecast dir and renaming next forecast dir to it')
+        try:
+            if os.path.exists(self.forecast_dir()):
+                shutil.rmtree(self.forecast_dir())
+            os.rename(self.next_forecast_dir(), self.forecast_dir())
+        except Exception as e:
+            self.logger.abort(f'Failed to move directory: {e}')
 
     # ----------------------------------------------------------------------------------------------
 
@@ -76,7 +69,7 @@ class MoveDaRestart(taskBase):
         # ------------------------------------------------------
         self.logger.info('GEOS restarts are being moved to the next forecast dir')
 
-        src = self.forecast_dir('*_checkpoint')
+        src = self.forecast_dir(['scratch', '*_checkpoint'])
 
         # This alternate source format corresponds to optional use of Restart Record
         # parameters in AGCM.rc
@@ -84,25 +77,26 @@ class MoveDaRestart(taskBase):
         agcm_dict = self.geos.parse_rc(self.forecast_dir('AGCM.rc'))
 
         if 'RECORD_FREQUENCY' in agcm_dict:
+            # We want to use rst_dto at the beginning of the DA window (window offset is negative)
+            # ---------------------------------------------------------
             an_fcst_offset = self.config.analysis_forecast_window_offset()
-            rst_dto = self.geos.adjacent_cycle(an_fcst_offset, return_date=True)
-
+            rst_dto = self.cycle_time_dto() + isodate.parse_duration(an_fcst_offset)
             self.logger.info('Using _checkpoint restarts with timestamps')
-            src = self.forecast_dir(rst_dto.strftime('*_checkpoint.%Y%m%d_%H%Mz.nc4'))
+            src = self.forecast_dir(['scratch', rst_dto.strftime('*_checkpoint.%Y%m%d_%H%Mz.nc4')])
 
         for filepath in list(glob.glob(src)):
             filename = os.path.basename(filepath).split('.')[0]
-            move_files(self.logger, filepath, self.at_next_fcst_dir(filename))
+            move_files(self.logger, filepath, self.next_forecast_dir(filename))
 
         # Create a dictionary of src/dst for the single files
         # ---------------------------------------------------
-        src_dst = {'tile.bin': '',
-                   'RESTART/iced.nc': 'INPUT',
+        src_dst = {'scratch/tile.bin': '',
+                   'scratch/RESTART/iced.nc': 'RESTART',
                    }
 
         for src, dst in src_dst.items():
             dst = os.path.join(dst, os.path.basename(src))
-            move_files(self.logger, self.forecast_dir(src), self.at_next_fcst_dir(dst))
+            move_files(self.logger, self.forecast_dir(src), self.next_forecast_dir(dst))
 
         # Having multiple restart outputs in MOM6 is hard coded and inevitable for high res
         # simulations. MOM restart for the next cycle should be at the beginning of the
@@ -115,33 +109,37 @@ class MoveDaRestart(taskBase):
 
         if 'RECORD_FREQUENCY' in agcm_dict:
 
+            # We want to use rst_dto at the beginning of the DA window (window offset is negative)
+            # ---------------------------------------------------------
             an_fcst_offset = self.config.analysis_forecast_window_offset()
-            rst_dto = self.geos.adjacent_cycle(an_fcst_offset, return_date=True)
+            rst_dto = self.cycle_time_dto() + isodate.parse_duration(an_fcst_offset)
             seconds = rst_dto.hour * 3600 + rst_dto.minute * 60 + rst_dto.second
 
             # Ensure seconds is a string with 5 digits
             seconds_str = f"{seconds:05d}"
-            rst_files = self.forecast_dir(['RESTART', rst_dto.strftime('MOM.res_Y%Y_D%j_S')
-                                           + seconds_str + '*.nc'])
+            rst_pattern = rst_dto.strftime('MOM.res_Y%Y_D%j_S') + seconds_str + '*.nc'
+            rst_files = os.path.join(self.forecast_dir('scratch/RESTART'), rst_pattern)
 
             for filepath in list(glob.glob(rst_files)):
                 filename = os.path.basename(filepath)
 
                 # Use re.sub to remove the time pattern from the string
                 # -----------------------------------------------------
-                filenext = re.sub(rst_dto.strftime('_Y%Y_D%j_S') + seconds_str, "", filename)
+                time_pattern = rst_dto.strftime('_Y%Y_D%j_S') + seconds_str
+                filenext = re.sub(time_pattern, "", filename)
 
+                dst_path = os.path.join(self.next_forecast_dir('RESTART'), filenext)
                 src_dst_dict.update({
-                        filepath: self.at_next_fcst_dir(['INPUT', filenext]),
+                        filepath: dst_path,
                 })
 
         else:
-            rst_files = self.forecast_dir(['RESTART', 'MOM.res*nc'])
+            rst_files = self.forecast_dir(['scratch', 'RESTART', 'MOM.res*nc'])
 
             for filepath in list(glob.glob(rst_files)):
                 filename = os.path.basename(filepath)
                 src_dst_dict.update({
-                        filepath: self.at_next_fcst_dir(['INPUT', filename]),
+                        filepath: self.next_forecast_dir(['RESTART', filename]),
                 })
 
         # If the src/dst dict is empty, abort run as something is messed up
@@ -155,7 +153,7 @@ class MoveDaRestart(taskBase):
         if (self.mom6_iau):
             src_dst_dict.update({
                 os.path.join(self.cycle_dir(), 'mom6_increment.nc'):
-                    self.at_next_fcst_dir(['INPUT', 'mom6_increment.nc'])
+                    self.next_forecast_dir(['RESTART', 'mom6_increment.nc'])
             })
 
         for src, dst in src_dst_dict.items():

--- a/src/swell/tasks/move_erase_forecast_restart.py
+++ b/src/swell/tasks/move_erase_forecast_restart.py
@@ -17,7 +17,7 @@ from swell.utilities.file_system_operations import move_files
 # --------------------------------------------------------------------------------------------------
 
 
-class MoveForecastRestart(taskBase):
+class MoveEraseForecastRestart(taskBase):
 
     # ----------------------------------------------------------------------------------------------
 
@@ -32,31 +32,26 @@ class MoveForecastRestart(taskBase):
         # Next cycle folder name
         # -----------------------
         self.forecast_duration = self.config.forecast_duration()
-        self.next_forecast_dir = self.geos.adjacent_cycle(self.forecast_duration)
 
-        # Create cycle_dir and INPUT
+        # Create cycle_dir and RESTART
         # ----------------------------
-        if not os.path.exists(self.at_next_fcst_dir('INPUT')):
-            os.makedirs(self.at_next_fcst_dir('INPUT'), 0o755, exist_ok=True)
+        if not os.path.exists(self.next_forecast_dir('RESTART')):
+            os.makedirs(self.next_forecast_dir('RESTART'), 0o755, exist_ok=True)
 
         # Move and rename files
         # ----------------------
         self.cycling_restarts()
-        self.geos.rename_checkpoints(self.next_forecast_dir)
+        self.geos.rename_checkpoints(self.next_forecast_dir())
 
-    # ----------------------------------------------------------------------------------------------
-
-    def at_next_fcst_dir(self, paths: Union[str, list]) -> str:
-
-        # Ensure what we have is a list (paths should be a list)
-        # ------------------------------------------------------
-        if isinstance(paths, str):
-            paths = [paths]
-
-        # Combining list of paths with cycle dir for script brevity
-        # ---------------------------------------------------------
-        full_path = os.path.join(self.next_forecast_dir, *paths)
-        return full_path
+        # Remove forecast_dir and rename next_forecast_dir to forecast_dir
+        # --------------------------------------------------------------
+        self.logger.info('Erasing current forecast dir and renaming next forecast dir to it')
+        try:
+            if os.path.exists(self.forecast_dir()):
+                shutil.rmtree(self.forecast_dir())
+            os.rename(self.next_forecast_dir(), self.forecast_dir())
+        except Exception as e:
+            self.logger.abort(f'Failed to move directory: {e}')
 
     # ----------------------------------------------------------------------------------------------
 
@@ -67,30 +62,28 @@ class MoveForecastRestart(taskBase):
         self.logger.info('GEOS restarts are being moved to the next forecast dir')
         self.logger.info('Finding _checkpoint restarts')
 
-        src = self.forecast_dir('*_checkpoint')
+        src = self.forecast_dir('scratch', '*_checkpoint')
 
         for filepath in list(glob.glob(src)):
             filename = os.path.basename(filepath).split('.')[0]
-            move_files(self.logger, filepath, self.at_next_fcst_dir(filename))
+            move_files(self.logger, filepath, self.next_forecast_dir(filename))
 
         # Create a dictionary of src/dst for the single files
         # ---------------------------------------------------
-        src_dst = {'tile.bin': '',
-                   'RESTART/iced.nc': 'INPUT',
+        src_dst = {'scratch/tile.bin': '',
+                   'scratch/RESTART/iced.nc': 'RESTART',
                    }
 
         for src, dst in src_dst.items():
             dst = os.path.join(dst, os.path.basename(src))
-            move_files(self.logger, self.forecast_dir(src), self.at_next_fcst_dir(dst))
+            move_files(self.logger, self.forecast_dir(src), self.next_forecast_dir(dst))
 
         # Consider the case of multiple MOM restarts
-        # TODO: this could be forced to be a single file (MOM_input option)
-        # so wildcard character can be omitted.
         # -----------------------------------------------------------------
-        src = self.forecast_dir(['RESTART', 'MOM.res*nc'])
+        src = self.forecast_dir(['scratch', 'RESTART', 'MOM.res*nc'])
 
         for filepath in list(glob.glob(src)):
             filename = os.path.basename(filepath)
-            move_files(self.logger, filepath, self.at_next_fcst_dir(['INPUT', filename]))
+            move_files(self.logger, filepath, self.next_forecast_dir(['FORECAST', filename]))
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/prep_coupled_geos_run_dir.py
+++ b/src/swell/tasks/prep_coupled_geos_run_dir.py
@@ -45,8 +45,13 @@ class PrepCoupledGeosRunDir(taskBase):
 
         # These links were created in get_*_geos_restart task. This step will copy experiment
         # config.s to the cycle forecast directory
+        # In some cases geos_homdir and geos_expdir are different, so we need to address that
         self.geos_homdir = os.path.join(self.experiment_path(), 'GEOSgcm', 'GEOS_homdir')
-        self.geos_expdir = os.path.join(self.experiment_path(), 'GEOSgcm', 'GEOS_expdir')
+        self.geos_expdir = self.geos_homdir
+
+        expdir_different = self.config.geos_expdir_different()
+        if expdir_different:
+            self.geos_expdir = os.path.join(self.experiment_path(), 'GEOSgcm', 'GEOS_expdir')
 
         self.geos_build = self.config.existing_geos_gcm_build_path()
 

--- a/src/swell/tasks/prep_coupled_geos_run_dir.py
+++ b/src/swell/tasks/prep_coupled_geos_run_dir.py
@@ -1,0 +1,267 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+import os
+import isodate
+import glob
+import yaml
+import json
+import re
+
+from datetime import datetime as dt
+
+from swell.tasks.base.task_base import taskBase
+from swell.utilities.file_system_operations import copy_to_dst_dir, check_if_files_exist_in_path
+
+# --------------------------------------------------------------------------------------------------
+
+
+class PrepCoupledGeosRunDir(taskBase):
+
+    # ----------------------------------------------------------------------------------------------
+
+    def execute(self) -> None:
+
+        """
+        Copies GEOS HOMDIR files to the cycle forecast directory to prepare before executing gcm_run.j.
+        Modifies certain resource files using python's re package according to cycle_date such as:
+        CAP.rc, AGCM.rc, input.nml, and gcm_run.j.
+
+        As the name suggests, this task is geared towards coupled GEOSgcm simulations but the only
+        difference should be in the get_static() method.
+
+        xx) Changes HOMDIR and EXPDIR in gcm_run.j to point to the forecast directory
+        xx) Provides consistency for GEOSgcm version by copying GEOSgcm.x from EXPDIR
+        xx) (Optional) Checks GEOSDIR, GEOSBIN, GEOSETC, GEOSUTIL are consistent with experiment.yaml
+        value if the override switch is on
+        xx) Modifies CAP.rc according to cycle_date and forecast_duration
+        """
+
+        # These links were created in get_*_geos_restart task. This step will copy experiment
+        # config.s to the cycle forecast directory
+        self.geos_homdir = os.path.join(self.experiment_path(), 'GEOSgcm', 'GEOS_homdir')
+        self.geos_expdir = os.path.join(self.experiment_path(), 'GEOSgcm', 'GEOS_expdir')
+
+        self.geos_build = self.config.existing_geos_gcm_build_path()
+
+        self.logger.info('Preparing GEOS Forecast directory')
+        self.logger.info('Some steps involve modifying input files and replacing')
+        self.logger.info(' file contents. Users are encouraged to validate file modifications.')
+
+        # Forecast start time can be calculated from cycle_date and forecast_duration
+        # This task doesn't have access to DA window lengths since it could be used without the DA
+        # context. So forecast start will be assigned as cycle_date - forecast_duration * 3/4
+        # Need to convert forecast_duration to a datetime object first
+        # -------------------------------------------------------------
+        self.forecast_duration = self.config.forecast_duration()
+        self.fc_dto = self.cycle_time_dto() - isodate.parse_duration(self.forecast_duration) * 3 / 4
+
+        # Get static files
+        # ----------------
+        self.get_static()
+
+        # Augment MOM_oda_incupd (IAU) with MOM_input IF mom6_iau is true and IF mom6_increment.nc
+        # file is located inside the INPUT directory. At the first cycle, mom6_increment.nc may not
+        # be present in the INPUT directory, so this step is skipped.
+        # --------------------------------------------------------------------------
+        if self.config.get_key_for_model('mom6_iau', 'geos_marine', False):
+            if os.path.exists(self.forecast_dir('RESTART/mom6_increment.nc')):
+
+                self.logger.info('MOM6 Increment file found in RESTART directory')
+                self.logger.info('Augmenting MOM_oda_incupd with MOM_input')
+
+                mom_input = self.forecast_dir('MOM_input')
+                mom_oda_incupd = self.forecast_dir('MOM_oda_incupd')
+                mom6_config = self.geos.parse_mom6_input(mom_oda_incupd)
+                # P50D is just a random input for get_key_for_model to function
+                mom6_iau_nhours = self.config.get_key_for_model('mom6_iau_nhours', 'geos_marine',
+                                                                'PT50D')
+
+                # convert ISO to 3.0
+                duration = isodate.parse_duration(mom6_iau_nhours)
+                hours = duration.total_seconds() / 3600
+                mom6_config["ODA_INCUPD_NHOURS"] = hours
+
+                # Write the updated configuration back to a file
+                output_path = self.forecast_dir('MOM_oda_incupd')
+                self.geos.write_mom6_input(mom6_config, output_path)
+
+                with open(mom_input, 'r') as inp_f, open(mom_oda_incupd, 'r') as append_f:
+                    mom_input_txt = inp_f.read()
+                    mom_oda_txt = append_f.read()
+
+                with open(mom_input, 'w') as out_f:
+                    out_f.write(mom_input_txt + mom_oda_txt)
+            else:
+                self.logger.warning('MOM6 Increment file was not found in RESTART directory')
+
+        # Modify input.nml if not cold start (default)
+        # --------------------------------------------
+        self.geos.process_nml()
+
+        # Parse .rc files and convert bool.s to Python format
+        # ---------------------------------------------------
+        self.cap_dict = self.geos.parse_rc(self.forecast_dir('CAP.rc'))
+
+        # Define the new directories you want to use
+        with open(self.forecast_dir('gcm_run.j'), "r") as infile:
+            lines = infile.readlines()
+
+        with open(self.forecast_dir('gcm_run.j'), "w") as outfile:
+            for line in lines:
+                # Match setenv EXPDIR with any whitespace
+                if re.match(r'^\s*setenv\s+EXPDIR\b', line):
+                    outfile.write(f"setenv EXPDIR {self.forecast_dir()}\n")
+                # Match setenv HOMDIR with any whitespace
+                elif re.match(r'^\s*setenv\s+HOMDIR\b', line):
+                    outfile.write(f"setenv HOMDIR {self.forecast_dir()}\n")
+                else:
+                    outfile.write(line)
+
+        # with open(self.forecast_dir('gcm_run.j'), "r") as infile:
+        #     lines = infile.readlines()
+
+        # If override switch is on, replace GEOSDIR, GEOSBIN, GEOSETC, GEOSUTIL paths
+        # This might be necessary if a user wants to use a different GEOSgcm build
+        # than the one used to create the experiment directory
+        # ------------------------------------------------------------
+        # with open(self.forecast_dir('gcm_run.j'), "w") as outfile:
+        #     for line in lines:
+        #         # Match setenv GEOSDIR, GEOSBIN, GEOSETC, GEOSUTIL and replace only the first path segment
+        #         match = re.match(r'^(\s*setenv\s+GEOS(DIR|BIN|ETC|UTIL)\s+)(\S+)', line)
+        #         if match:
+        #             var_prefix = match.group(1)
+        #             full_path = match.group(3)
+        #             # Split the path into main path and subpath (e.g., /bin, /etc)
+        #             parts = full_path.split('/')
+        #             # Find index of 'install' in the path and keep everything after it as subpath
+        #             try:
+        #                 idx = parts.index('install')
+        #                 subpath = '/' + '/'.join(parts[idx+1:]) if idx+1 < len(parts) else ''
+        #             except ValueError:
+        #                 # If 'install' not found, replace the whole path
+        #                 subpath = ''
+        #             new_line = f"{var_prefix}{self.geos_build}{subpath}\n"
+        #             outfile.write(new_line)
+        #         else:
+        #             outfile.write(line)
+
+        # TODO: Still need to rewrite CAP.rc here for now to make sure END_TIME is long enough
+        self.cap_dict = self.rewrite_cap(self.cap_dict, self.forecast_dir('CAP.rc'))
+
+        self.agcm_dict = self.geos.parse_rc(self.forecast_dir('AGCM.rc'))
+
+        # Set AGCM.rc record ref_date to fcst start time
+        # RECORD_FREQUENCY is used for dropping restart files at specific intervals
+        # The values needs to be rewrittent according to the forecast and DA window lengths
+        # TODO: This may need rethinking for forecast_geos vs cycle cases
+        # ------------------------------------------------------------
+        if 'RECORD_FREQUENCY' in self.agcm_dict:
+            self.rewrite_agcm(self.agcm_dict, self.forecast_dir('AGCM.rc'))
+
+        # Create cap_restart in GEOSgcm preferred format
+        # ----------------------------------------------
+        with open(self.forecast_dir('cap_restart'), 'w') as file:
+            file.write(self.fc_dto.strftime("%Y%m%d %H%M%S"))
+
+    # ----------------------------------------------------------------------------------------------
+
+    def get_static(self) -> None:
+
+        # Obtain experiment input files created by GEOS gcm_setup
+        # Keep in mind that GEOSgcm uses .HOMDIR and .EXPDIR to define paths to the experiment
+        # folders
+        # --------------------------------------------------
+        geos_install_path = os.path.join(self.experiment_path(), 'GEOSgcm', 'build', 'bin')
+
+        src_dirs = []
+
+        # Make a list of required files to copy, so not everything is copied.
+        # This part will eventually be handled with a modern gcm_setup script but for now these will
+        # be very model specific
+        req_files = ['AGCM.rc', 'CAP.rc', 'data_table', 'diag_table', 'fvcore_layout.rc',
+                     'gcm_emip.setup', 'gcm_run.j', 'HISTORY.rc', '__init__.py', 'input.nml',
+                     'logging.yaml' , 'ice_in', 'MOM_input', 'MOM_override']
+
+        # Optional files in the sense that these are optional MOM6 modules that might be used in
+        # forecast or IAU mode
+        opt_files = ['MOM_oda_incupd', 'MOM_saltrestore']
+
+        # Append required files to src_dirs with geos_homdir
+        for file in req_files:
+            src_dirs.append(os.path.join(self.geos_homdir, file))
+
+        # Append optional files to src_dirs with geos_homdir only if they exist
+        for file in opt_files:
+            src_path = os.path.join(self.geos_homdir, file)
+            if os.path.exists(src_path):
+                self.logger.info(f'Adding optional file: {file}')
+                src_dirs.append(src_path)
+
+        # Finalize the list of source directories
+        # TODO: Where do we want the GEOSgcm.x binary to come from?
+        # ---------------------------------------
+        src_dirs.append(os.path.join(self.geos_expdir, 'GEOSgcm.x'))
+        src_dirs.append(os.path.join(self.geos_expdir, 'linkbcs'))
+
+        for src_dir in src_dirs:
+            copy_to_dst_dir(self.logger, src_dir, self.forecast_dir())
+
+        # Copy RC directory as a whole
+        # ---------------------------------------------------
+        copy_to_dst_dir(self.logger, os.path.join(self.geos_expdir, 'RC'), self.forecast_dir('RC'))
+
+    # ----------------------------------------------------------------------------------------------
+
+    def rewrite_agcm(self, rcdict: dict, rcfile: str) -> dict:
+
+        # This part is relevant for move_da_restart task. Be mindful of your changes
+        # and what impacts they might have on others (also a good motto in life).
+
+        # AGCM.rc might require some modifications depending on the restart intervals
+        # ----------------------------------------------------------------------------
+        self.logger.info('Modifying AGCM.rc RECORD_* entries')
+        [time_string, _, half_duration] = self.geos.iso_to_time_str(self.forecast_duration,
+                                                                    half=True,
+                                                                    agcm=True)
+
+        # We are assuming the beginning of the DA window is half of the forecast
+        # duration. We don't need DA information in GEOS preparation tasks (for now).
+        # --------------------------------------------------------------------------
+        da_begin_dto = self.fc_dto + half_duration
+
+        rcdict['RECORD_FREQUENCY'] = time_string
+        rcdict['RECORD_REF_DATE'] = da_begin_dto.strftime("%Y%m%d")
+        rcdict['RECORD_REF_TIME'] = da_begin_dto.strftime("%H%M%S")
+
+        self.geos.write_rc(rcdict, rcfile)
+        return self.geos.rc_to_bool(rcdict)
+
+    # ----------------------------------------------------------------------------------------------
+
+    def rewrite_cap(self, rcdict: dict, rcfile: str) -> dict:
+
+        # CAP.rc requires modifications before job submission
+        # This method returns rcdict with the bool fix
+        # ---------------------------------------------
+        self.logger.info('Modifying CAP.rc')
+        [time_string, days, _] = self.geos.iso_to_time_str(self.config.forecast_duration())
+
+        # Prepend day information
+        # -----------------------
+        time_string = f'0000{int(days):04d} ' + time_string
+
+        rcdict['NUM_SGMT'] = '1'
+        rcdict['JOB_SGMT'] = time_string
+        rcdict['END_DATE'] = '50010101 000000' # far into the future, we only want to run one segment
+
+        self.geos.write_rc(rcdict, rcfile)
+        return self.geos.rc_to_bool(rcdict)
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/prep_geos_run_dir.py
+++ b/src/swell/tasks/prep_geos_run_dir.py
@@ -102,6 +102,7 @@ class PrepGeosRunDir(taskBase):
             else:
                 self.logger.warning('MOM6 Increment file was not found in INPUT directory')
 
+        # TODO/WARNING: This following combination does not happen anymore after the GEOSgcm revamp
         # Combine input.nml and fvcore_layout
         # Modify input.nml if not cold start (default)
         # --------------------------------------------
@@ -118,12 +119,6 @@ class PrepGeosRunDir(taskBase):
         # --------------------------------------------------
         self.geos.rc_assign(self.cap_dict, 'USE_EXTDATA2G')
 
-        # Link replay files if active TODO
-        # --------------------------------
-        if 'REPLAY_MODE' in self.agcm_dict:
-            self.logger.info('Replay Mode is Active')
-            self.link_replay()
-
         # Set AGCM.rc record ref_date to fcst start time
         # TODO: This needs rethinking for forecast_geos vs cycle cases
         # ------------------------------------------------------------
@@ -134,7 +129,7 @@ class PrepGeosRunDir(taskBase):
         # ------------------------------------------------------
         self.gcm_dict = self.geos.parse_gcmrun(self.forecast_dir('gcm_run.j'))
 
-        # Beginning GEOSgcm v11.6.0, linkbcs is a separate file outside of gcm_run.j.
+        # As of GEOSgcm v11.6.0, linkbcs is a separate file outside of gcm_run.j.
         # So parse linkbcs file using parse_gcmrun method and update gcm_dict
         # -----------------------------------------------------------------------
         self.gcm_dict.update(self.geos.parse_gcmrun(self.forecast_dir('linkbcs')))
@@ -183,6 +178,12 @@ class PrepGeosRunDir(taskBase):
         # ------------------
         self.geos.run_geos_script(self.geosbin, 'bundleParser.py')
 
+        # Link replay files if active
+        # --------------------------------
+        if 'REPLAY_MODE' in self.agcm_dict:
+            self.logger.info('Replay Mode is Active')
+            self.link_replay()
+
     # ----------------------------------------------------------------------------------------------
 
     def generate_extdata(self) -> None:
@@ -216,6 +217,18 @@ class PrepGeosRunDir(taskBase):
             self.geos.run_geos_script(self.geosbin, 'construct_extdata_yaml_list.py',
                                       './GEOS_ChemGridComp.rc')
             open(self.forecast_dir('ExtData.rc'), 'w').close()
+
+        # Modify RRTMG to RRTMGP in all _instance*.rc files
+        instance_pattern = self.forecast_dir('*_instance*.rc')
+        for instance_file in glob.glob(instance_pattern):
+            with open(instance_file, 'r') as f:
+                lines = f.readlines()
+            with open(instance_file, 'w') as f:
+                for line in lines:
+                    # Only substitute on lines containing 'RRTMG'
+                    if 'RRTMG' in line:
+                        line = line.replace('RRTMG', 'RRTMGP')
+                    f.write(line)
 
     # ----------------------------------------------------------------------------------------------
 
@@ -313,20 +326,19 @@ class PrepGeosRunDir(taskBase):
 
         self.bcs_dict = {
             os.path.join(geos_geomdir, f"{geos_bcrslv}-Pfafstetter.til"):
-                'tile.data',
+            'tile.data',
             os.path.join(geos_geomdir, f"{geos_bcrslv}-Pfafstetter.TRN"):
-                'runoff.bin',
-            os.path.join(geos_obcsdir, f"SEAWIFS_KPAR_mon_clim.{OGCM_IM}x{OGCM_JM}"):
-                'SEAWIFS_KPAR_mon_clim.data',
-            os.path.join(geos_geomdir, 'MAPL_Tripolar.nc'): 'MAPL_Tripolar.nc',
+            'runoff.bin',
+            os.path.join(geos_obcsdir, f"SEAWIFS_KPAR_mon_clim.nob.{OGCM_IM}x{OGCM_JM}"):
+            'SEAWIFS_KPAR_mon_clim.data',
+            # os.path.join(geos_geomdir, 'MAPL_Tripolar.nc'): 'MAPL_Tripolar.nc',
+            os.path.join(geos_cpldir, f"{OGCM_IM}x{OGCM_JM}", 'MAPL_Tripolar.nc'):
+            'MAPL_Tripolar.nc',
             os.path.join(geos_obcsdir, f"vgrid{OGCM_LM}.ascii"): 'vgrid.ascii',
-            os.path.join(geos_bcsdir, pchem_dir, pchem[pchem_clim_years]):
-                'species.data',
             # os.path.join(geos_bcsdir, 'Shared', '*bin'): '',
             os.path.join(geos_chmdir, '*'): self.forecast_dir('ExtData'),
             os.path.join('/discover/nobackup/projects/gmao/ssd/aogcm/atmosphere_bcs/',
-                         '*'): self.forecast_dir('ExtData'),
-            # os.path.join(geos_bcsdir, 'Shared', '*c2l*.nc4'): '',
+                 '*'): self.forecast_dir('ExtData'),
             os.path.join(geos_landdir, f"visdf_{AGCM_IM}x{AGCM_JM}.dat"): 'visdf.dat',
             os.path.join(geos_landdir, f"nirdf_{AGCM_IM}x{AGCM_JM}.dat"): 'nirdf.dat',
             os.path.join(geos_landdir, f"vegdyn_{AGCM_IM}x{AGCM_JM}.dat"): 'vegdyn.data',
@@ -334,15 +346,19 @@ class PrepGeosRunDir(taskBase):
             os.path.join(geos_landdir, f"green_clim_{AGCM_IM}x{AGCM_JM}.data"): 'green.data',
             os.path.join(geos_landdir, f"ndvi_clim_{AGCM_IM}x{AGCM_JM}.data"): 'ndvi.data',
             os.path.join(geos_topodir, f"topo_DYN_ave_{AGCM_IM}x{AGCM_JM}.data"):
-                'topo_dynave.data',
+            'topo_dynave.data',
             os.path.join(geos_topodir, f"topo_GWD_var_{AGCM_IM}x{AGCM_JM}.data"):
-                'topo_gwdvar.data',
+            'topo_gwdvar.data',
             os.path.join(geos_topodir, f"topo_TRB_var_{AGCM_IM}x{AGCM_JM}.data"):
-                'topo_trbvar.data',
+            'topo_trbvar.data',
             os.path.join(geos_obcsdir, 'cice6', 'cice6_grid.nc'): '',
             os.path.join(geos_obcsdir, 'cice6', 'cice6_kmt.nc'): '',
             os.path.join(geos_obcsdir, 'cice6', 'cice6_global.bathy.nc'): '',
         }
+
+        # Only add pchem species file if pchem_clim_years is not None
+        if pchem_clim_years is not None:
+            self.bcs_dict[os.path.join(geos_bcsdir, pchem_dir, pchem[pchem_clim_years])] = 'species.data'
 
         # Conditional BCs that don't break the model
         # ------------------------------------------
@@ -358,9 +374,21 @@ class PrepGeosRunDir(taskBase):
                     })
 
         # Fetch more resolution dependent files
+        # Hit an edge case which is avoided by cp but impacts shutil
+        # https://stackoverflow.com/questions/11835833/why-would-shutil-copy-raise-a-permission-exception-when-cp-doesnt
         # -------------------------------------
-        copy_to_dst_dir(self.logger, os.path.join(geos_obcsdir, 'INPUT'),
-                        self.forecast_dir('INPUT'))
+        # Copy files individually from the OBCS INPUT directory
+        src_input_dir = os.path.join(geos_obcsdir, 'INPUT')
+        dst_input_dir = self.forecast_dir('INPUT')
+        if os.path.isdir(src_input_dir):
+            for name in sorted(os.listdir(src_input_dir)):
+                src_path = os.path.join(src_input_dir, name)
+                # skip file name "WOA05_ptemp_salt_annual.v20141007.nc"
+                if name == "WOA05_ptemp_salt_annual.v20141007.nc":
+                    continue
+                copy_to_dst_dir(self.logger, src_path, dst_input_dir)
+        else:
+            self.logger.warning(f"OBCS INPUT directory not found: {src_input_dir}")
 
     # ----------------------------------------------------------------------------------------------
 
@@ -393,14 +421,35 @@ class PrepGeosRunDir(taskBase):
     def get_static(self) -> None:
 
         # Obtain experiment input files created by GEOS gcm_setup
+        # Keep in mind that GEOSgcm uses .HOMDIR and .EXPDIR to define paths to the experiment
+        # folders
         # --------------------------------------------------
         geos_install_path = os.path.join(self.experiment_path(), 'GEOSgcm', 'build', 'bin')
 
         src_dirs = []
 
-        # Create list of static files
-        # ---------------------------------
-        src_dirs.append(self.geos_exp_dir)
+        # Make a list of required files to copy, so not everything is copied.
+        # This part will eventually be handled with a modern gcm_setup script.
+        req_files = ['AGCM.rc', 'CAP.rc', 'data_table', 'diag_table', 'fvcore_layout.rc',
+                     'gcm_emip.setup', 'gcm_run.j', 'HISTORY.rc', '__init__.py', 'input.nml',
+                     'linkbcs', 'logging.yaml']
+
+        # Optional files in the sense that they are required for coupled or dataAtm runs
+        opt_files = ['ice_in', 'MOM_input', 'MOM_oda_incupd', 'MOM_override', 'MOM_saltrestore']
+
+        # Append required files to src_dirs with geos_exp_dir
+        for file in req_files:
+            src_dirs.append(os.path.join(self.geos_exp_dir, file))
+
+        # Append optional files to src_dirs with geos_exp_dir only if they exist
+        for file in opt_files:
+            src_path = os.path.join(self.geos_exp_dir, file)
+            if os.path.exists(src_path):
+                self.logger.info(f'Adding optional file: {file}')
+                src_dirs.append(src_path)
+
+        # Finalize the list of source directories
+        # ---------------------------------------
         src_dirs.append(os.path.join(self.geos_exp_dir, 'RC'))
         src_dirs.append(os.path.join(geos_install_path, 'bundleParser.py'))
 
@@ -416,20 +465,39 @@ class PrepGeosRunDir(taskBase):
         # ---------------------------------------------------------
 
         if self.agcm_dict['REPLAY_MODE'] == 'Exact' or self.agcm_dict['REPLAY_MODE'] == 'Regular':
-            # ANA_EXPID = self.agcm_dict['REPLAY_ANA_EXPID']
+            ANA_EXPID = self.agcm_dict['REPLAY_ANA_EXPID']
             ANA_LOCATION = self.agcm_dict['REPLAY_ANA_LOCATION']
             # REPLAY_FILE = self.agcm_dict['REPLAY_FILE']
 
+            # Modify GAAS_GridComp_ExtData.yaml
+            yaml_file = self.forecast_dir('GAAS_GridComp_ExtData.yaml')
+            yaml_tmpl = yaml_file + '.tmpl'
+            if os.path.exists(yaml_file):
+                os.rename(yaml_file, yaml_tmpl)
+                with open(yaml_tmpl, 'r') as f_in, open(yaml_file, 'w') as f_out:
+                    for line in f_in:
+                        # Substitute das.aod_ with chem/Y%y4/M%m2/${ANA_EXPID}.aod_
+                        f_out.write(line.replace(
+                            'das.aod_',
+                            f'chem/Y%y4/M%m2/{ANA_EXPID}.aod_'
+                        ))
+
+            # Modify GAAS_GridComp_ExtData.rc
+            rc_file = self.forecast_dir('GAAS_GridComp_ExtData.rc')
+            rc_tmpl = rc_file + '.tmpl'
+            if os.path.exists(rc_file):
+                os.rename(rc_file, rc_tmpl)
+                with open(rc_tmpl, 'r') as f_in, open(rc_file, 'w') as f_out:
+                    for line in f_in:
+                        f_out.write(line.replace(
+                            'das.aod_',
+                            f'chem/Y%y4/M%m2/{ANA_EXPID}.aod_'
+                        ))
+
         rply_dict = {
             os.path.join(ANA_LOCATION, 'ana'): '',
+            os.path.join(ANA_LOCATION, 'chem'): '',
         }
-
-        # if 'REPLAY_FILE09' in self.agcm_dict:
-        #     REPLAY_FILE09 = self.agcm_dict['REPLAY_FILE09']
-        #     self.logger.info(' Including REPLAY_FILE09: ' + src)
-        #     self.rply_dict.update({
-        #         os.path.join(ANA_LOCATION): '',
-        #         })
 
         for src, dst in rply_dict.items():
             self.logger.info(' Linking file: ' + src)
@@ -490,8 +558,7 @@ class PrepGeosRunDir(taskBase):
         rcdict['RECORD_REF_DATE'] = da_begin_dto.strftime("%Y%m%d")
         rcdict['RECORD_REF_TIME'] = da_begin_dto.strftime("%H%M%S")
 
-        with open(rcfile, "w") as f:
-            yaml.dump(rcdict, f, default_flow_style=False, sort_keys=False)
+        self.geos.write_rc(rcdict, rcfile)
 
         return self.geos.rc_to_bool(rcdict)
 
@@ -512,8 +579,7 @@ class PrepGeosRunDir(taskBase):
         rcdict['NUM_SGMT'] = '1'
         rcdict['JOB_SGMT'] = time_string
 
-        with open(rcfile, "w") as f:
-            yaml.dump(rcdict, f, default_flow_style=False, sort_keys=False)
+        self.geos.write_rc(rcdict, rcfile)
 
         return self.geos.rc_to_bool(rcdict)
 

--- a/src/swell/tasks/prepare_analysis.py
+++ b/src/swell/tasks/prepare_analysis.py
@@ -8,6 +8,7 @@
 # --------------------------------------------------------------------------------------------------
 
 import glob
+import isodate
 import netCDF4 as nc
 import os
 import shutil
@@ -27,6 +28,12 @@ class PrepareAnalysis(taskBase):
 
         """
         Updates variables in restart files with analysis variables.
+
+        For FV3-jedi:
+            - None
+        For SOCA:
+            - MOM6: This is handled here where IAU method is actively used and supported.
+            - CICE6: This is handled by soca2cice script
         """
 
         self.logger.info('Preparing analysis and updating restarts')
@@ -37,17 +44,16 @@ class PrepareAnalysis(taskBase):
         self.jedi_rendering.add_key('mom6_iau', self.config.mom6_iau(False))
 
         model_component_meta = self.jedi_rendering.render_interface_meta()
-        self.SOCA_dict = model_component_meta['variables']
 
         # Current and restart time objects
         # --------------------------------
-        self.current_cycle = os.path.basename(self.forecast_dir())
         self.cc_dto = self.cycle_time_dto()
 
         # GEOS restarts have seconds in their filename
-        # --------------------------------------------
+        # We want to use rst_dto at the beginning of the DA window (window offset is negative)
+        # ---------------------------------------------------------
         an_fcst_offset = self.config.analysis_forecast_window_offset()
-        rst_dto = self.geos.adjacent_cycle(an_fcst_offset, return_date=True)
+        rst_dto = self.cc_dto + isodate.parse_duration(an_fcst_offset)
         seconds = str(rst_dto.hour * 3600 + rst_dto.minute * 60 + rst_dto.second)
 
         # Determine which models require analysis (code will fail if executed
@@ -60,6 +66,7 @@ class PrepareAnalysis(taskBase):
         # Below is SOCA specific
         # Generic analysis and increment file format independent of exp_id
         # ---------------------------------------------------------------
+        self.SOCA_dict = model_component_meta['variables']
         ana_path = self.at_cycledir(['ocn.*' + self.cc_dto.strftime('.an.%Y-%m-%dT%H:%M:%SZ.nc')])
         incr_path = self.at_cycledir(['ocn.*' +
                                       self.cc_dto.strftime('.incr.%Y-%m-%dT%H:%M:%SZ.nc')])
@@ -70,15 +77,15 @@ class PrepareAnalysis(taskBase):
 
         # Generic rst file format
         # ------------------------
-        f_rst = self.forecast_dir(['RESTART', 'MOM.res.nc'])
+        f_rst = self.forecast_dir(['scratch', 'RESTART', 'MOM.res.nc'])
 
         # This alternate restart format corresponds to optional use of Restart Record
         # parameters in AGCM.rc
         # -------------------------------------------------------------------------
-        agcm_dict = self.geos.parse_rc(self.forecast_dir('AGCM.rc'))
+        agcm_dict = self.geos.parse_rc(self.forecast_dir(['scratch', 'AGCM.rc']))
 
         if 'RECORD_FREQUENCY' in agcm_dict:
-            f_rst = self.forecast_dir(['RESTART', rst_dto.strftime('MOM.res_Y%Y_D%j_S')
+            f_rst = self.forecast_dir(['scratch', 'RESTART', rst_dto.strftime('MOM.res_Y%Y_D%j_S')
                                        + seconds + '.nc'])
 
         self.soca_ana = self.config.analysis_variables()
@@ -92,6 +99,9 @@ class PrepareAnalysis(taskBase):
     # ----------------------------------------------------------------------------------------
 
     def at_cycledir(self, paths: Union[list, str] = []) -> str:
+        '''
+        Get the absolute path to the model cycle directory for the given relative paths.
+        '''
 
         # Ensure what we have is a list (paths should be a list)
         # ------------------------------------------------------
@@ -107,10 +117,12 @@ class PrepareAnalysis(taskBase):
 
     def mom6_increment(self, f_rst: str, ana_path: str, incr_path: str) -> None:
 
-        # This method prepares MOM6 increment file for IAU during next cycle.
-        # SOCA increment does not contain layer thickness (h) variable. Hence,
-        # SOCA incr needs to be combined with the h variable from
-        # the SOCA analysis file.
+        '''
+        This method prepares MOM6 increment file for IAU during next cycle.
+        SOCA increment does not contain layer thickness (h) variable. Hence,
+        SOCA incr needs to be combined with the h variable from
+        the SOCA analysis file.
+        '''
 
         for filepath in list(glob.glob(ana_path)):
             f_ana = filepath
@@ -135,6 +147,11 @@ class PrepareAnalysis(taskBase):
     # --------------------------------------------------------------------------------------------------
 
     def replace_ocn(self, f_rst: str, ana_pth: str) -> None:
+
+        '''
+        Not-recommended
+        Non-IAU method to update analysis variables in MOM6 restart file.
+        '''
 
         # TODO: This will fail for multiple restart files and no IAU
         # ----------------------------------------------------------
@@ -162,6 +179,6 @@ class PrepareAnalysis(taskBase):
         ds_ana.close()
         ds_rst.close()
 
-        shutil.move(f_rst, self.forecast_dir(['RESTART', 'MOM.res.nc']))
+        shutil.move(f_rst, self.forecast_dir(['scratch', 'RESTART', 'MOM.res.nc']))
 
 # --------------------------------------------------------------------------------------------------

--- a/src/swell/tasks/save_restart.py
+++ b/src/swell/tasks/save_restart.py
@@ -94,7 +94,7 @@ class SaveRestart(taskBase):
         dst_date = dt.strftime(forecast_start_time, datetime_formats['iso_format'])
 
         # Oceanstats is produced at the end of the forecast
-        src_stats = os.path.join(self.forecast_dir(), 'ocean.stats.nc')
+        src_stats = self.forecast_dir(['scratch', 'ocean.stats.nc'])
         dst_stats = os.path.join(mainf, forecast_start_time.strftime('%Y-%m-%d'),
                                  f'mom6_cice6_UFS.{self.experiment_id()}.fc.global.MOM.oceanstats.'
                                  + dst_date + '.' + forecast_duration + '.nc')

--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -538,9 +538,9 @@ class TaskQuestions(QuestionContainer, Enum):
     PrepCoupledGeosRunDir = QuestionList(
         list_name="PrepCoupledGeosRunDir",
         questions=[
-            # swell_static_file_questions,
             qd.existing_geos_gcm_build_path(),
             qd.forecast_duration(),
+            geos_gcm_questions,
             # qd.geos_experiment_directory(),
             qd.mom6_iau_nhours()
         ]

--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -55,6 +55,16 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.window_type()
         ]
     )
+    # --------------------------------------------------------------------------------------------------
+
+    geos_gcm_questions = QuestionList(
+        list_name="geos_gcm_questions",
+        questions=[
+            qd.geos_homdir(),
+            qd.geos_expdir_different(),
+            qd.geos_expdir(),
+        ]
+    )
 
     # --------------------------------------------------------------------------------------------------
 
@@ -331,6 +341,15 @@ class TaskQuestions(QuestionContainer, Enum):
 
     # --------------------------------------------------------------------------------------------------
 
+    GetCoupledGeosRestart = QuestionList(
+        list_name="GetCoupledGeosRestart",
+        questions=[
+            geos_gcm_questions,
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------
+
     GetGeosRestart = QuestionList(
         list_name="GetGeosRestart",
         questions=[
@@ -422,12 +441,33 @@ class TaskQuestions(QuestionContainer, Enum):
 
     # --------------------------------------------------------------------------------------------------
 
+    LinkCoupledGeosOutput = QuestionList(
+        list_name="LinkCoupledGeosOutput",
+        questions=[
+            window_questions,
+            qd.background_frequency(),
+            qd.marine_models()
+        ]
+    )
+    # --------------------------------------------------------------------------------------------------
+
     LinkGeosOutput = QuestionList(
         list_name="LinkGeosOutput",
         questions=[
             window_questions,
             qd.background_frequency(),
             qd.marine_models()
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------
+
+    MoveEraseDaRestart = QuestionList(
+        list_name="MoveEraseDaRestart",
+        questions=[
+            qd.analysis_forecast_window_offset(),
+            qd.mom6_iau(),
+            qd.window_length()
         ]
     )
 
@@ -465,13 +505,26 @@ class TaskQuestions(QuestionContainer, Enum):
 
     # --------------------------------------------------------------------------------------------------
 
+    PrepCoupledGeosRunDir = QuestionList(
+        list_name="PrepCoupledGeosRunDir",
+        questions=[
+            # swell_static_file_questions,
+            qd.existing_geos_gcm_build_path(),
+            qd.forecast_duration(),
+            # qd.geos_experiment_directory(),
+            qd.mom6_iau_nhours()
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------
+
     PrepGeosRunDir = QuestionList(
         list_name="PrepGeosRunDir",
         questions=[
             swell_static_file_questions,
             qd.existing_geos_gcm_build_path(),
             qd.forecast_duration(),
-            qd.geos_experiment_directory(),
+            # qd.geos_experiment_directory(),
             qd.mom6_iau_nhours()
         ]
     )

--- a/src/swell/utilities/file_system_operations.py
+++ b/src/swell/utilities/file_system_operations.py
@@ -28,8 +28,8 @@ def copy_to_dst_dir(logger: Logger, src: str, dst_dir: str) -> None:
             logger.info(' Copying file: '+src)
             shutil.copy(src, dst_dir)
 
-    except Exception:
-        logger.abort('Copying failed, see if source files exists')
+    except Exception as e:
+        logger.abort(f'Copying failed: {e}')
 
 # --------------------------------------------------------------------------------------------------
 
@@ -153,7 +153,7 @@ def move_files(logger: Logger, src_dir: str, dst_dir: str) -> None:
         logger.info(' Moving file(s) from: '+src_dir)
         shutil.move(src_dir, dst_dir)
 
-    except Exception:
-        logger.abort('Moving failed, see if source files exist')
+    except Exception as e:
+        logger.abort(f'Moving failed: {e}')
 
 # ----------------------------------------------------------------------------------------------

--- a/src/swell/utilities/geos.py
+++ b/src/swell/utilities/geos.py
@@ -9,6 +9,7 @@
 
 import datetime
 import f90nml
+import glob
 import isodate
 import os
 import re
@@ -25,10 +26,13 @@ class Geos():
 
     # ----------------------------------------------------------------------------------------------
 
-    def __init__(self, logger: Logger, forecast_dir: Optional[str]) -> None:
+    def __init__(self,
+        logger: Logger,
+        forecast_dir: Optional[str],
+    ) -> None:
 
         '''
-        Intention with creating this GEOS class is to not have any model dependent
+        The intention behind creating this GEOS class is to not have any model dependent
         methods. This way, methods would be shared between the forecast-only and
         cycling DA tasks.
         '''
@@ -224,7 +228,20 @@ class Geos():
 
                 if parts[0] == 'setenv':
                     key = parts[1]
-                    rcdict[key] = parts[2]
+                    # if setenv is empty, assign None
+                    value = parts[2] if len(parts) > 2 else None
+                    rcdict[key] = value
+
+                # Parse set lines (e.g., set VAR = VALUE)
+                elif parts[0] == 'set' and '=' in line:
+                    # Find the variable name and value
+                    match = re.match(r'set\s+(\w+)\s*=\s*(.*)', line)
+                    if match:
+                        key = match.group(1)
+                        value = match.group(2)
+                        # Remove backticks and shell expressions for now
+                        value = value.strip('`').strip()
+                        rcdict[key] = value
 
         return rcdict
 
@@ -277,59 +294,90 @@ class Geos():
     # ----------------------------------------------------------------------------------------------
 
     def parse_rc(self, rcfile: str) -> dict:
-
-        # Parse AGCM.rc & CAP.rc line by line. It ignores comments and commented
-        # out lines. Some values involve multiple ":" characters which required
-        # some extra steps to handle them as dictionary values.
-        # ----------------------------------------------------------------------
-
+        """
+        Parses .rc files line by line, ignoring comments and handling empty entries.
+        Properly handles multi-line sections delimited by :: markers.
+        """
         with open(rcfile, 'r') as file:
             lines = file.readlines()
 
         rcdict = {}
+        in_multiline_section = False
+        current_section_key = None
+        section_content = []
 
-        for line in lines:
-            # Strip any leading or trailing whitespace from the line
-            # ------------------------------------------------------
+        for line_num, line in enumerate(lines, 1):
             line = line.strip()
 
-            # Skip if the line is a comment (i.e., starts with #)
-            # ------------------------------------------------------
-            if line.startswith("#"):
+            if not line or line.startswith("#"):
                 continue
 
-            # Split the line to ignore comments after #
-            # ---------------------------------------------
+            # Check for start of multi-line section (key followed by ::)
+            if line.endswith("::") and line != "::":
+                current_section_key = line[:-2].strip()  # Remove :: and get the key
+                in_multiline_section = True
+                section_content = []
+                continue
+
+            # Check for end of multi-line section (standalone ::)
+            if line == "::":
+                if in_multiline_section and current_section_key:
+                    # Store the multiline section as a list
+                    rcdict[current_section_key] = section_content.copy()
+                in_multiline_section = False
+                current_section_key = None
+                section_content = []
+                continue
+
+            # Collect content inside multi-line sections
+            if in_multiline_section:
+                section_content.append(line)
+                continue
+
+            # Regular key-value parsing
             parts = line.split('#', 1)
-            line = parts[0]
+            clean_line = parts[0].strip()
 
-            # Split the line into key and value using the first occurrence of ":" as the delimiter
-            # This part is required because of AGCM.rc entries with confusing
-            # lines (e.g., CH4_FRIENDLIES: DYNAMICS:TURBULENCE:MOIST)
-            # ------------------------------------------------------------------------------------
-            split_line = line.split(":", 1)
-            if len(split_line) == 2:
-                key, value = split_line
-                # Re-join any remaining parts of the value with ":" again
-                # -------------------------------------------------------
-                value = value.split(":")
-                value = ":".join(value)
+            if not clean_line:
+                continue
 
-                # Strip any whitespace from the key and value
-                # --------------------------------------------
+            if ":" in clean_line:
+                key, value = clean_line.split(":", 1)
                 key = key.strip()
                 value = value.strip()
-                rcdict[key] = value
+
+                if key:
+                    rcdict[key] = value if value else None
 
         return rcdict
 
     # ----------------------------------------------------------------------------------------------
 
+    def write_rc(self, rcdict: dict, output_file: str) -> None:
+        """
+        Writes the parsed RC dictionary back to a file.
+        Properly handles multi-line sections.
+        """
+        with open(output_file, 'w') as file:
+            for key, value in rcdict.items():
+                if isinstance(value, list):
+                    # Multi-line section
+                    file.write(f"{key}::\n")
+                    for item in value:
+                        file.write(f"{item}\n")
+                    file.write("::\n")
+                elif value is None:
+                    # Empty value
+                    file.write(f"{key}:\n")
+                else:
+                    # Regular key-value pair
+                    file.write(f"{key}: {value}\n")
+
+    # ----------------------------------------------------------------------------------------------
+
     def process_nml(self, cold_restart: bool = False) -> None:
 
-        # In gcm_run.j, fvcore_layout.rc is concatenated with input.nml
-        # -------------------------------------------------------------
-
+        # Make sure input.nml is set up properly for hot/cold restart
         nml1 = f90nml.read(os.path.join(self.forecast_dir, 'input.nml'))
 
         if not cold_restart:
@@ -339,13 +387,9 @@ class Geos():
             # ----------------------------------------------
             nml1['mom_input_nml']['input_filename'] = 'r'
 
-        nml2 = f90nml.read(os.path.join(self.forecast_dir, 'fvcore_layout.rc'))
-
         # Combine the dictionaries and write the new input.nml
         # ---------------------------------------------------
-        nml_comb = {**nml1, **nml2}
-
-        self.logger.info('Combining input.nml and fvcore_layout.rc')
+        nml_comb = {**nml1}
 
         with open(os.path.join(self.forecast_dir, 'input.nml'), 'w') as f:
             f90nml.write(nml_comb, f)
@@ -373,33 +417,53 @@ class Geos():
         # ----------------------------------------------------------------------
 
         for key, value in rcdict.items():
-            if rcdict[key].strip('.').lower() == 'true':
-                rcdict[key] = True
-            elif rcdict[key].strip('.').lower() == 't':
-                rcdict[key] = True
-            elif rcdict[key].strip('.').lower() == 'false':
-                rcdict[key] = False
-            elif rcdict[key].strip('.').lower() == 'f':
-                rcdict[key] = False
-            else:
+            # Skip None values and non-string values
+            if value is None or not isinstance(value, str):
                 continue
+
+            # Strip dots and convert to lowercase for comparison
+            normalized_value = value.strip('.').lower()
+
+            if normalized_value == 'true' or normalized_value == 't':
+                rcdict[key] = True
+            elif normalized_value == 'false' or normalized_value == 'f':
+                rcdict[key] = False
+            # If it's not a boolean value, keep it as is
 
         return rcdict
 
     # ----------------------------------------------------------------------------------------------
 
-    def rename_checkpoints(self, next_geosdir):
+    def rename_checkpoints(self, next_forecast_dir: str) -> None:
 
-        # Rename _checkpoint files to _rst
-        # Move to the next geos cycle directory
-        # -------------------------------------
-        os.chdir(next_geosdir)
+        """
+        Rename _checkpoint files to _rst in the next_forecast_dir directory.
+        """
+        # Validate directory exists
+        if not os.path.exists(next_forecast_dir):
+            self.logger.abort(f'Directory does not exist: {next_forecast_dir}')
 
-        self.logger.info('Renaming *_checkpoint files to *_rst')
-        try:
-            os.system('rename -v _checkpoint _rst *_checkpoint')
-        except Exception:
-            self.logger.abort('Renaming failed, see if checkpoint files exists')
+        self.logger.info(f'Renaming *_checkpoint files to *_rst in {next_forecast_dir}')
+
+        # Use glob to find checkpoint files instead of relying on shell commands
+        checkpoint_pattern = os.path.join(next_forecast_dir, '*_checkpoint')
+        checkpoint_files = glob.glob(checkpoint_pattern)
+
+        if not checkpoint_files:
+            self.logger.abort(f'No _checkpoint files found in {next_forecast_dir}')
+
+        # Rename each file individually for better error handling
+        for checkpoint_file in checkpoint_files:
+            try:
+                # Generate the new filename by replacing _checkpoint with _rst
+                rst_file = checkpoint_file.replace('_checkpoint', '_rst')
+                # Rename the file
+                os.rename(checkpoint_file, rst_file)
+                self.logger.info(f'Renamed {os.path.basename(checkpoint_file)}')
+                self.logger.info(f'    to {os.path.basename(rst_file)}')
+
+            except OSError as e:
+                self.logger.abort(f'Failed to rename {checkpoint_file}: {e}')
 
     # --------------------------------------------------------------------------------------------------
 
@@ -449,7 +513,7 @@ class Geos():
         # Calculate the number of states using background frequency and window length
         number_of_states = int(isodate.parse_duration(window_length)
                                / isodate.parse_duration(background_frequency)) + 1
-        self.logger.info('Number of states: ', str(number_of_states-1))
+        self.logger.info('Number of states: ' + str(number_of_states-1))
 
         # Generate the list of states dictionary with date and marine filename entries.
         # The date is calculated by adding the background frequency to the window begin date.

--- a/src/swell/utilities/question_defaults.py
+++ b/src/swell/utilities/question_defaults.py
@@ -123,8 +123,8 @@ class QuestionDefaults():
         default_value: str = "P4"
         question_name: str = "runahead_limit"
         ask_question: bool = True
-        prompt: str = ("Since this suite is non-cycling choose how "
-                       "many hours the workflow can run ahead?")
+        prompt: str = ("How many additional cycles can be run"
+                       "simultaneously? (P1: one, P3: three)")
         widget_type: WType = WType.STRING
 
     # --------------------------------------------------------------------------------------------------
@@ -498,12 +498,49 @@ class QuestionDefaults():
 
     # --------------------------------------------------------------------------------------------------
 
+    # @dataclass
+    # class geos_experiment_directory(TaskQuestion):
+    #     default_value: str = "defer_to_platform"
+    #     question_name: str = "geos_experiment_directory"
+    #     ask_question: bool = True
+    #     prompt: str = "What is the path to the GEOS restarts directory?"
+    #     widget_type: WType = WType.STRING
+
+    # --------------------------------------------------------------------------------------------------
+
     @dataclass
-    class geos_experiment_directory(TaskQuestion):
+    class geos_homdir(TaskQuestion):
         default_value: str = "defer_to_platform"
-        question_name: str = "geos_experiment_directory"
+        question_name: str = "geos_homdir"
         ask_question: bool = True
-        prompt: str = "What is the path to the GEOS restarts directory?"
+        prompt: str = "What is the path to the GEOS experiment directory (HOMDIR)?"
+        widget_type: WType = WType.STRING
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
+    class geos_expdir_different(TaskQuestion):
+        default_value: str = False
+        question_name: str = "geos_expdir_different"
+        ask_question: bool = True
+        options: List[bool] = mutable_field([
+            True,
+            False
+        ])
+        prompt: str = "Is your GEOS EXPDIR (where restarts and scratch is located) different than your HOMDIR?"
+        widget_type: WType = WType.BOOLEAN
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
+    class geos_expdir(TaskQuestion):
+        default_value: str = "/dev/null/"
+        question_name: str = "geos_expdir"
+        depends: Dict = mutable_field({
+            "geos_expdir_different": True
+        })
+        prompt: str = ("What is the path to the GEOS experiment directory (EXPDIR), where restarts are located"
+                       " if it is different than HOMDIR?")
         widget_type: WType = WType.STRING
 
     # --------------------------------------------------------------------------------------------------
@@ -512,7 +549,9 @@ class QuestionDefaults():
     class geos_gcm_tag(TaskQuestion):
         default_value: str = "v11.6.0"
         question_name: str = "geos_gcm_tag"
-        ask_question: bool = True
+        depends: Dict = mutable_field({
+            "geos_build_method": "create"
+        })
         prompt: str = "Which GEOS tag do you wish to clone?"
         widget_type: WType = WType.STRING
 

--- a/src/swell/utilities/question_defaults.py
+++ b/src/swell/utilities/question_defaults.py
@@ -588,14 +588,14 @@ class QuestionDefaults():
 
     @dataclass
     class geos_expdir_different(TaskQuestion):
-        default_value: str = False
+        default_value: bool = False
         question_name: str = "geos_expdir_different"
         ask_question: bool = True
         options: List[bool] = mutable_field([
             True,
             False
         ])
-        prompt: str = "Is your GEOS EXPDIR (where restarts and scratch is located) different than your HOMDIR?"
+        prompt: str = "Is your GEOS EXPDIR (where restarts, linkbcs, RC, and scratch is located) different than your HOMDIR?"
         widget_type: WType = WType.BOOLEAN
 
     # --------------------------------------------------------------------------------------------------

--- a/src/swell/utilities/slurm.py
+++ b/src/swell/utilities/slurm.py
@@ -76,6 +76,7 @@ def prepare_scheduling_dict(
         'EvaObservations',
         'EvaTimeseries',
         'GenerateBClimatology',
+        'RunGeos',
         'RunJediEnsembleMeanVariance',
         'RunJediConvertStateSoca2ciceExecutable',
         'RunJediFgatExecutable',
@@ -85,7 +86,6 @@ def prepare_scheduling_dict(
         'RunJediObsfiltersExecutable',
         'RunJediUfoTestsExecutable',
         'RunJediVariationalExecutable',
-        'RunGeosExecutable'
         }
 
     # Throw an error if a user tries to set SLURM directives for a task that
@@ -131,7 +131,6 @@ def prepare_scheduling_dict(
         # Set model_agnostic directives
         validate_directives(directives)
         scheduling_dict[slurm_task] = {"directives": {"all": directives}}
-
         # Now, add model component-specific logic. The inheritance here is more
         # complicated:
         # - Experiment global defaults (`experiment_globals`)
@@ -182,7 +181,6 @@ def prepare_scheduling_dict(
         if slurm_task in experiment_task_directives.keys():
             x = experiment_task_directives[slurm_task].get('execution_time_limit', x)
         scheduling_dict[slurm_task]['execution_time_limit'] = x
-
     return scheduling_dict
 
 


### PR DESCRIPTION
To address #625 I worked on a different way of executing GEOSgcm in SWELL. I had to make a lot of changes but i will try to explain the essential part of this PR.

Let's consider `gcm_run.j` in 4 stages:

1) SLURM & node assignment
2) Preprocessing
3) Execution
4) Postprocessing

In the current implementation, SWELL handles 2 & 3 via python and `subprocess` and 1 is assumed to be set properly by the user, which caused trouble with the NCCS. For DA purposes 4, postprocessing is explicitly handled by SWELL but that is not the focus of this PR.

In this proposed implementation, the main difference is that we rely on `gcm_run.j` for 2 and 3 by conducting surgical edits via `PrepCoupledGeosRundir` at few locations and running `gcm_run.j` directly from Cylc (which doesn't capture failed exit status):

```cylc
    [[RunGeos]]
        script = "{{experiment_path}}/forecast/gcm_run.j"
        platform = {{platform}}
        [[[job]]]
            shell = /bin/csh
        [[[directives]]]
        {%- for key, value in scheduling["RunGeos"]["directives"]["all"].items() %}
            --{{key}} = {{value}}
        {%- endfor %}
```

I created the `3dfgat_coupled_cycle` suite for testing, should work by default if anyone has time to check it out.

Sorry I'm tagging a lot of people but I would like to get some feedback on this, but not sure if my explanation was sufficient here. Otherwise i can explain it during the next Swell Development Tag-up.

Also it has the idea of model-differentiated tasks (inspired by the Skylab workflow and @mranst has a PR for it already), so perhaps having `tasks/model/` might be better way of organizing the model specific tasks like he proposed.