### PR TITLE
Minor QOL updates

### DIFF
--- a/docs/code_tests/code_tests.md
+++ b/docs/code_tests/code_tests.md
@@ -10,3 +10,10 @@ Here are a few steps the CI test will run online after your PR, but it can be ea
 
   If you do not see the print-out information following the error code this could be due to `LOGLEVEL` is set to `WARNING` by default. See
 line 32 of `swell/test/code_tests/code_tests.py`, which reads `os.environ.setdefault("LOGLEVEL", "WARNING")`. To debug, set the `LOGLEVEL` environment value to `DEBUG` and run `swell test code_tests` again, this time more details will be provided regarding the failed tests.
+
+By default, swell will create several directories in the working directory that code tests are launched from during the testing process. The user can select a custom location for these directories to be sent to by setting `test_cache_location` under `~/.swell/swell-test.yaml`. For example
+
+`~/.swell/swell-test.yaml`:
+```yaml
+test_cache_location: /discover/nobackup/<user>/swell-test-cache
+```

--- a/src/swell/deployment/launch_experiment.py
+++ b/src/swell/deployment/launch_experiment.py
@@ -12,7 +12,7 @@ import os
 
 # local imports
 from swell.utilities.logger import get_logger
-from swell.utilities.shell_commands import run_subprocess
+from swell.utilities.shell_commands import run_subprocess_simple_output
 
 # --------------------------------------------------------------------------------------------------
 
@@ -55,21 +55,22 @@ class DeployWorkflow():
             # Add optional path for workflow engine logging.
             option = '--symlink-dirs=run=' + self.log_path
             print(['cylc', 'install', option])
-            run_subprocess(self.logger, ['cylc', 'install', option])
+            run_subprocess_simple_output(self.logger, ['cylc', 'install', option])
         else:
-            run_subprocess(self.logger, ['cylc', 'install'])
+            run_subprocess_simple_output(self.logger, ['cylc', 'install'])
 
         # Start the workflow
 
         if self.no_detach:
 
             # Start the suite and wait for the workflow to complete.
-            run_subprocess(self.logger, ['cylc', 'play', '--no-detach', self.experiment_name])
+            run_subprocess_simple_output(self.logger,
+                                         ['cylc', 'play', '--no-detach', self.experiment_name])
 
         else:
 
             # Start the suite and return
-            run_subprocess(self.logger, ['cylc', 'play', self.experiment_name])
+            run_subprocess_simple_output(self.logger, ['cylc', 'play', self.experiment_name])
 
             # Pre TUI messages
             self.logger.info(' ')
@@ -95,7 +96,7 @@ class DeployWorkflow():
             self.logger.info(' ')
             self.logger.info('  \u001b[32mcylc tui ' + self.experiment_name + '\033[0m')
             self.logger.info(' ')
-            run_subprocess(self.logger, ['cylc', 'tui', self.experiment_name])
+            run_subprocess_simple_output(self.logger, ['cylc', 'tui', self.experiment_name])
 
 # --------------------------------------------------------------------------------------------------
 

--- a/src/swell/test/code_tests/test_generate_observing_system.py
+++ b/src/swell/test/code_tests/test_generate_observing_system.py
@@ -42,7 +42,7 @@ class GenerateObservingSystemTest(unittest.TestCase):
         if test_cache:
             observing_system_records_path = os.path.join(test_cache, observing_system_records_path)
         else:
-            observing_system_records_path = os.path.join('./', observing_sytem_records_path)
+            observing_system_records_path = os.path.join('./', observing_system_records_path)
         cls.observing_system_records_path = observing_system_records_path
         cls.dt_cycle_time = dt.strptime("20211212T000000Z", "%Y%m%dT%H%M%SZ")
         geos_mksi_path = 'GEOS_mksi/'

--- a/src/swell/test/code_tests/test_generate_observing_system.py
+++ b/src/swell/test/code_tests/test_generate_observing_system.py
@@ -7,20 +7,28 @@ from swell.utilities.exceptions import SwellError
 from swell.utilities.get_channels import get_channels
 from swell.test.code_tests.testing_utilities import suppress_stdout
 from swell.utilities.observing_system_records import ObservingSystemRecords
+from swell.utilities.test_cache import get_test_cache
 
 
 def setup_geos_mksi(reference: str):
     """
     Clone GEOS-mksi and checkout a branch or commit specified by `reference`.
     """
+
+    geos_mksi_path = 'GEOS_mksi'
+
+    test_cache = get_test_cache()
+    if test_cache:
+        geos_mksi_path = os.path.join(test_cache, geos_mksi_path)
+
     url = "https://github.com/GEOS-ESM/GEOS_mksi.git"
     # Clone repo if not already cloned
-    if not os.path.exists("GEOS_mksi"):
-        git_clone_cmd = ["git", "clone", url, "GEOS_mksi"]
+    if not os.path.exists(geos_mksi_path):
+        git_clone_cmd = ["git", "clone", url, geos_mksi_path]
         subprocess.run(git_clone_cmd, stderr=subprocess.DEVNULL)
 
     git_checkout_cmd = ["git", "checkout", reference]
-    subprocess.run(git_checkout_cmd, cwd="./GEOS_mksi", stdout=subprocess.DEVNULL,
+    subprocess.run(git_checkout_cmd, cwd=geos_mksi_path, stdout=subprocess.DEVNULL,
                    stderr=subprocess.DEVNULL)
 
 
@@ -29,9 +37,18 @@ class GenerateObservingSystemTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.logger = get_logger("GenerateObservingSystemTest")
-        cls.observing_system_records_path = "./output/"
+        observing_system_records_path = "output/"
+        test_cache = get_test_cache()
+        if test_cache:
+            observing_system_records_path = os.path.join(test_cache, observing_system_records_path)
+        else:
+            observing_system_records_path = os.path.join('./', observing_sytem_records_path)
+        cls.observing_system_records_path = observing_system_records_path
         cls.dt_cycle_time = dt.strptime("20211212T000000Z", "%Y%m%dT%H%M%SZ")
-        cls.path_to_gsi_records = os.path.join("GEOS_mksi/", "sidb")
+        geos_mksi_path = 'GEOS_mksi/'
+        if test_cache:
+            geos_mksi_path = os.path.join(test_cache, geos_mksi_path)
+        cls.path_to_gsi_records = os.path.join(geos_mksi_path, "sidb")
 
     def test_geos_mksi_broken(self):
 

--- a/src/swell/test/code_tests/test_pinned_versions.py
+++ b/src/swell/test/code_tests/test_pinned_versions.py
@@ -5,15 +5,19 @@ from swell.utilities.logger import get_logger
 from swell.utilities.exceptions import SwellError
 from swell.test.code_tests.testing_utilities import suppress_stdout
 from swell.utilities.pinned_versions.check_hashes import check_hashes
+from swell.utilities.test_cache import get_test_cache
 
 
 class PinnedVersionsTest(unittest.TestCase):
 
     def test_wrong_hash(self) -> None:
         logger = get_logger("PinnedVersionsTest")
+
         jedi_bundle_dir = "jedi_bundle/"
-        if not os.path.exists(jedi_bundle_dir):
-            os.makedirs(jedi_bundle_dir)
+        test_cache = get_test_cache()
+
+        if test_cache:
+            jedi_bundle_dir = os.path.join(test_cache, jedi_bundle_dir)
 
         # Clone oops repository in jedi_bundle (develop hash)
         if not os.path.exists(jedi_bundle_dir + "oops"):

--- a/src/swell/test/code_tests/test_pinned_versions.py
+++ b/src/swell/test/code_tests/test_pinned_versions.py
@@ -19,6 +19,9 @@ class PinnedVersionsTest(unittest.TestCase):
         if test_cache:
             jedi_bundle_dir = os.path.join(test_cache, jedi_bundle_dir)
 
+        if not os.path.exists(jedi_bundle_dir):
+            os.makedirs(jedi_bundle_dir)
+
         # Clone oops repository in jedi_bundle (develop hash)
         if not os.path.exists(jedi_bundle_dir + "oops"):
             cmd = ["git", "clone", "https://github.com/JCSDA/oops.git"]

--- a/src/swell/utilities/shell_commands.py
+++ b/src/swell/utilities/shell_commands.py
@@ -8,6 +8,7 @@
 
 
 import os
+import sys
 import stat
 import subprocess
 from typing import Any, Optional, IO, Union
@@ -89,6 +90,25 @@ def run_subprocess(
     except subprocess.CalledProcessError as e:
         msg = (f"Subprocess with command '{command}' failed, throwing error '{e}'")
         logger.abort(msg)
+
+# --------------------------------------------------------------------------------------------------
+
+
+def run_subprocess_simple_output(
+    logger: Logger,
+    command: Union[list[str], str],
+    stdout: Union[int, IO[Any], None] = None,
+    stderr: Union[int, IO[Any], None] = None,
+    **kwargs
+) -> None:
+
+    # Run subprocess
+    try:
+        result = subprocess.run(command, check=True, text=True, capture_output=True)
+        print(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(e.stderr)
+        sys.exit(e.stderr)
 
 # --------------------------------------------------------------------------------------------------
 

--- a/src/swell/utilities/test_cache.py
+++ b/src/swell/utilities/test_cache.py
@@ -1,0 +1,27 @@
+# (C) Copyright 2023- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+
+# --------------------------------------------------------------------------------------------------
+
+from typing import Optional
+
+import os
+import yaml
+
+# --------------------------------------------------------------------------------------------------
+
+
+def get_test_cache() -> Optional[str]:
+    test_settings_file = os.path.expanduser('~/.swell/swell-test.yaml')
+    if os.path.exists(test_settings_file):
+        with open(test_settings_file, 'r') as f:
+            test_settings = yaml.safe_load(f)
+        if 'test_cache_location' in test_settings:
+            return test_settings['test_cache_location']
+    return None
+
+# --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR addresses two things that have been bugging me about swell for a while. The first allows for a location to be set for code tests to send the `jedi_bundle`, `GEOS_mksi`, and `output` directories that are created when code testing, rather than being created in the cwd. The second suppresses some of the output from the subprocess commands used to run cylc from within swell, making the error messages a bit easier to parse