### PR TITLE
Add sp to modules

### DIFF
--- a/src/swell/deployment/platforms/nccs_discover_cascade/modules
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/modules
@@ -44,6 +44,10 @@ module load r2d2-client/112025
 module load eva/sles15_skylab9
 module load jedi_bundle/sles15_skylab9
 
+# Load sp
+# -------
+module load sp/2.5.0
+
 # Set the swell paths
 # -------------------
 PATH={{swell_bin_path}}:$PATH

--- a/src/swell/deployment/platforms/nccs_discover_sles15/modules
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/modules
@@ -44,6 +44,10 @@ module load r2d2-client/112025
 module load eva/sles15_milan_1.6.5
 module load jedi_bundle/sles15_skylab9
 
+# Load sp
+# -------
+module load sp/2.5.0
+
 # Remove any r2d2 v2 paths from PYTHONPATH to prevent conflicts
 export PYTHONPATH=$(echo $PYTHONPATH | tr ':' '\n' | grep -v "/r2d2/sles15_spack19/" | tr '\n' ':' | sed 's/:$//')
 

--- a/src/swell/tasks/jedi_log_comparison.py
+++ b/src/swell/tasks/jedi_log_comparison.py
@@ -8,6 +8,7 @@
 # --------------------------------------------------------------------------------------------------
 
 
+import yaml
 import os
 import re
 import numpy as np
@@ -25,8 +26,21 @@ class JediLogComparison(taskBase):
 
     def execute(self):
 
+
+        experiment_paths = self.config.comparison_experiment_paths()
+
+        # Get the number of iterations between experiments
+        iterations_list = []
+        for path in experiment_paths:
+            with open(path, 'r') as f:
+                exp_dict = yaml.safe_load(f)
+                num_iters = int(exp_dict['models'][self.get_model()]['number_of_iterations'][0])
+                iterations_list.append(num_iters)
+
+        number_of_iterations = min(iterations_list)
+
         tolerances = {}
-        for number in range(int(self.config.number_of_iterations()[0])):
+        for number in range(number_of_iterations):
             tolerances[f'Residual norm ( {number})'] = 0.01
 
         # Construct dictionary for all results from log file
@@ -35,7 +49,6 @@ class JediLogComparison(taskBase):
         # Boolean for whether fields fall within tolerances
         passed = True
 
-        experiment_paths = self.config.comparison_experiment_paths()
         log_type = self.config.comparison_log_type()
 
         for exp_num, experiment_path in enumerate(experiment_paths):

--- a/src/swell/tasks/jedi_log_comparison.py
+++ b/src/swell/tasks/jedi_log_comparison.py
@@ -26,7 +26,6 @@ class JediLogComparison(taskBase):
 
     def execute(self):
 
-
         experiment_paths = self.config.comparison_experiment_paths()
 
         # Get the number of iterations between experiments


### PR DESCRIPTION
This fixes the discrepancy between JEDI builds (#661) by adding sp to the modules so that Swell builds jedi correctly. Thanks to @mer-a-o for figuring out this issue.

This also matches the number of iterations properly in `JediLogComparison`.