### PR TITLE
Move r2d2 credentials import to pertinent tasks

### DIFF
--- a/src/swell/tasks/base/task_base.py
+++ b/src/swell/tasks/base/task_base.py
@@ -277,17 +277,6 @@ class taskFactory():
         ensemblePacket: Optional[str]
     ) -> taskBase:
 
-        # Load R2D2 credentials before importing any task modules
-        # -------------------------------------------------------
-        from swell.utilities.config import Config
-        from swell.utilities.r2d2 import load_r2d2_credentials
-        from swell.utilities.logger import get_logger
-
-        # Get platform info from config to load credentials
-        temp_logger = get_logger('R2D2Setup')
-        temp_config = Config(config, temp_logger, task, model)
-        load_r2d2_credentials(temp_logger, temp_config.__platform__)
-
         # Convert camel case string to snake case
         task_lower = camel_case_to_snake_case(task)
 

--- a/src/swell/tasks/get_background.py
+++ b/src/swell/tasks/get_background.py
@@ -9,7 +9,7 @@
 
 
 from swell.tasks.base.task_base import taskBase
-from swell.utilities.r2d2 import create_r2d2_config
+from swell.utilities.r2d2 import create_r2d2_config, load_r2d2_credentials
 
 import isodate
 import os
@@ -36,6 +36,10 @@ class GetBackground(taskBase):
              All inputs are extracted from the JEDI experiment file configuration.
              See the taskBase constructor for more information.
         """
+
+        # Load R2D2 credentials
+        # ---------------------
+        load_r2d2_credentials(self.logger, self.platform())
 
         # Get duration into forecast for first background file
         # ----------------------------------------------------

--- a/src/swell/tasks/get_geovals.py
+++ b/src/swell/tasks/get_geovals.py
@@ -11,7 +11,7 @@
 import os
 
 from swell.tasks.base.task_base import taskBase
-from swell.utilities.r2d2 import create_r2d2_config
+from swell.utilities.r2d2 import create_r2d2_config, load_r2d2_credentials
 from r2d2 import fetch
 
 
@@ -20,6 +20,10 @@ from r2d2 import fetch
 class GetGeovals(taskBase):
 
     def execute(self) -> None:
+
+        # Load R2D2 credentials
+        # ---------------------
+        load_r2d2_credentials(self.logger, self.platform())
 
         # Parse config
         # ------------

--- a/src/swell/tasks/get_ncdiags.py
+++ b/src/swell/tasks/get_ncdiags.py
@@ -10,7 +10,7 @@
 import os
 from swell.tasks.base.task_base import taskBase
 from r2d2 import fetch
-from swell.utilities.r2d2 import create_r2d2_config
+from swell.utilities.r2d2 import create_r2d2_config, load_r2d2_credentials
 
 # --------------------------------------------------------------------------------------------------
 
@@ -22,6 +22,10 @@ class GetNcdiags(taskBase):
     """
 
     def execute(self) -> None:
+
+        # Load R2D2 credentials
+        # ---------------------
+        load_r2d2_credentials(self.logger, self.platform())
 
         # Parse config
         # ------------

--- a/src/swell/tasks/get_observations.py
+++ b/src/swell/tasks/get_observations.py
@@ -17,7 +17,7 @@ from typing import Union
 
 from datetime import timedelta, datetime as dt
 from swell.tasks.base.task_base import taskBase
-from swell.utilities.r2d2 import create_r2d2_config
+from swell.utilities.r2d2 import create_r2d2_config, load_r2d2_credentials
 from swell.utilities.datetime_util import datetime_formats
 from swell.utilities.observations import get_ioda_names_list, get_provider_for_observation
 
@@ -97,6 +97,10 @@ class GetObservations(taskBase):
         --------------
         "tlapse" files need to be fetched.
         """
+
+        # Load R2D2 credentials
+        # ---------------------
+        load_r2d2_credentials(self.logger, self.platform())
 
         # Parse config
         # ------------

--- a/src/swell/tasks/ingest_obs.py
+++ b/src/swell/tasks/ingest_obs.py
@@ -18,7 +18,7 @@ from datetime import datetime
 import requests
 
 from swell.tasks.base.task_base import taskBase
-from swell.utilities.r2d2 import create_r2d2_config
+from swell.utilities.r2d2 import create_r2d2_config, load_r2d2_credentials
 from swell.utilities.observations import get_ioda_names_list, get_provider_for_observation
 import r2d2
 
@@ -68,6 +68,10 @@ class IngestObs(taskBase):
     """
 
     def execute(self) -> None:
+
+        # Load R2D2 credentials
+        # ---------------------
+        load_r2d2_credentials(self.logger, self.platform())
 
         # Get list of observations to ingest (strings)
         obs_to_ingest = self.config.obs_to_ingest([])

--- a/src/swell/tasks/save_forecast.py
+++ b/src/swell/tasks/save_forecast.py
@@ -16,7 +16,7 @@ from r2d2 import store
 
 from swell.tasks.base.task_base import taskBase
 from swell.utilities.datetime_util import datetime_formats
-from swell.utilities.r2d2 import create_r2d2_config
+from swell.utilities.r2d2 import create_r2d2_config, load_r2d2_credentials
 
 
 # --------------------------------------------------------------------------------------------------
@@ -33,6 +33,10 @@ class StoreBackground(taskBase):
              All inputs are extracted from the JEDI experiment file configuration.
              See the taskBase constructor for more information.
         """
+
+        # Load R2D2 credentials
+        # ---------------------
+        load_r2d2_credentials(self.logger, self.platform())
 
         # Current cycle time object
         # -------------------------

--- a/src/swell/tasks/save_obs_diags.py
+++ b/src/swell/tasks/save_obs_diags.py
@@ -9,7 +9,7 @@
 
 import r2d2
 from swell.tasks.base.task_base import taskBase
-from swell.utilities.r2d2 import create_r2d2_config
+from swell.utilities.r2d2 import create_r2d2_config, load_r2d2_credentials
 from swell.utilities.run_jedi_executables import check_obs
 
 # --------------------------------------------------------------------------------------------------
@@ -22,6 +22,10 @@ class SaveObsDiags(taskBase):
     """
 
     def execute(self) -> None:
+
+        # Load R2D2 credentials
+        # ---------------------
+        load_r2d2_credentials(self.logger, self.platform())
 
         # Parse config
         # ------------

--- a/src/swell/tasks/save_restart.py
+++ b/src/swell/tasks/save_restart.py
@@ -15,7 +15,7 @@ from r2d2 import store
 from swell.tasks.base.task_base import taskBase
 from swell.utilities.datetime_util import datetime_formats
 from swell.utilities.file_system_operations import copy_to_dst_dir
-from swell.utilities.r2d2 import create_r2d2_config
+from swell.utilities.r2d2 import create_r2d2_config, load_r2d2_credentials
 
 # --------------------------------------------------------------------------------------------------
 
@@ -33,6 +33,10 @@ class SaveRestart(taskBase):
         self.logger.info('Skipping this task as R2D2v3 restart storage is not implemented ' +
                          'for coupled models yet')
         return
+
+        # Load R2D2 credentials
+        # ---------------------
+        load_r2d2_credentials(self.logger, self.platform())
 
         # Parse config
         window_type = self.config.window_type()


### PR DESCRIPTION
Addresses #731, moves the import of r2d2 credentials from task_base to individual tasks

- [x] Running tier1 tests