### PR TITLE
Fix for cylc tui launch

### DIFF
--- a/src/swell/deployment/launch_experiment.py
+++ b/src/swell/deployment/launch_experiment.py
@@ -12,7 +12,7 @@ import os
 
 # local imports
 from swell.utilities.logger import get_logger
-from swell.utilities.shell_commands import run_subprocess_simple_output
+from swell.utilities.shell_commands import run_subprocess_simple_output, run_subprocess
 
 # --------------------------------------------------------------------------------------------------
 
@@ -96,7 +96,7 @@ class DeployWorkflow():
             self.logger.info(' ')
             self.logger.info('  \u001b[32mcylc tui ' + self.experiment_name + '\033[0m')
             self.logger.info(' ')
-            run_subprocess_simple_output(self.logger, ['cylc', 'tui', self.experiment_name])
+            run_subprocess(self.logger, ['cylc', 'tui', self.experiment_name])
 
 # --------------------------------------------------------------------------------------------------
 

--- a/src/swell/suites/3dfgat_cycle/flow.cylc
+++ b/src/swell/suites/3dfgat_cycle/flow.cylc
@@ -204,6 +204,7 @@
         script = "swell task GenerateBClimatology $config -d $datetime -m {{model_component}}"
         platform = {{platform}}
         execution time limit = {{scheduling["GenerateBClimatology"]["execution_time_limit"]}}
+        execution retry delays = 2*PT1M
         [[[directives]]]
         {%- for key, value in scheduling["GenerateBClimatology"]["directives"][model_component].items() %}
             --{{key}} = {{value}}

--- a/src/swell/suites/3dvar/flow.cylc
+++ b/src/swell/suites/3dvar/flow.cylc
@@ -129,6 +129,7 @@
         script = "swell task GenerateBClimatology $config -d $datetime -m {{model_component}}"
         platform = {{platform}}
         execution time limit = {{scheduling["GenerateBClimatology"]["execution_time_limit"]}}
+        execution retry delays = 2*PT1M
         [[[directives]]]
         {%- for key, value in scheduling["GenerateBClimatology"]["directives"][model_component].items() %}
             --{{key}} = {{value}}

--- a/src/swell/suites/3dvar_cycle/flow.cylc
+++ b/src/swell/suites/3dvar_cycle/flow.cylc
@@ -203,6 +203,7 @@
         script = "swell task GenerateBClimatology $config -d $datetime -m {{model_component}}"
         platform = {{platform}}
         execution time limit = {{scheduling["GenerateBClimatology"]["execution_time_limit"]}}
+        execution retry delays = 2*PT1M
         [[[directives]]]
         {%- for key, value in scheduling["GenerateBClimatology"]["directives"][model_component].items() %}
             --{{key}} = {{value}}


### PR DESCRIPTION
## Description

The change in #654 broke the way the tui opens after running cylc launch. This fixes that and also adds `execution retry delays` to `GenerateBClimatology` as an attempt at a band-aid solution to it failing sometimes on ci tests