### PR TITLE
Bufr2IODA working in conjunction with Var

### DIFF
--- a/src/swell/configuration/jedi/bufr2ioda/bufr_ncep_mtiasi.yaml
+++ b/src/swell/configuration/jedi/bufr2ioda/bufr_ncep_mtiasi.yaml
@@ -62,6 +62,18 @@ observations:
             query: "*/SELV"
             type: float 
 
+          sensorChannelStart1:
+            query: "*/STCH"
+#           mnemonic: STCH
+
+          sensorChannelEnd1:
+            query: "*/ENCH"
+#           mnemonic: ENCH
+
+          channelScaleFactor1:
+            query: "*/CHSF"
+#           mnemonic: CHSF
+
           sensorViewAngle:
             sensorScanAngle:
               fieldOfViewNumber: "*/FOVN"
@@ -233,9 +245,27 @@ observations:
           units: "1"
           range: [0, 1]
 
+        - name: "MetaData/sensorChannelStart1"
+          source: variables/sensorChannelStart1
+          dimensions: ["ChannelBlock"]
+          longName: "Starting channel number"
+          units: ""
+
+        - name: "MetaData/sensorChannelEnd1"
+          source: variables/sensorChannelEnd1
+          dimensions: ["ChannelBlock"]
+          longName: "Ending channel number"
+          units: ""
+
+        - name: "MetaData/channelScaleFactor1"
+          source: variables/channelScaleFactor1
+          dimensions: ["ChannelBlock"]
+          longName: "Channel scale factor"
+          units: ""
+
 #       The unit from BUFR is W m-2 sr-1 m -- this is radiance per wavenumber
-#       - name: "ObsValue/spectralRadiance"
-        - name: "ObsValue/radiance"
+#       - name: "ObsValue/radiance"
+        - name: "ObsValue/spectralRadiance"
           source: variables/spectralRadiance
           longName: "IASI Spectral Radiance"
           units: "W m-2 sr-1"

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_aqua.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_aqua.yaml
@@ -1,0 +1,23 @@
+      obs pre filters:
+      # Remove Observations from the Edge of the Scan
+      - filter: Domain Check
+        filter variables:
+        - name: brightnessTemperature
+          channels: 1-15
+        where:
+        - variable:
+            name: MetaData/sensorScanPosition
+          is_in: 4-27
+        action:
+          name: reduce obs space
+
+      # Data Thinning
+      - filter: Gaussian Thinning
+        horizontal_mesh: 145
+        use_reduced_horizontal_grid: true
+        distance_norm: geodesic
+      #  round_horizontal_bin_count_to_nearest: true
+      #  partition_longitude_bins_using_mesh: true
+        action:
+          name: reduce obs space
+

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_metop-b.yaml
@@ -1,0 +1,23 @@
+      obs pre filters:
+      # Remove Observations from the Edge of the Scan
+      - filter: Domain Check
+        filter variables:
+        - name: brightnessTemperature
+          channels: 1-15
+        where:
+        - variable:
+            name: MetaData/sensorScanPosition
+          is_in: 4-27
+        action:
+          name: reduce obs space
+
+      # Data Thinning
+      - filter: Gaussian Thinning
+        horizontal_mesh: 145
+        use_reduced_horizontal_grid: true
+        distance_norm: geodesic
+      #  round_horizontal_bin_count_to_nearest: true
+      #  partition_longitude_bins_using_mesh: true
+        action:
+          name: reduce obs space
+

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_metop-c.yaml
@@ -1,0 +1,23 @@
+      obs pre filters:
+      # Remove Observations from the Edge of the Scan
+      - filter: Domain Check
+        filter variables:
+        - name: brightnessTemperature
+          channels: 1-15
+        where:
+        - variable:
+            name: MetaData/sensorScanPosition
+          is_in: 4-27
+        action:
+          name: reduce obs space
+
+      # Data Thinning
+      - filter: Gaussian Thinning
+        horizontal_mesh: 145
+        use_reduced_horizontal_grid: true
+        distance_norm: geodesic
+      #  round_horizontal_bin_count_to_nearest: true
+      #  partition_longitude_bins_using_mesh: true
+        action:
+          name: reduce obs space
+

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_n15.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_n15.yaml
@@ -1,0 +1,23 @@
+      obs pre filters:
+      # Remove Observations from the Edge of the Scan
+      - filter: Domain Check
+        filter variables:
+        - name: brightnessTemperature
+          channels: 1-15
+        where:
+        - variable:
+            name: MetaData/sensorScanPosition
+          is_in: 4-27
+        action:
+          name: reduce obs space
+
+      # Data Thinning
+      - filter: Gaussian Thinning
+        horizontal_mesh: 145
+        use_reduced_horizontal_grid: true
+        distance_norm: geodesic
+      #  round_horizontal_bin_count_to_nearest: true
+      #  partition_longitude_bins_using_mesh: true
+        action:
+          name: reduce obs space
+

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_n18.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_n18.yaml
@@ -1,0 +1,23 @@
+      obs pre filters:
+      # Remove Observations from the Edge of the Scan
+      - filter: Domain Check
+        filter variables:
+        - name: brightnessTemperature
+          channels: 1-15
+        where:
+        - variable:
+            name: MetaData/sensorScanPosition
+          is_in: 4-27
+        action:
+          name: reduce obs space
+
+      # Data Thinning
+      - filter: Gaussian Thinning
+        horizontal_mesh: 145
+        use_reduced_horizontal_grid: true
+        distance_norm: geodesic
+      #  round_horizontal_bin_count_to_nearest: true
+      #  partition_longitude_bins_using_mesh: true
+        action:
+          name: reduce obs space
+

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_n19.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/amsua_n19.yaml
@@ -1,0 +1,23 @@
+      obs pre filters:
+      # Remove Observations from the Edge of the Scan
+      - filter: Domain Check
+        filter variables:
+        - name: brightnessTemperature
+          channels: 1-15
+        where:
+        - variable:
+            name: MetaData/sensorScanPosition
+          is_in: 4-27
+        action:
+          name: reduce obs space
+
+      # Data Thinning
+      - filter: Gaussian Thinning
+        horizontal_mesh: 145
+        use_reduced_horizontal_grid: true
+        distance_norm: geodesic
+      #  round_horizontal_bin_count_to_nearest: true
+      #  partition_longitude_bins_using_mesh: true
+        action:
+          name: reduce obs space
+

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/iasi_metop-b.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/iasi_metop-b.yaml
@@ -1,0 +1,94 @@
+      # Observation Pre Filters (QC)
+      # ----------------------------
+      obs pre filters:
+      # Step 1: Create Derived Variables
+      # Assign channel wavenumbers in m-1
+      - filter: Variable Assignment
+        assignments:
+        - name: MetaData/sensorCentralWavenumber
+          type: float
+          channels: *iasi_metop-b_channels
+          function:
+            name: ObsFunction/LinearCombination
+            options:
+              variables:
+              - name: ObsValue/spectralRadiance
+                channels: *iasi_metop-b_channels
+              coefs: [25.0]
+              intercept: 64475.0
+              use channel numbers: true
+
+    ### Do not need this in the present setting
+    ### Scaled radiance to spectral radiance
+    ### creates a spectral radiance in (W / (m^2.sr.m^-1))
+#     - filter: Variable Transforms
+#       Transform: SatRadianceFromScaledRadiance
+#       transform from:
+#         name: ObsValue/spectralRadiance
+#         channels: *iasi_metop-b_channels
+#       number of scale factors: 1
+#       scale factor variable: MetaData/channelScaleFactor
+#       scale factor start: MetaData/sensorChannelStart
+#       scale factor end: MetaData/sensorChannelEnd
+#       get scaling factors from multiple arrays: true
+
+     # Step 2: Transform radiance to brightness temperature
+      - filter: Variable Transforms
+        Transform: SatBrightnessTempFromRad
+        transform from:
+          name: ObsValue/spectralRadiance
+          channels: *iasi_metop-b_channels
+        spectral variable:
+          name: MetaData/sensorCentralWavenumber
+          channels: *iasi_metop-b_channels
+        radiance units: wavenumber
+        planck1: 1.191042953e-16
+        planck2: 1.4387774e-2
+
+      # Step 3: Assign Observation Error
+      - filter: Perform Action
+        filter variables:
+        - name: brightnessTemperature
+          channels: *iasi_metop-b_channels
+        action:
+          name: assign error
+          error parameter vector: *iasi_metop-b_obserr
+     
+      # Step 4: Remove Observations from the Edge of the Scan
+      - filter: Domain Check
+        filter variables:
+        - name: brightnessTemperature
+          channels: *iasi_metop-b_channels
+        where:
+        - variable:
+            name: MetaData/sensorScanPosition
+          is_in: 5-56
+        action:
+          name: reduce obs space
+     
+      # Step 5: Create cloudFree variable (for thinning) 
+      - filter: Variable Assignment
+        assignments:
+        - name: DerivedMetaData/fractionOfClearPixelsInFOV
+          type: float
+          function:
+            name: ObsFunction/Arithmetic
+            options:
+              variables:
+              - name: MetaData/fractionOfClearPixelsInFOV
+              coefs: [1.0]
+     
+      # Step 6: Data Thinning 
+      - filter: Gaussian Thinning
+        filter variables:
+        - name: brightnessTemperature
+          channels: *iasi_metop-b_channels
+#       GSI value leads to consirably more obs than GSI uses!
+#       horizontal_mesh: 145
+        horizontal_mesh: 175
+        use_reduced_horizontal_grid: true
+        distance_norm: geodesic
+        priority_variable: DerivedMetaData/fractionOfClearPixelsInFOV
+        action:
+          name: reduce obs space
+

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/iasi_metop-c.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/pre-filters/iasi_metop-c.yaml
@@ -1,0 +1,94 @@
+      # Observation Pre Filters (QC)
+      # ----------------------------
+      obs pre filters:
+      # Step 1: Create Derived Variables
+      # Assign channel wavenumbers in m-1
+      - filter: Variable Assignment
+        assignments:
+        - name: MetaData/sensorCentralWavenumber
+          type: float
+          channels: *iasi_metop-c_channels
+          function:
+            name: ObsFunction/LinearCombination
+            options:
+              variables:
+              - name: ObsValue/spectralRadiance
+                channels: *iasi_metop-c_channels
+              coefs: [25.0]
+              intercept: 64475.0
+              use channel numbers: true
+
+    ### Do not need this in the present setting
+    ### Scaled radiance to spectral radiance
+    ### creates a spectral radiance in (W / (m^2.sr.m^-1))
+#     - filter: Variable Transforms
+#       Transform: SatRadianceFromScaledRadiance
+#       transform from:
+#         name: ObsValue/spectralRadiance
+#         channels: *iasi_metop-c_channels
+#       number of scale factors: 1
+#       scale factor variable: MetaData/channelScaleFactor
+#       scale factor start: MetaData/sensorChannelStart
+#       scale factor end: MetaData/sensorChannelEnd
+#       get scaling factors from multiple arrays: true
+
+     # Step 2: Transform radiance to brightness temperature
+      - filter: Variable Transforms
+        Transform: SatBrightnessTempFromRad
+        transform from:
+          name: ObsValue/spectralRadiance
+          channels: *iasi_metop-c_channels
+        spectral variable:
+          name: MetaData/sensorCentralWavenumber
+          channels: *iasi_metop-c_channels
+        radiance units: wavenumber
+        planck1: 1.191042953e-16
+        planck2: 1.4387774e-2
+
+      # Step 3: Assign Observation Error
+      - filter: Perform Action
+        filter variables:
+        - name: brightnessTemperature
+          channels: *iasi_metop-c_channels
+        action:
+          name: assign error
+          error parameter vector: *iasi_metop-c_obserr
+     
+      # Step 4: Remove Observations from the Edge of the Scan
+      - filter: Domain Check
+        filter variables:
+        - name: brightnessTemperature
+          channels: *iasi_metop-c_channels
+        where:
+        - variable:
+            name: MetaData/sensorScanPosition
+          is_in: 5-56
+        action:
+          name: reduce obs space
+     
+      # Step 5: Create cloudFree variable (for thinning) 
+      - filter: Variable Assignment
+        assignments:
+        - name: DerivedMetaData/fractionOfClearPixelsInFOV
+          type: float
+          function:
+            name: ObsFunction/Arithmetic
+            options:
+              variables:
+              - name: MetaData/fractionOfClearPixelsInFOV
+              coefs: [1.0]
+     
+      # Step 6: Data Thinning 
+      - filter: Gaussian Thinning
+        filter variables:
+        - name: brightnessTemperature
+          channels: *iasi_metop-c_channels
+#       GSI value leads to consirably more obs than GSI uses!
+#       horizontal_mesh: 145
+        horizontal_mesh: 175
+        use_reduced_horizontal_grid: true
+        distance_norm: geodesic
+        priority_variable: DerivedMetaData/fractionOfClearPixelsInFOV
+        action:
+          name: reduce obs space
+

--- a/src/swell/configuration/jedi/observation_ioda_names.yaml
+++ b/src/swell/configuration/jedi/observation_ioda_names.yaml
@@ -88,10 +88,10 @@ ioda instrument names:
     inst type: radiance
   - ioda name: iasi_metop-b
     full name: IASI (METOP-B)
-    inst type: radiance
+    inst type: spectralRadiance
   - ioda name: iasi_metop-c
     full name: IASI (METOP-C)
-    inst type: radiance
+    inst type: spectralRadiance
   - ioda name: mhs_metop-a
     full name: MHS (METOP-A)
     inst type: radiance


### PR DESCRIPTION
## Description

This is preliminary work to introduce and test extra configuration to add pre-filters needed for intrustruments whose IODA files have been generated from bufr files as opposed to from NCdiags.

Still pending:

- [ ] handle for files beyond IASI and AMSUA instruments
- [ ] addiition in swell to be able to append pre-filters to observation yamls (notice this can be placed at the end of the obs space for instrument.
- [ ] change workflows of Var to allow for opt to pull bufr: (i) get bufr files from archive; and (ii) convert to IODA. This flow already exists in what @cohen-seth has done so far.

**NOTICE NOTICE NOTICE: I**n the results below, I am not too concerned on how things compare w/ GSI and how correct or not the increments are. All I am concerned about is how the results of develop comare w/ results when the ncdiag-generated IODA files are replaced with files generated from the bufr converter.

## Dependencies

- [ ] waiting on #673 

## Impact

For now: None