### PR TITLE
Fix variational3D oops configuration

### DIFF
--- a/src/swell/configuration/jedi/oops/variational3D.py
+++ b/src/swell/configuration/jedi/oops/variational3D.py
@@ -56,7 +56,7 @@ class variational3D(OopsConfig):
             },
             'output': self.interface_model('analysis')
         }
-        
+
         # TODO: Implement this more cleanly in the OOPS schema
         if self.jedi_interface == 'geos_cf':
             oops['final']['increment'] = {'geometry': self.interface_model('geometry'),

--- a/src/swell/configuration/jedi/oops/variational3D.py
+++ b/src/swell/configuration/jedi/oops/variational3D.py
@@ -56,7 +56,8 @@ class variational3D(OopsConfig):
             },
             'output': self.interface_model('analysis')
         }
-
+        
+        # TODO: Implement this more cleanly in the OOPS schema
         if self.jedi_interface == 'geos_cf':
             oops['final']['increment'] = {'geometry': self.interface_model('geometry'),
                                           'output': self.interface_model('increment_cs')}

--- a/src/swell/configuration/jedi/oops/variational3D.py
+++ b/src/swell/configuration/jedi/oops/variational3D.py
@@ -52,15 +52,14 @@ class variational3D(OopsConfig):
                 },
                 'prints': {
                     'frequency': 'PT3H'
-                },
-                'increment': {
-                    'geometry': self.interface_model('geometry'),
-                    'output': self.interface_model('increment_cs'),
-                },
-
+                }
             },
             'output': self.interface_model('analysis')
         }
+
+        if self.jedi_interface == 'geos_cf':
+            oops['final']['increment'] = {'geometry': self.interface_model('geometry'),
+                                          'output': self.interface_model('increment_cs')}
 
         return oops
 


### PR DESCRIPTION
Sorry, this is on me for not running the tier1 tests before merging. The addition to the `variational3D` oops configuration in #716 breaks the suites for other models. This is a band-aid fix that avoids having to revert the PR adding `3dvar_cf` and restoring functionality of all suites. This may not be an ideal solution but we can amend it later

I've tested this works for tier1 suites + `3dvar_cf`