### PR TITLE
Automatically calculate window_offset from window_length

### DIFF
--- a/docs/adding_a_suite.md
+++ b/docs/adding_a_suite.md
@@ -364,7 +364,6 @@ class SuiteConfig(QuestionContainer, Enum):
             qd.cycle_times(['T12']),
             qd.marine_models(['mom6']),
             qd.window_length("P1D"),
-            qd.window_offset("PT12H"),
             qd.horizontal_resolution("72x36"),
             qd.vertical_resolution("50"),
             qd.total_processors(6),
@@ -385,7 +384,6 @@ class SuiteConfig(QuestionContainer, Enum):
                 "temp_profile_xbt"
             ]),
             qd.obs_provider(['odas', 'gdas_marine']),
-            qd.analysis_forecast_window_offset("-PT12H"),
             qd.background_time_offset("PT18H"),
             qd.clean_patterns(['*.nc4', '*.txt']),
         ]

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/task_questions.yaml
@@ -1,7 +1,3 @@
-analysis_forecast_window_offset:
-  default_value: -PT3H
-  options:
-  - -PT3H
 
 analysis_variables:
   default_value:
@@ -373,9 +369,6 @@ vertical_resolution:
 
 window_length:
   default_value: PT6H
-
-window_offset:
-  default_value: PT3H
 
 window_type:
   default_value: 4D

--- a/src/swell/configuration/jedi/interfaces/geos_marine/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/task_questions.yaml
@@ -1,8 +1,3 @@
-analysis_forecast_window_offset:
-  default_value: -PT6H
-  options:
-  - -PT12H
-  - -PT6H
 
 analysis_variables:
   default_value:
@@ -140,9 +135,6 @@ vertical_resolution:
 
 window_length:
   default_value: PT12H
-
-window_offset:
-  default_value: PT6H
 
 window_type:
   default_value: 3D

--- a/src/swell/suites/3dfgat_cycle/suite_config.py
+++ b/src/swell/suites/3dfgat_cycle/suite_config.py
@@ -50,7 +50,6 @@ class SuiteConfig(QuestionContainer, Enum):
                 "sea_ice_snow_thickness"
             ]),
             qd.window_length("PT6H"),
-            qd.window_offset("PT3H"),
             qd.window_type("4D"),
             qd.horizontal_resolution("72x36"),
             qd.vertical_resolution("50"),
@@ -77,7 +76,6 @@ class SuiteConfig(QuestionContainer, Enum):
             qd.number_of_iterations([10]),
             qd.obs_provider(['odas', 'gdas_marine']),
             qd.mom6_iau(True),
-            qd.analysis_forecast_window_offset("-PT3H"),
             qd.background_time_offset("PT9H"),
             qd.clean_patterns([
                 "*.txt",

--- a/src/swell/suites/3dvar/suite_config.py
+++ b/src/swell/suites/3dvar/suite_config.py
@@ -34,7 +34,6 @@ class SuiteConfig(QuestionContainer, Enum):
             qd.cycle_times(['T12']),
             qd.marine_models(['mom6']),
             qd.window_length("P1D"),
-            qd.window_offset("PT12H"),
             qd.horizontal_resolution("72x36"),
             qd.vertical_resolution("50"),
             qd.total_processors(6),
@@ -55,7 +54,6 @@ class SuiteConfig(QuestionContainer, Enum):
                 "temp_profile_xbt"
             ]),
             qd.obs_provider(['odas', 'gdas_marine']),
-            qd.analysis_forecast_window_offset("-PT12H"),
             qd.background_time_offset("PT18H"),
             qd.clean_patterns(['*.nc4', '*.txt']),
         ]

--- a/src/swell/suites/3dvar_atmos/suite_config.py
+++ b/src/swell/suites/3dvar_atmos/suite_config.py
@@ -41,7 +41,6 @@ class SuiteConfig(QuestionContainer, Enum):
             qd.geos_x_background_directory("/discover/nobackup/projects/gmao/"
                                            "dadev/rtodling/archive/Restarts/JEDI/541x"),
             qd.window_length("PT6H"),
-            qd.window_offset("PT3H"),
             qd.window_type("3D"),
             qd.horizontal_resolution("91"),
             qd.gsibec_nlats("91"),

--- a/src/swell/suites/3dvar_cycle/suite_config.py
+++ b/src/swell/suites/3dvar_cycle/suite_config.py
@@ -40,7 +40,6 @@ class SuiteConfig(QuestionContainer, Enum):
                 "T18",
             ]),
             qd.window_length("PT6H"),
-            qd.window_offset("PT3H"),
             qd.horizontal_resolution("72x36"),
             qd.vertical_resolution("50"),
             qd.total_processors(6),
@@ -63,7 +62,6 @@ class SuiteConfig(QuestionContainer, Enum):
             qd.obs_provider(['odas', 'gdas_marine']),
             qd.mom6_iau(True),
             qd.marine_models(['mom6']),
-            qd.analysis_forecast_window_offset("-PT3H"),
             qd.background_time_offset("PT9H"),
             qd.clean_patterns([
                 "*.nc4",

--- a/src/swell/suites/eva_capabilities/suite_config.py
+++ b/src/swell/suites/eva_capabilities/suite_config.py
@@ -32,7 +32,6 @@ class SuiteConfig(QuestionContainer, Enum):
         geos_marine=[
             qd.cycle_times(['T00', 'T06', 'T12', 'T18']),
             qd.window_length("PT6H"),
-            qd.window_offset("PT3H"),
             qd.observations([
                 "adt_cryosat2n",
                 "adt_jason3",

--- a/src/swell/tasks/eva_comparison_increment.py
+++ b/src/swell/tasks/eva_comparison_increment.py
@@ -31,9 +31,9 @@ class EvaComparisonIncrement(taskBase):
             config_dict = yaml.safe_load(f)
 
         window_type = config_dict['models'][self.get_model()]['window_type']
-        window_offset = config_dict['models'][self.get_model()]['window_offset']
+        window_length = config_dict['models'][self.get_model()]['window_length']
 
-        return window_type, window_offset
+        return window_type, window_length
 
     def execute(self) -> None:
 
@@ -51,7 +51,7 @@ class EvaComparisonIncrement(taskBase):
         experiment_path_1 = experiment_paths[0]
         experiment_path_2 = experiment_paths[1]
 
-        window_type, window_offset = self.window_info_from_config(experiment_path_1)
+        window_type, window_length = self.window_info_from_config(experiment_path_1)
 
         # Create the cycle dir for this experiment
         cycle_dir = self.cycle_dir()
@@ -61,7 +61,7 @@ class EvaComparisonIncrement(taskBase):
         da_window_params = DataAssimilationWindowParams(self.logger, cycle_time_dto.strftime(
             '%Y-%m-%dT%H:%M:%SZ'))
 
-        window_begin_dto = da_window_params.window_begin(window_offset, dto=True)
+        window_begin_dto = da_window_params.window_begin(window_length, dto=True)
         window_begin = window_begin_dto.strftime('%Y%m%d_%H%M%Sz')
 
         # Info to task log

--- a/src/swell/tasks/eva_increment.py
+++ b/src/swell/tasks/eva_increment.py
@@ -46,7 +46,7 @@ class EvaIncrement(taskBase):
 
         # Create time strings for eva_override directory
         cycle_time_reformat = self.cycle_time_dto().strftime('%Y%m%d_%H%M%Sz')
-        window_begin_dto = self.da_window_params.window_begin(self.config.window_offset(),
+        window_begin_dto = self.da_window_params.window_begin(self.config.window_length(),
                                                               dto=True)
         window_begin = window_begin_dto.strftime('%Y%m%d_%H%M%Sz')
 

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -41,9 +41,8 @@ class EvaObservations(taskBase):
         # Compute window beginning time
         # -----------------------------
         window_begin = self.da_window_params.window_begin(window_length)
-        background_time = self.da_window_params.background_time(window_length,
-                                                                self.config.background_time_offset()
-                                                                )
+        background_time = self.da_window_params.background_time(
+                self.config.background_time_offset())
 
         # Create JEDI interface config templates dictionary
         # -------------------------------------------------

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -36,10 +36,12 @@ class EvaObservations(taskBase):
 
     def execute(self) -> None:
 
+        window_length = self.config.window_length()
+
         # Compute window beginning time
         # -----------------------------
-        window_begin = self.da_window_params.window_begin(self.config.window_offset())
-        background_time = self.da_window_params.background_time(self.config.window_offset(),
+        window_begin = self.da_window_params.window_begin(window_length)
+        background_time = self.da_window_params.background_time(window_length,
                                                                 self.config.background_time_offset()
                                                                 )
 

--- a/src/swell/tasks/eva_timeseries.py
+++ b/src/swell/tasks/eva_timeseries.py
@@ -43,9 +43,8 @@ class EvaTimeseries(taskBase):
         # Compute window beginning time
         # -----------------------------
         window_begin = self.da_window_params.window_begin(window_length)
-        background_time = self.da_window_params.background_time(window_length,
-                                                                self.config.background_time_offset()
-                                                                )
+        background_time = self.da_window_params.background_time(
+                self.config.background_time_offset())
 
         ncdiag_experiments = self.config.ncdiag_experiments()
 

--- a/src/swell/tasks/eva_timeseries.py
+++ b/src/swell/tasks/eva_timeseries.py
@@ -38,13 +38,15 @@ class EvaTimeseries(taskBase):
 
     def execute(self) -> None:
 
+        window_length = self.config.window_length()
+
         # Compute window beginning time
         # -----------------------------
-        window_begin = self.da_window_params.window_begin(self.config.window_offset())
-        background_time = self.da_window_params.background_time(self.config.window_offset(),
+        window_begin = self.da_window_params.window_begin(window_length)
+        background_time = self.da_window_params.background_time(window_length,
                                                                 self.config.background_time_offset()
                                                                 )
-        window_length = self.config.window_length()
+
         ncdiag_experiments = self.config.ncdiag_experiments()
 
         # Use built-in methods to get the start and end cycle points
@@ -54,7 +56,7 @@ class EvaTimeseries(taskBase):
 
         # Parse window length and offset
         window_duration = isodate.parse_duration(window_length)
-        window_offset = isodate.parse_duration(self.config.window_offset())
+        window_offset = self.da_window_params.window_offset(window_length, dto=True)
 
         # Create a list of cycles beginning with the start cycle point
         # and ending with the final cycle point using the window length

--- a/src/swell/tasks/generate_b_climatology.py
+++ b/src/swell/tasks/generate_b_climatology.py
@@ -235,7 +235,7 @@ class GenerateBClimatology(taskBase):
 
         # Parse configuration
         # -------------------
-        window_offset = self.config.window_offset()
+        window_length = self.config.window_length()
         window_type = self.config.window_type()
         background_error_model = self.config.background_error_model()
 
@@ -264,9 +264,9 @@ class GenerateBClimatology(taskBase):
         self.jedi_rendering.add_key('marine_models', self.config.marine_models(None))
         # Compute data assimilation window parameters
         # -------------------------------------------
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,
                                                                                     window_type)
 
         # Background

--- a/src/swell/tasks/generate_b_climatology_by_linking.py
+++ b/src/swell/tasks/generate_b_climatology_by_linking.py
@@ -64,9 +64,9 @@ class GenerateBClimatologyByLinking(taskBase):
 
         # Compute data assimilation window parameters to obtain the local background time
         # -------------------------------------------------------------------------------
-        window_offset = self.config.window_offset()
+        window_length = self.config.window_length()
         window_type = self.config.window_type()
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
 
         # Background

--- a/src/swell/tasks/get_background.py
+++ b/src/swell/tasks/get_background.py
@@ -43,17 +43,15 @@ class GetBackground(taskBase):
         # Parse config
         background_experiment = self.config.background_experiment()
         background_frequency = self.config.background_frequency(None)
-        forecast_offset = self.config.analysis_forecast_window_offset()
         horizontal_resolution = self.config.horizontal_resolution()
         window_length = self.config.window_length()
-        window_offset = self.config.window_offset()
         window_type = self.config.window_type()
         r2d2_local_path = self.config.r2d2_local_path()
 
         # Get window parameters
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        analysis_time_iso = self.da_window_params.analysis_time_iso(window_type, self.suite_name())
+        analysis_time_iso = self.da_window_params.analysis_time_iso()
 
         # Add to jedi config rendering dictionary
         self.jedi_rendering.add_key('local_background_time', local_background_time)
@@ -67,7 +65,7 @@ class GetBackground(taskBase):
         # Convert to datetime durations
         # -----------------------------
         window_length_dur = isodate.parse_duration(window_length)
-        forecast_offset_dur = isodate.parse_duration(forecast_offset)
+        forecast_offset_dur = self.da_window_params.analysis_forecast_window_offset(window_length, dto=True)
 
         # Duration between the start of the forecast that generated the background
         # and the middle of the current window
@@ -78,7 +76,7 @@ class GetBackground(taskBase):
         # occurs at the beginning of the window
         # -------------------------------------------------------------------------------
         if window_type == "4D":
-            window_offset_dur = isodate.parse_duration(window_offset)
+            window_offset_dur = self.da_window_params.window_offset(window_length, dto=True)
             forecast_duration_for_background = forecast_duration_for_background - window_offset_dur
 
         # Append the list of backgrounds to get with the first background

--- a/src/swell/tasks/get_background.py
+++ b/src/swell/tasks/get_background.py
@@ -65,7 +65,8 @@ class GetBackground(taskBase):
         # Convert to datetime durations
         # -----------------------------
         window_length_dur = isodate.parse_duration(window_length)
-        forecast_offset_dur = self.da_window_params.analysis_forecast_window_offset(window_length, dto=True)
+        forecast_offset_dur = self.da_window_params.analysis_forecast_window_offset(window_length,
+                                                                                    dto=True)
 
         # Duration between the start of the forecast that generated the background
         # and the middle of the current window

--- a/src/swell/tasks/get_geovals.py
+++ b/src/swell/tasks/get_geovals.py
@@ -25,7 +25,6 @@ class GetGeovals(taskBase):
         # ------------
         geovals_experiment = self.config.geovals_experiment()
         geovals_provider = self.config.geovals_provider()
-        window_offset = self.config.window_offset()
         background_time_offset = self.config.background_time_offset()
         observations = self.config.observations()
         window_length = self.config.window_length()
@@ -33,8 +32,8 @@ class GetGeovals(taskBase):
         r2d2_local_path = self.config.r2d2_local_path()
 
         # Get window begin time
-        window_begin = self.da_window_params.window_begin(window_offset)
-        background_time = self.da_window_params.background_time(window_offset,
+        window_begin = self.da_window_params.window_begin(window_length)
+        background_time = self.da_window_params.background_time(window_length,
                                                                 background_time_offset)
 
         # Set R2D2 config file

--- a/src/swell/tasks/get_geovals.py
+++ b/src/swell/tasks/get_geovals.py
@@ -33,8 +33,7 @@ class GetGeovals(taskBase):
 
         # Get window begin time
         window_begin = self.da_window_params.window_begin(window_length)
-        background_time = self.da_window_params.background_time(window_length,
-                                                                background_time_offset)
+        background_time = self.da_window_params.background_time(background_time_offset)
 
         # Set R2D2 config file
         # --------------------

--- a/src/swell/tasks/get_ncdiags.py
+++ b/src/swell/tasks/get_ncdiags.py
@@ -27,15 +27,14 @@ class GetNcdiags(taskBase):
         # ------------
         ncdiag_experiments = self.config.ncdiag_experiments()
         observations = self.config.observations()
-        window_offset = self.config.window_offset()
         window_length = self.config.window_length()
         r2d2_local_path = self.config.r2d2_local_path()
         background_time_offset = self.config.background_time_offset()
 
         # Compute data assimilation window parameters
         # --------------------------------------------
-        window_begin = self.da_window_params.window_begin(window_offset)
-        background_time = self.da_window_params.background_time(window_offset,
+        window_begin = self.da_window_params.window_begin(window_length)
+        background_time = self.da_window_params.background_time(window_length,
                                                                 background_time_offset)
         self.jedi_rendering.add_key('window_begin', window_begin)
         self.jedi_rendering.add_key('background_time', background_time)

--- a/src/swell/tasks/get_ncdiags.py
+++ b/src/swell/tasks/get_ncdiags.py
@@ -34,8 +34,7 @@ class GetNcdiags(taskBase):
         # Compute data assimilation window parameters
         # --------------------------------------------
         window_begin = self.da_window_params.window_begin(window_length)
-        background_time = self.da_window_params.background_time(window_length,
-                                                                background_time_offset)
+        background_time = self.da_window_params.background_time(background_time_offset)
         self.jedi_rendering.add_key('window_begin', window_begin)
         self.jedi_rendering.add_key('background_time', background_time)
 

--- a/src/swell/tasks/get_observations.py
+++ b/src/swell/tasks/get_observations.py
@@ -120,10 +120,8 @@ class GetObservations(taskBase):
         window_begin_dto = self.da_window_params.window_begin_iso(window_length, dto=True)
         window_end_dto = self.da_window_params.window_end_iso(window_length,
                                                               dto=True)
-        background_time = self.da_window_params.background_time(window_length,
-                                                                background_time_offset)
-        background_time_iso = self.da_window_params.background_time_iso(window_length,
-                                                                        background_time_offset)
+        background_time = self.da_window_params.background_time(background_time_offset)
+        background_time_iso = self.da_window_params.background_time_iso(background_time_offset)
 
         # Determine the input observation files to be fetched, this mainly depends on
         # the observation file organization in R2D2. In other words, they could be

--- a/src/swell/tasks/get_observations.py
+++ b/src/swell/tasks/get_observations.py
@@ -104,7 +104,7 @@ class GetObservations(taskBase):
         observations = self.config.observations()
         window_length = self.config.window_length()
         crtm_coeff_dir = self.config.crtm_coeff_dir(None)
-        window_offset = self.config.window_offset()
+        window_length = self.config.window_length()
         r2d2_local_path = self.config.r2d2_local_path()
         cycling_varbc = self.config.cycling_varbc(None)
 
@@ -116,13 +116,13 @@ class GetObservations(taskBase):
         self.jedi_rendering.set_obs_records_path(self.config.observing_system_records_path(None))
 
         # Get window begin time
-        window_begin = self.da_window_params.window_begin(window_offset)
-        window_begin_dto = self.da_window_params.window_begin_iso(window_offset, dto=True)
-        window_end_dto = self.da_window_params.window_end_iso(window_offset, window_length,
+        window_begin = self.da_window_params.window_begin(window_length)
+        window_begin_dto = self.da_window_params.window_begin_iso(window_length, dto=True)
+        window_end_dto = self.da_window_params.window_end_iso(window_length,
                                                               dto=True)
-        background_time = self.da_window_params.background_time(window_offset,
+        background_time = self.da_window_params.background_time(window_length,
                                                                 background_time_offset)
-        background_time_iso = self.da_window_params.background_time_iso(window_offset,
+        background_time_iso = self.da_window_params.background_time_iso(window_length,
                                                                         background_time_offset)
 
         # Determine the input observation files to be fetched, this mainly depends on

--- a/src/swell/tasks/gsi_bc_to_ioda.py
+++ b/src/swell/tasks/gsi_bc_to_ioda.py
@@ -27,13 +27,13 @@ class GsiBcToIoda(taskBase):
         # Parse configuration
         # -------------------
         observations = self.config.observations()
-        window_offset = self.config.window_offset()
         background_time_offset = self.config.background_time_offset()
+        window_length = self.config.window_length()
         crtm_coeff_dir = self.config.crtm_coeff_dir(None)
 
         # Get window beginning time
-        window_begin = self.da_window_params.window_begin(window_offset)
-        background_time = self.da_window_params.background_time(window_offset,
+        window_begin = self.da_window_params.window_begin(window_length)
+        background_time = self.da_window_params.background_time(window_length,
                                                                 background_time_offset)
 
         # Prepare dictionary for rendering jedi interface files

--- a/src/swell/tasks/gsi_bc_to_ioda.py
+++ b/src/swell/tasks/gsi_bc_to_ioda.py
@@ -33,8 +33,7 @@ class GsiBcToIoda(taskBase):
 
         # Get window beginning time
         window_begin = self.da_window_params.window_begin(window_length)
-        background_time = self.da_window_params.background_time(window_length,
-                                                                background_time_offset)
+        background_time = self.da_window_params.background_time(background_time_offset)
 
         # Prepare dictionary for rendering jedi interface files
         self.jedi_rendering.add_key('background_time', background_time)

--- a/src/swell/tasks/gsi_ncdiag_to_ioda.py
+++ b/src/swell/tasks/gsi_ncdiag_to_ioda.py
@@ -35,10 +35,10 @@ class GsiNcdiagToIoda(taskBase):
         observations = self.config.observations()
         single_observations = self.config.single_observations()
         produce_geovals = self.config.produce_geovals()
-        window_offset = self.config.window_offset()
+        window_length = self.config.window_length()
 
         # Get window beginning time
-        window_begin = self.da_window_params.window_begin(window_offset)
+        window_begin = self.da_window_params.window_begin(window_length)
 
         # Keep copy of the
         observations_orig = observations.copy()

--- a/src/swell/tasks/link_geos_output.py
+++ b/src/swell/tasks/link_geos_output.py
@@ -38,14 +38,13 @@ class LinkGeosOutput(taskBase):
         self.marine_models = self.config.marine_models(None) or []
         self.window_type = self.config.window_type()
         self.window_length = self.config.window_length()
-        self.window_offset = self.config.window_offset()
-        self.window_begin_iso = self.da_window_params.window_begin_iso(self.window_offset)
+        self.window_begin_iso = self.da_window_params.window_begin_iso(self.window_length)
 
         if self.window_type == '4D' or 'fgat' in self.suite_name():
             self.background_frequency = self.config.background_frequency()
 
         self.bkgr_time_iso, self.bkgr_time_dto = self.da_window_params.local_background_time(
-            self.window_offset,
+            self.window_length,
             self.window_type,
             dto=True)
 

--- a/src/swell/tasks/move_da_restart.py
+++ b/src/swell/tasks/move_da_restart.py
@@ -84,7 +84,8 @@ class MoveDaRestart(taskBase):
         agcm_dict = self.geos.parse_rc(self.forecast_dir('AGCM.rc'))
 
         if 'RECORD_FREQUENCY' in agcm_dict:
-            an_fcst_offset = self.config.analysis_forecast_window_offset()
+            window_length = self.config.window_length()
+            an_fcst_offset = self.da_window_params.analysis_forecast_window_offset(window_length)
             rst_dto = self.geos.adjacent_cycle(an_fcst_offset, return_date=True)
 
             self.logger.info('Using _checkpoint restarts with timestamps')
@@ -115,7 +116,9 @@ class MoveDaRestart(taskBase):
 
         if 'RECORD_FREQUENCY' in agcm_dict:
 
-            an_fcst_offset = self.config.analysis_forecast_window_offset()
+            window_length = self.config.window_length()
+
+            an_fcst_offset = self.da_window_params.analysis_forecast_window_offset(window_length)
             rst_dto = self.geos.adjacent_cycle(an_fcst_offset, return_date=True)
             seconds = rst_dto.hour * 3600 + rst_dto.minute * 60 + rst_dto.second
 

--- a/src/swell/tasks/prepare_analysis.py
+++ b/src/swell/tasks/prepare_analysis.py
@@ -44,9 +44,11 @@ class PrepareAnalysis(taskBase):
         self.current_cycle = os.path.basename(self.forecast_dir())
         self.cc_dto = self.cycle_time_dto()
 
+        window_length = self.config.window_length()
+
         # GEOS restarts have seconds in their filename
         # --------------------------------------------
-        an_fcst_offset = self.config.analysis_forecast_window_offset()
+        an_fcst_offset = self.da_window_params.analysis_forecast_window_offset(window_length)
         rst_dto = self.geos.adjacent_cycle(an_fcst_offset, return_date=True)
         seconds = str(rst_dto.hour * 3600 + rst_dto.minute * 60 + rst_dto.second)
 

--- a/src/swell/tasks/run_jedi_convert_state_soca2cice_executable.py
+++ b/src/swell/tasks/run_jedi_convert_state_soca2cice_executable.py
@@ -36,8 +36,8 @@ class RunJediConvertStateSoca2ciceExecutable(taskBase):
 
         # Compute data assimilation window parameters
         # --------------------------------------------
-        analysis_time = self.da_window_params.analysis_time(window_type, self.suite_name())
-        analysis_time_iso = self.da_window_params.analysis_time_iso(window_type, self.suite_name())
+        analysis_time = self.da_window_params.analysis_time()
+        analysis_time_iso = self.da_window_params.analysis_time_iso()
         local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
         local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,

--- a/src/swell/tasks/run_jedi_convert_state_soca2cice_executable.py
+++ b/src/swell/tasks/run_jedi_convert_state_soca2cice_executable.py
@@ -32,15 +32,15 @@ class RunJediConvertStateSoca2ciceExecutable(taskBase):
         generate_yaml_and_exit = self.config.generate_yaml_and_exit(False)
         observations = self.config.observations(None)
         window_type = self.config.window_type()
-        window_offset = self.config.window_offset()
+        window_length = self.config.window_length()
 
         # Compute data assimilation window parameters
         # --------------------------------------------
         analysis_time = self.da_window_params.analysis_time(window_type, self.suite_name())
         analysis_time_iso = self.da_window_params.analysis_time_iso(window_type, self.suite_name())
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,
                                                                                     window_type)
 
         # Populate jedi interface templates dictionary

--- a/src/swell/tasks/run_jedi_ensemble_mean_variance.py
+++ b/src/swell/tasks/run_jedi_ensemble_mean_variance.py
@@ -39,13 +39,12 @@ class RunJediEnsembleMeanVariance(taskBase):
         # Compute data assimilation window parameters
         window_type = self.config.window_type()
         window_length = self.config.window_length()
-        window_offset = self.config.window_offset()
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,
                                                                                     window_type)
-        window_begin_iso = self.da_window_params.window_begin_iso(window_offset)
-        window_end_iso = self.da_window_params.window_end_iso(window_offset, window_length)
+        window_begin_iso = self.da_window_params.window_begin_iso(window_length)
+        window_end_iso = self.da_window_params.window_end_iso(window_length)
 
         # Set the observing system records path
         self.jedi_rendering.set_obs_records_path(self.config.observing_system_records_path(None))

--- a/src/swell/tasks/run_jedi_fgat_executable.py
+++ b/src/swell/tasks/run_jedi_fgat_executable.py
@@ -32,7 +32,6 @@ class RunJediFgatExecutable(taskBase):
         marine_models = self.config.marine_models()
         window_type = self.config.window_type()
         window_length = self.config.window_length()
-        window_offset = self.config.window_offset()
         background_time_offset = self.config.background_time_offset()
         number_of_iterations = self.config.number_of_iterations()
         observations = self.config.observations()
@@ -51,15 +50,15 @@ class RunJediFgatExecutable(taskBase):
 
         # Compute data assimilation window parameters
         # --------------------------------------------
-        background_time = self.da_window_params.background_time(window_offset,
+        background_time = self.da_window_params.background_time(window_length,
                                                                 background_time_offset)
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,
                                                                                     window_type)
-        window_begin = self.da_window_params.window_begin(window_offset)
-        window_begin_iso = self.da_window_params.window_begin_iso(window_offset)
-        window_end_iso = self.da_window_params.window_end_iso(window_offset, window_length)
+        window_begin = self.da_window_params.window_begin(window_length)
+        window_begin_iso = self.da_window_params.window_begin_iso(window_length)
+        window_end_iso = self.da_window_params.window_end_iso(window_length)
 
         # Populate jedi interface templates dictionary
         # --------------------------------------------

--- a/src/swell/tasks/run_jedi_fgat_executable.py
+++ b/src/swell/tasks/run_jedi_fgat_executable.py
@@ -50,8 +50,7 @@ class RunJediFgatExecutable(taskBase):
 
         # Compute data assimilation window parameters
         # --------------------------------------------
-        background_time = self.da_window_params.background_time(window_length,
-                                                                background_time_offset)
+        background_time = self.da_window_params.background_time(background_time_offset)
         local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
         local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,

--- a/src/swell/tasks/run_jedi_hofx_ensemble_executable.py
+++ b/src/swell/tasks/run_jedi_hofx_ensemble_executable.py
@@ -39,22 +39,21 @@ class RunJediHofxEnsembleExecutable(RunJediHofxExecutable, taskBase):
         # -------------------------------------------------------------------
         window_type = self.config.window_type()
         window_length = self.config.window_length()
-        window_offset = self.config.window_offset()
         background_time_offset = self.config.background_time_offset()
         observations = self.config.observations()
         jedi_forecast_model = self.config.jedi_forecast_model(None)
         generate_yaml_and_exit = self.config.generate_yaml_and_exit(False)
 
         # Compute data assimilation window parameters
-        background_time = self.da_window_params.background_time(window_offset,
+        background_time = self.da_window_params.background_time(window_length,
                                                                 background_time_offset)
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,
                                                                                     window_type)
-        window_begin = self.da_window_params.window_begin(window_offset)
-        window_begin_iso = self.da_window_params.window_begin_iso(window_offset)
-        window_end_iso = self.da_window_params.window_end_iso(window_offset, window_length)
+        window_begin = self.da_window_params.window_begin(window_length)
+        window_begin_iso = self.da_window_params.window_begin_iso(window_length)
+        window_end_iso = self.da_window_params.window_end_iso(window_length)
 
         # Ensemble hofx components
         # ------------------------

--- a/src/swell/tasks/run_jedi_hofx_ensemble_executable.py
+++ b/src/swell/tasks/run_jedi_hofx_ensemble_executable.py
@@ -45,12 +45,10 @@ class RunJediHofxEnsembleExecutable(RunJediHofxExecutable, taskBase):
         generate_yaml_and_exit = self.config.generate_yaml_and_exit(False)
 
         # Compute data assimilation window parameters
-        background_time = self.da_window_params.background_time(window_length,
-                                                                background_time_offset)
+        background_time = self.da_window_params.background_time(background_time_offset)
         local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,
-                                                                                    window_type)
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_type)
         window_begin = self.da_window_params.window_begin(window_length)
         window_begin_iso = self.da_window_params.window_begin_iso(window_length)
         window_end_iso = self.da_window_params.window_end_iso(window_length)

--- a/src/swell/tasks/run_jedi_hofx_executable.py
+++ b/src/swell/tasks/run_jedi_hofx_executable.py
@@ -35,7 +35,6 @@ class RunJediHofxExecutable(taskBase):
         # -------------------
         window_type = self.config.window_type()
         window_length = self.config.window_length()
-        window_offset = self.config.window_offset()
         background_time_offset = self.config.background_time_offset()
         observations = self.config.observations()
         jedi_forecast_model = self.config.jedi_forecast_model(None)
@@ -47,15 +46,15 @@ class RunJediHofxExecutable(taskBase):
 
         # Compute data assimilation window parameters
         # --------------------------------------------
-        background_time = self.da_window_params.background_time(window_offset,
+        background_time = self.da_window_params.background_time(window_length,
                                                                 background_time_offset)
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,
                                                                                     window_type)
-        window_begin = self.da_window_params.window_begin(window_offset)
-        window_begin_iso = self.da_window_params.window_begin_iso(window_offset)
-        window_end_iso = self.da_window_params.window_end_iso(window_offset, window_length)
+        window_begin = self.da_window_params.window_begin(window_length)
+        window_begin_iso = self.da_window_params.window_begin_iso(window_length)
+        window_end_iso = self.da_window_params.window_end_iso(window_length)
 
         # Populate jedi interface templates dictionary
         # --------------------------------------------

--- a/src/swell/tasks/run_jedi_hofx_executable.py
+++ b/src/swell/tasks/run_jedi_hofx_executable.py
@@ -46,8 +46,7 @@ class RunJediHofxExecutable(taskBase):
 
         # Compute data assimilation window parameters
         # --------------------------------------------
-        background_time = self.da_window_params.background_time(window_length,
-                                                                background_time_offset)
+        background_time = self.da_window_params.background_time(background_time_offset)
         local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
         local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,

--- a/src/swell/tasks/run_jedi_local_ensemble_da_executable.py
+++ b/src/swell/tasks/run_jedi_local_ensemble_da_executable.py
@@ -33,7 +33,6 @@ class RunJediLocalEnsembleDaExecutable(taskBase):
         # -------------------
         window_type = self.config.window_type()
         window_length = self.config.window_length()
-        window_offset = self.config.window_offset()
         background_time_offset = self.config.background_time_offset()
         observations = self.config.observations()
         jedi_forecast_model = self.config.jedi_forecast_model(None)
@@ -45,15 +44,15 @@ class RunJediLocalEnsembleDaExecutable(taskBase):
         self.jedi_rendering.set_obs_records_path(self.config.observing_system_records_path(None))
 
         # Compute data assimilation window parameters
-        background_time = self.da_window_params.background_time(window_offset,
+        background_time = self.da_window_params.background_time(window_length,
                                                                 background_time_offset)
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,
                                                                                     window_type)
-        window_begin = self.da_window_params.window_begin(window_offset)
-        window_begin_iso = self.da_window_params.window_begin_iso(window_offset)
-        window_end_iso = self.da_window_params.window_end_iso(window_offset, window_length)
+        window_begin = self.da_window_params.window_begin(window_length)
+        window_begin_iso = self.da_window_params.window_begin_iso(window_length)
+        window_end_iso = self.da_window_params.window_end_iso(window_length)
 
         # Populate jedi interface templates dictionary
         # --------------------------------------------

--- a/src/swell/tasks/run_jedi_local_ensemble_da_executable.py
+++ b/src/swell/tasks/run_jedi_local_ensemble_da_executable.py
@@ -44,8 +44,7 @@ class RunJediLocalEnsembleDaExecutable(taskBase):
         self.jedi_rendering.set_obs_records_path(self.config.observing_system_records_path(None))
 
         # Compute data assimilation window parameters
-        background_time = self.da_window_params.background_time(window_length,
-                                                                background_time_offset)
+        background_time = self.da_window_params.background_time(background_time_offset)
         local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
         local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,

--- a/src/swell/tasks/run_jedi_obsfilters_executable.py
+++ b/src/swell/tasks/run_jedi_obsfilters_executable.py
@@ -32,7 +32,6 @@ class RunJediObsfiltersExecutable(taskBase):
         # -------------------
         window_type = self.config.window_type()
         window_length = self.config.window_length()
-        window_offset = self.config.window_offset()
         background_time_offset = self.config.background_time_offset()
         observations = self.config.observations()
         jedi_forecast_model = self.config.jedi_forecast_model(None)
@@ -44,15 +43,15 @@ class RunJediObsfiltersExecutable(taskBase):
 
         # Compute data assimilation window parameters
         # --------------------------------------------
-        background_time = self.da_window_params.background_time(window_offset,
+        background_time = self.da_window_params.background_time(window_length,
                                                                 background_time_offset)
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,
                                                                                     window_type)
-        window_begin = self.da_window_params.window_begin(window_offset)
-        window_begin_iso = self.da_window_params.window_begin_iso(window_offset)
-        window_end_iso = self.da_window_params.window_end_iso(window_offset, window_length)
+        window_begin = self.da_window_params.window_begin(window_length)
+        window_begin_iso = self.da_window_params.window_begin_iso(window_length)
+        window_end_iso = self.da_window_params.window_end_iso(window_length)
 
         # Populate jedi interface templates dictionary
         # --------------------------------------------

--- a/src/swell/tasks/run_jedi_obsfilters_executable.py
+++ b/src/swell/tasks/run_jedi_obsfilters_executable.py
@@ -43,8 +43,7 @@ class RunJediObsfiltersExecutable(taskBase):
 
         # Compute data assimilation window parameters
         # --------------------------------------------
-        background_time = self.da_window_params.background_time(window_length,
-                                                                background_time_offset)
+        background_time = self.da_window_params.background_time(background_time_offset)
         local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
         local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,

--- a/src/swell/tasks/run_jedi_ufo_tests_executable.py
+++ b/src/swell/tasks/run_jedi_ufo_tests_executable.py
@@ -32,7 +32,6 @@ class RunJediUfoTestsExecutable(taskBase):
 
         # Parse configuration
         # -------------------
-        window_offset = self.config.window_offset()
         window_length = self.config.window_length()
         bkg_time_offset = self.config.background_time_offset()
         observations = self.config.observations()
@@ -43,13 +42,13 @@ class RunJediUfoTestsExecutable(taskBase):
         self.jedi_rendering.set_obs_records_path(self.config.observing_system_records_path(None))
 
         # Compute data assimilation window parameters
-        window_begin = self.da_window_params.window_begin(window_offset)
-        window_begin_iso = self.da_window_params.window_begin_iso(window_offset)
-        window_end_iso = self.da_window_params.window_end_iso(window_offset, window_length)
+        window_begin = self.da_window_params.window_begin(window_length)
+        window_begin_iso = self.da_window_params.window_begin_iso(window_length)
+        window_end_iso = self.da_window_params.window_end_iso(window_length)
 
         # Populate jedi interface templates dictionary
         # --------------------------------------------
-        background_time = self.da_window_params.background_time(window_offset, bkg_time_offset)
+        background_time = self.da_window_params.background_time(window_length, bkg_time_offset)
         self.jedi_rendering.add_key('window_begin_iso', window_begin_iso)
         self.jedi_rendering.add_key('window_end_iso', window_end_iso)
 

--- a/src/swell/tasks/run_jedi_ufo_tests_executable.py
+++ b/src/swell/tasks/run_jedi_ufo_tests_executable.py
@@ -48,7 +48,7 @@ class RunJediUfoTestsExecutable(taskBase):
 
         # Populate jedi interface templates dictionary
         # --------------------------------------------
-        background_time = self.da_window_params.background_time(window_length, bkg_time_offset)
+        background_time = self.da_window_params.background_time(bkg_time_offset)
         self.jedi_rendering.add_key('window_begin_iso', window_begin_iso)
         self.jedi_rendering.add_key('window_end_iso', window_end_iso)
 

--- a/src/swell/tasks/run_jedi_variational_executable.py
+++ b/src/swell/tasks/run_jedi_variational_executable.py
@@ -32,7 +32,6 @@ class RunJediVariationalExecutable(taskBase):
         # -------------------
         window_type = self.config.window_type()
         window_length = self.config.window_length()
-        window_offset = self.config.window_offset()
         background_time_offset = self.config.background_time_offset()
         number_of_iterations = self.config.number_of_iterations()
         observations = self.config.observations()
@@ -50,15 +49,15 @@ class RunJediVariationalExecutable(taskBase):
 
         # Compute data assimilation window parameters
         # --------------------------------------------
-        background_time = self.da_window_params.background_time(window_offset,
+        background_time = self.da_window_params.background_time(window_length,
                                                                 background_time_offset)
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,
                                                                                     window_type)
-        window_begin = self.da_window_params.window_begin(window_offset)
-        window_begin_iso = self.da_window_params.window_begin_iso(window_offset)
-        window_end_iso = self.da_window_params.window_end_iso(window_offset, window_length)
+        window_begin = self.da_window_params.window_begin(window_length)
+        window_begin_iso = self.da_window_params.window_begin_iso(window_length)
+        window_end_iso = self.da_window_params.window_end_iso(window_length)
 
         # Populate jedi interface templates dictionary
         # --------------------------------------------

--- a/src/swell/tasks/run_jedi_variational_executable.py
+++ b/src/swell/tasks/run_jedi_variational_executable.py
@@ -49,8 +49,7 @@ class RunJediVariationalExecutable(taskBase):
 
         # Compute data assimilation window parameters
         # --------------------------------------------
-        background_time = self.da_window_params.background_time(window_length,
-                                                                background_time_offset)
+        background_time = self.da_window_params.background_time(background_time_offset)
         local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
         local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,

--- a/src/swell/tasks/save_obs_diags.py
+++ b/src/swell/tasks/save_obs_diags.py
@@ -38,8 +38,7 @@ class SaveObsDiags(taskBase):
 
         # Get window beginning
         window_begin = self.da_window_params.window_begin(window_length)  # dto
-        background_time = self.da_window_params.background_time(window_length,
-                                                                background_time_offset)
+        background_time = self.da_window_params.background_time(background_time_offset)
 
         # Create templates dictionary
         self.jedi_rendering.add_key('background_time', background_time)

--- a/src/swell/tasks/save_obs_diags.py
+++ b/src/swell/tasks/save_obs_diags.py
@@ -29,7 +29,7 @@ class SaveObsDiags(taskBase):
         background_time_offset = self.config.background_time_offset()
         crtm_coeff_dir = self.config.crtm_coeff_dir(None)
         observations = self.config.observations()
-        window_offset = self.config.window_offset()
+        window_length = self.config.window_length()
         r2d2_local_path = self.config.r2d2_local_path()
 
         # Set the observing system records path
@@ -37,8 +37,8 @@ class SaveObsDiags(taskBase):
         self.jedi_rendering.add_key('marine_models', self.config.marine_models(None))
 
         # Get window beginning
-        window_begin = self.da_window_params.window_begin(window_offset)  # dto
-        background_time = self.da_window_params.background_time(window_offset,
+        window_begin = self.da_window_params.window_begin(window_length)  # dto
+        background_time = self.da_window_params.background_time(window_length,
                                                                 background_time_offset)
 
         # Create templates dictionary

--- a/src/swell/tasks/save_restart.py
+++ b/src/swell/tasks/save_restart.py
@@ -33,7 +33,6 @@ class SaveRestart(taskBase):
         # Parse config
         window_type = self.config.window_type()
         window_length = self.config.window_length()
-        window_offset = self.config.window_offset()
         forecast_duration = self.config.forecast_duration()
         self.jedi_rendering.add_key('marine_models', self.config.marine_models(None))
         r2d2_local_path = self.config.r2d2_local_path()
@@ -43,11 +42,11 @@ class SaveRestart(taskBase):
         forecast_start_time = self.cycle_time_dto() - isodate.parse_duration(background_time_offset)
 
         # Convert to datetime durations
-        local_background_time = self.da_window_params.local_background_time(window_offset,
+        local_background_time = self.da_window_params.local_background_time(window_length,
                                                                             window_type)
-        local_background_time_iso = self.da_window_params.local_background_time_iso(window_offset,
+        local_background_time_iso = self.da_window_params.local_background_time_iso(window_length,
                                                                                     window_type)
-        analysis_time_iso = self.da_window_params.analysis_time_iso(window_type, self.suite_name())
+        analysis_time_iso = self.da_window_params.analysis_time_iso()
         self.jedi_rendering.add_key('local_background_time', local_background_time)
         self.jedi_rendering.add_key('local_background_time_iso', local_background_time_iso)
         self.jedi_rendering.add_key('analysis_time_iso', analysis_time_iso)

--- a/src/swell/tasks/store_background.py
+++ b/src/swell/tasks/store_background.py
@@ -45,17 +45,16 @@ class StoreBackground(taskBase):
         # Parse config
         window_type = self.config.window_type()
         window_length = self.config.window_length()
-        window_offset = self.config.window_offset()
         background_experiment = self.config.background_experiment()
         background_frequency = self.config.background_frequency()
         r2d2_local_path = self.config.r2d2_local_path()
 
         # Position relative to center of the window where forecast starts
-        forecast_offset = self.config.analysis_forecast_window_offset()
+        forecast_offset = self.da_window_params.analysis_forecast_window_offset(window_length)
 
         # Convert to datetime durations
         window_length_dur = isodate.parse_duration(window_length)
-        window_offset_dur = isodate.parse_duration(window_offset)
+        window_offset_dur = self.da_window_params.window_offset(window_length, dto=True)
         forecast_offset_dur = isodate.parse_duration(forecast_offset)
 
         # Set R2D2 config file

--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -684,6 +684,7 @@ class TaskQuestions(QuestionContainer, Enum):
         list_name="SaveObsDiags",
         questions=[
             background_crtm_obs,
+            qd.window_length(),
             qd.r2d2_local_path(),
             qd.marine_models()
         ]

--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -51,7 +51,6 @@ class TaskQuestions(QuestionContainer, Enum):
         list_name="window_questions",
         questions=[
             qd.window_length(),
-            qd.window_offset(),
             qd.window_type()
         ]
     )
@@ -197,7 +196,7 @@ class TaskQuestions(QuestionContainer, Enum):
         list_name="EvaIncrement",
         questions=[
             qd.marine_models(),
-            qd.window_offset(),
+            qd.window_length(),
             qd.window_type()
         ]
     )
@@ -210,7 +209,7 @@ class TaskQuestions(QuestionContainer, Enum):
             background_crtm_obs,
             qd.marine_models(),
             qd.observing_system_records_path(),
-            qd.window_offset(),
+            qd.window_length(),
             qd.marine_models(),
         ]
     )
@@ -222,7 +221,6 @@ class TaskQuestions(QuestionContainer, Enum):
         questions=[
             background_crtm_obs,
             qd.window_length(),
-            qd.window_offset(),
             qd.ncdiag_experiments(),
             qd.marine_models(),
         ]
@@ -248,7 +246,7 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.number_of_iterations(),
             qd.observing_system_records_path(),
             qd.total_processors(),
-            qd.window_offset(),
+            qd.window_length(),
             qd.window_type()
         ]
     )
@@ -262,7 +260,6 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.background_error_model(),
             qd.horizontal_resolution(),
             qd.vertical_resolution(),
-            qd.window_offset(),
             qd.window_type()
         ]
     )
@@ -284,7 +281,6 @@ class TaskQuestions(QuestionContainer, Enum):
         list_name="GetBackground",
         questions=[
             window_questions,
-            qd.analysis_forecast_window_offset(),
             qd.background_experiment(),
             qd.background_frequency(),
             qd.horizontal_resolution(),
@@ -344,7 +340,6 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.geovals_provider(),
             qd.r2d2_local_path(),
             qd.window_length(),
-            qd.window_offset()
         ]
     )
 
@@ -396,7 +391,6 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.marine_models(),
             qd.r2d2_local_path(),
             qd.window_length(),
-            qd.window_offset(),
         ]
     )
 
@@ -412,7 +406,6 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.observing_system_records_path(),
             qd.r2d2_local_path(),
             qd.window_length(),
-            qd.window_offset(),
         ]
     )
 
@@ -432,7 +425,7 @@ class TaskQuestions(QuestionContainer, Enum):
         questions=[
             background_crtm_obs,
             qd.observing_system_records_path(),
-            qd.window_offset()
+            qd.window_length()
         ]
     )
 
@@ -444,7 +437,7 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.observations(),
             qd.produce_geovals(),
             qd.single_observations(),
-            qd.window_offset()
+            qd.window_length()
         ]
     )
 
@@ -483,7 +476,6 @@ class TaskQuestions(QuestionContainer, Enum):
     MoveDaRestart = QuestionList(
         list_name="MoveDaRestart",
         questions=[
-            qd.analysis_forecast_window_offset(),
             qd.mom6_iau(),
             qd.window_length()
         ]
@@ -503,10 +495,10 @@ class TaskQuestions(QuestionContainer, Enum):
     PrepareAnalysis = QuestionList(
         list_name="PrepareAnalysis",
         questions=[
-            qd.analysis_forecast_window_offset(),
             qd.analysis_variables(),
             qd.mom6_iau(),
-            qd.total_processors()
+            qd.total_processors(),
+            qd.window_length()
         ]
     )
 
@@ -534,7 +526,7 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.marine_models(),
             qd.observations(),
             qd.total_processors(),
-            qd.window_offset(),
+            qd.window_length(),
             qd.window_type(),
             qd.comparison_log_type('convert_state_soca2cice'),
         ]
@@ -671,7 +663,6 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.generate_yaml_and_exit(),
             qd.single_observations(),
             qd.window_length(),
-            qd.window_offset(),
             qd.comparison_log_type('ufo_tests'),
         ]
     )
@@ -694,7 +685,6 @@ class TaskQuestions(QuestionContainer, Enum):
         questions=[
             background_crtm_obs,
             qd.r2d2_local_path(),
-            qd.window_offset(),
             qd.marine_models()
         ]
     )
@@ -733,7 +723,6 @@ class TaskQuestions(QuestionContainer, Enum):
         list_name="StoreBackground",
         questions=[
             window_questions,
-            qd.analysis_forecast_window_offset(),
             qd.background_experiment(),
             qd.background_frequency(),
             qd.horizontal_resolution(),

--- a/src/swell/utilities/check_da_params.py
+++ b/src/swell/utilities/check_da_params.py
@@ -50,7 +50,6 @@ def check_da_params(config_list: list,
         final_cycle_point = config_dict['final_cycle_point']
 
         window_length = config_dict['models'][model_component]['window_length']
-        window_offset = config_dict['models'][model_component]['window_offset']
         cycle_times = config_dict['models'][model_component]['cycle_times']
 
         # Save the information
@@ -60,14 +59,12 @@ def check_da_params(config_list: list,
                                                           datetime_formats['iso_format'])
 
         cycle_dict['window_length'] = window_length
-        cycle_dict['window_offset'] = window_offset
         cycle_dict['cycle_times'] = cycle_times
 
     start_cycle_dtos = []
     final_cycle_dtos = []
 
     window_lengths = []
-    window_offsets = []
 
     # Gather all the window params into a list
     for value in cycle_dicts.values():
@@ -75,10 +72,9 @@ def check_da_params(config_list: list,
         final_cycle_dtos.append(value['final_cycle_dto'])
 
         window_lengths.append(value['window_length'])
-        window_offsets.append(value['window_offset'])
 
     # Check to make sure the window params match
-    if len(set(window_lengths)) > 1 or len(set(window_offsets)) > 1:
+    if len(set(window_lengths)) > 1:
         logger.abort('The experiments specified have mismatched window parameters.')
 
     # Iterate through all the cycle times and find the common ones.

--- a/src/swell/utilities/data_assimilation_window_params.py
+++ b/src/swell/utilities/data_assimilation_window_params.py
@@ -35,9 +35,39 @@ class DataAssimilationWindowParams():
 
     # ----------------------------------------------------------------------------------------------
 
-    def __get_window_begin_dto__(self, window_offset: str) -> datetime.datetime:
+    def __get_window_offset_dur__(self, window_length: str) -> datetime.datetime:
+        # Calculate window offset from window length
+        window_offset_dur = isodate.parse_duration(window_length) / 2
 
-        window_offset_dur = isodate.parse_duration(window_offset)
+        return window_offset_dur
+    
+    # ----------------------------------------------------------------------------------------------
+
+    def window_offset(self, window_length: str, dto: bool = False) -> str:
+        window_offset_dur = self.__get_window_offset_dur__(window_length)
+
+        if dto:
+            return window_offset_dur
+        else:
+            return isodate.duration_isoformat(window_offset_dur)
+        
+    # ----------------------------------------------------------------------------------------------
+
+    def analysis_forecast_window_offset(self, window_length, dto: bool = False) -> str:
+        window_offset_dur = self.__get_window_offset_dur__(window_length)
+
+        analysis_forecast_window_offset = -1 * window_offset_dur
+
+        if dto:
+            return analysis_forecast_window_offset
+        else:
+            return isodate.duration_isoformat(analysis_forecast_window_offset)
+
+    # ----------------------------------------------------------------------------------------------
+
+    def __get_window_begin_dto__(self, window_length: str) -> datetime.datetime:
+        window_offset_dur = self.__get_window_offset_dur__(self, window_length)
+
         return self.__current_cycle_dto__ - window_offset_dur
 
     # ----------------------------------------------------------------------------------------------
@@ -45,12 +75,12 @@ class DataAssimilationWindowParams():
     def __get_local_background_time__(
         self,
         window_type: str,
-        window_offset: str
+        window_length: str
     ) -> datetime.datetime:
 
         # Background time for the window
         if window_type == '4D':
-            local_background_time = self.__get_window_begin_dto__(window_offset)
+            local_background_time = self.__get_window_begin_dto__(window_length)
         elif window_type == '3D':
             local_background_time = self.__current_cycle_dto__
 
@@ -58,11 +88,7 @@ class DataAssimilationWindowParams():
 
     # ----------------------------------------------------------------------------------------------
 
-    def __get_analysis_time__(
-        self,
-        window_type: str,
-        suite_name: str
-    ) -> datetime.datetime:
+    def __get_analysis_time__(self) -> datetime.datetime:
 
         # Default, 3D or 3D-FGAT
         analysis_time_dto = self.__current_cycle_dto__
@@ -75,21 +101,21 @@ class DataAssimilationWindowParams():
 
     # ----------------------------------------------------------------------------------------------
 
-    def analysis_time(self, window_type: str, suite_name: str) -> str:
+    def analysis_time(self) -> str:
 
-        analysis_time_dto = self.__get_analysis_time__(window_type, suite_name)
+        analysis_time_dto = self.__get_analysis_time__()
         return analysis_time_dto.strftime(datetime_formats['directory_format'])
 
     # ----------------------------------------------------------------------------------------------
 
-    def analysis_time_iso(self, window_type: str, suite_name: str) -> str:
+    def analysis_time_iso(self) -> str:
 
-        analysis_time_dto = self.__get_analysis_time__(window_type, suite_name)
+        analysis_time_dto = self.__get_analysis_time__()
         return analysis_time_dto.strftime(datetime_formats['iso_format'])
 
     # ----------------------------------------------------------------------------------------------
 
-    def background_time(self, window_offset: str, background_time_offset: str) -> str:
+    def background_time(self, background_time_offset: str) -> str:
 
         background_time_offset_dur = isodate.parse_duration(background_time_offset)
         background_time_dto = self.__current_cycle_dto__ - background_time_offset_dur
@@ -97,7 +123,7 @@ class DataAssimilationWindowParams():
 
     # ----------------------------------------------------------------------------------------------
 
-    def background_time_iso(self, window_offset: str, background_time_offset: str) -> str:
+    def background_time_iso(self, background_time_offset: str) -> str:
 
         background_time_offset_dur = isodate.parse_duration(background_time_offset)
         background_time_dto = self.__current_cycle_dto__ - background_time_offset_dur
@@ -105,17 +131,20 @@ class DataAssimilationWindowParams():
 
     # ----------------------------------------------------------------------------------------------
 
-    def local_background_time_iso(self, window_offset: str, window_type: str) -> str:
+    def local_background_time_iso(self, window_length: str, window_type: str) -> str:
 
-        local_background_time = self.__get_local_background_time__(window_type, window_offset)
+        local_background_time = self.__get_local_background_time__(window_type, window_length)
         return local_background_time.strftime(datetime_formats['iso_format'])
 
     # ----------------------------------------------------------------------------------------------
 
-    def local_background_time(self, window_offset, window_type, dto=False
+    def local_background_time(self,
+                              window_length,
+                              window_type,
+                              dto=False
                               ) -> Union[str, Tuple[str, datetime.datetime]]:
 
-        local_background_time = self.__get_local_background_time__(window_type, window_offset)
+        local_background_time = self.__get_local_background_time__(window_type, window_length)
 
         # Return datetime object if asked
         if dto:
@@ -126,9 +155,9 @@ class DataAssimilationWindowParams():
 
     # ----------------------------------------------------------------------------------------------
 
-    def window_begin(self, window_offset: str, dto: bool = False) -> Union[str, datetime.datetime]:
+    def window_begin(self, window_length: str, dto: bool = False) -> Union[str, datetime.datetime]:
 
-        window_begin_dto = self.__get_window_begin_dto__(window_offset)
+        window_begin_dto = self.__get_window_begin_dto__(window_length)
 
         # Return datetime object if asked
         if dto:
@@ -138,9 +167,9 @@ class DataAssimilationWindowParams():
 
     # ----------------------------------------------------------------------------------------------
 
-    def window_begin_iso(self, window_offset: str, dto: bool = False):
+    def window_begin_iso(self, window_length: str, dto: bool = False):
 
-        window_begin_dto = self.__get_window_begin_dto__(window_offset)
+        window_begin_dto = self.__get_window_begin_dto__(window_length)
 
         # Return datetime object if asked
         if dto:
@@ -150,13 +179,13 @@ class DataAssimilationWindowParams():
 
     # ----------------------------------------------------------------------------------------------
 
-    def window_end_iso(self, window_offset: str, window_length: str, dto: bool = False) -> str:
+    def window_end_iso(self, window_length: str, dto: bool = False) -> str:
 
         # Compute window length duration
         window_length_dur = isodate.parse_duration(window_length)
 
         # Get window beginning time
-        window_begin_dto = self.__get_window_begin_dto__(window_offset)
+        window_begin_dto = self.__get_window_begin_dto__(window_length)
 
         # Window end time
         window_end_dto = window_begin_dto + window_length_dur

--- a/src/swell/utilities/data_assimilation_window_params.py
+++ b/src/swell/utilities/data_assimilation_window_params.py
@@ -40,7 +40,7 @@ class DataAssimilationWindowParams():
         window_offset_dur = isodate.parse_duration(window_length) / 2
 
         return window_offset_dur
-    
+
     # ----------------------------------------------------------------------------------------------
 
     def window_offset(self, window_length: str, dto: bool = False) -> str:
@@ -50,7 +50,7 @@ class DataAssimilationWindowParams():
             return window_offset_dur
         else:
             return isodate.duration_isoformat(window_offset_dur)
-        
+
     # ----------------------------------------------------------------------------------------------
 
     def analysis_forecast_window_offset(self, window_length, dto: bool = False) -> str:
@@ -66,7 +66,7 @@ class DataAssimilationWindowParams():
     # ----------------------------------------------------------------------------------------------
 
     def __get_window_begin_dto__(self, window_length: str) -> datetime.datetime:
-        window_offset_dur = self.__get_window_offset_dur__(self, window_length)
+        window_offset_dur = self.__get_window_offset_dur__(window_length)
 
         return self.__current_cycle_dto__ - window_offset_dur
 

--- a/src/swell/utilities/question_defaults.py
+++ b/src/swell/utilities/question_defaults.py
@@ -204,19 +204,6 @@ class QuestionDefaults():
     # --------------------------------------------------------------------------------------------------
 
     @dataclass
-    class analysis_forecast_window_offset(TaskQuestion):
-        default_value: str = "defer_to_model"
-        question_name: str = "analysis_forecast_window_offset"
-        options: str = "defer_to_model"
-        models: List[str] = mutable_field([
-            "all_models"
-        ])
-        prompt: str = "What is the duration from the middle of the window when forecasts start?"
-        widget_type: WType = WType.STRING_DROP_LIST
-
-    # --------------------------------------------------------------------------------------------------
-
-    @dataclass
     class analysis_variables(TaskQuestion):
         default_value: str = "defer_to_model"
         question_name: str = "analysis_variables"
@@ -1381,19 +1368,6 @@ class QuestionDefaults():
             "all_models"
         ])
         prompt: str = "What is the duration for the data assimilation window?"
-        widget_type: WType = WType.ISO_DURATION
-
-    # --------------------------------------------------------------------------------------------------
-
-    @dataclass
-    class window_offset(TaskQuestion):
-        question_name: str = "window_offset"
-        default_value: str = "defer_to_model"
-        ask_question: bool = True
-        models: List[str] = mutable_field([
-            "all_models"
-        ])
-        prompt: str = "What is the duration between the middle of the window and the beginning?"
         widget_type: WType = WType.ISO_DURATION
 
     # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR eliminates the `window_offset` and `analysis_forecast_window_offset` keys from experiment.yaml. These parameters are now calculated in `data_assimilation_window_params.py` using `window_length`. 

`background_time_offset` can also potentially be calculated from window_length but I wasn't sure of the relationship. From what I could tell they should have the following values by default:


3dvar:
window_length: P1D
background_time_offset: PT18H

3dvar_atmos:
window_length: PT6H
background_time_offset: PT9H

If it's just window_offset + 6 I can add that too if someone can confirm

Tier1 tests pass for this
