### PR TITLE
breaking down PR/660 into smaller pieces -- part1

### DIFF
--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -40,6 +40,8 @@ class TaskQuestions(QuestionContainer, Enum):
         questions=[
             qd.npx_proc(),
             qd.npy_proc(),
+            qd.npx(),
+            qd.npy(),
             qd.horizontal_resolution(),
             qd.vertical_resolution()
         ]

--- a/src/swell/utilities/question_defaults.py
+++ b/src/swell/utilities/question_defaults.py
@@ -1005,6 +1005,32 @@ class QuestionDefaults():
     # --------------------------------------------------------------------------------------------------
 
     @dataclass
+    class npx(TaskQuestion):
+        default_value: str = "defer_to_model"
+        question_name: str = "npx"
+        ask_question: bool = True
+        models: List[str] = mutable_field([
+            "geos_cf"
+        ])
+        prompt: str = "What is the number of grid points in the x-direction on each cube face?"
+        widget_type: WType = WType.INTEGER
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
+    class npy(TaskQuestion):
+        default_value: str = "defer_to_model"
+        question_name: str = "npy"
+        ask_question: bool = True
+        models: List[str] = mutable_field([
+            "geos_cf"
+        ])
+        prompt: str = "What is the number of grid points in the y-direction on each cube face?"
+        widget_type: WType = WType.INTEGER
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
     class number_of_iterations(TaskQuestion):
         default_value: str = "defer_to_model"
         question_name: str = "number_of_iterations"

--- a/src/swell/utilities/render_jedi_interface_files.py
+++ b/src/swell/utilities/render_jedi_interface_files.py
@@ -107,6 +107,8 @@ class JediConfigRendering():
             'mom6_iau',
             'npx_proc',
             'npy_proc',
+            'npx',
+            'npy',
             'number_of_iterations',
             'obs_filenames',
             'packet_ensemble_members',


### PR DESCRIPTION
## Description

Add `npx` and `npy` to the list of questions. See PR description https://github.com/GEOS-ESM/swell/pull/660 for more details.

I don't think if there's any way to test the changes prior to adding `geos-cf` model SWELL. Code tests pass. 

## Dependencies

None

## Impact

None
