### PR TITLE
Add comparisons for 3dvar_cf

### DIFF
--- a/src/swell/suites/3dvar_cf/suite_config.py
+++ b/src/swell/suites/3dvar_cf/suite_config.py
@@ -47,7 +47,7 @@ class SuiteConfig(QuestionContainer, Enum):
                 "tempo_no2_tropo",
                 "tropomi_s5p_no2_tropo",
             ]),
-            qd.clean_patterns(['*.nc4', '*.txt', 'logfile.*.out']),
+            qd.clean_patterns(['*.txt', 'logfile.*.out']),
         ]
     )
 

--- a/src/swell/suites/compare/eva/comparison_increment-geos_cf.yaml
+++ b/src/swell/suites/compare/eva/comparison_increment-geos_cf.yaml
@@ -1,0 +1,100 @@
+datasets:
+
+- group: increment
+  type: LatLon
+  filename: {{increment_file_path_1}}
+  name: experiment_increment_1
+  variables: [NO2, lat, lon]
+
+- group: increment
+  type: LatLon
+  filename: {{increment_file_path_2}}
+  name: experiment_increment_2
+  variables: [NO2, lat, lon]
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  #map plot for NO2 increment (near surface)
+  - batch figure:
+      variables: [NO2]
+    figure:
+      figure size: [20,10]
+      layout: [1,1]
+      title: 'NO2 Increment from JEDI'
+      output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_surface.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: NO2 Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::NO2
+            slices: '[71,...]'
+          label: "{{experiment_tag_1}} NO2 increment (surface level)"
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1e-10
+          vmax: 1e-10
+
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: NO2 Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_2::increment::lon
+          latitude:
+            variable: experiment_increment_2::increment::lat
+          data:
+            variable: experiment_increment_2::increment::NO2
+            slices: '[71,...]'
+          label: "{{experiment_tag_2}} NO2 increment (surface level)"
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1e-10
+          vmax: 1e-10
+
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_colorbar:
+          label: NO2 Increment
+        add_grid:
+        layers:
+        - type: MapGridded
+          longitude:
+            variable: experiment_increment_1::increment::lon
+          latitude:
+            variable: experiment_increment_1::increment::lat
+          data:
+            variable: experiment_increment_1::increment::NO2_diff
+            slices: '[71,...]'
+          label: "{{experiment_tag_1}} NO2 increment diff (surface level)"
+          colorbar: true
+          cmap: 'bwr'
+          vmin: -1e-11
+          vmax: 1e-11
+
+transforms:
+- equals: experiment_increment_1::increment::NO2-experiment_increment_2::increment::N02
+  for:
+    variable: NO2
+  new name: experiment_increment_1::increment::NO2_diff
+  transform: arithmetic

--- a/src/swell/suites/compare/eva/comparison_increment-geos_cf.yaml
+++ b/src/swell/suites/compare/eva/comparison_increment-geos_cf.yaml
@@ -21,7 +21,7 @@ graphics:
   - batch figure:
       variables: [NO2]
     figure:
-      figure size: [60,10]
+      figure size: [60,30]
       layout: [3,1]
       title: 'NO2 Increment from JEDI'
       output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_surface.png'

--- a/src/swell/suites/compare/eva/comparison_increment-geos_cf.yaml
+++ b/src/swell/suites/compare/eva/comparison_increment-geos_cf.yaml
@@ -21,10 +21,11 @@ graphics:
   - batch figure:
       variables: [NO2]
     figure:
-      figure size: [20,10]
-      layout: [1,1]
+      figure size: [60,10]
+      layout: [3,1]
       title: 'NO2 Increment from JEDI'
       output name: '{{cycle_dir}}/eva/increment/map_plots/${variable}/inc_${variable}_surface.png'
+      tight_layout: true 
     plots:
       - mapping:
           projection: plcarr
@@ -33,6 +34,7 @@ graphics:
         add_colorbar:
           label: NO2 Increment
         add_grid:
+        add_title: '{{experiment_tag_1}}'
         layers:
         - type: MapGridded
           longitude:
@@ -55,6 +57,7 @@ graphics:
         add_colorbar:
           label: NO2 Increment
         add_grid:
+        add_title: '{{experiment_tag_2}}'
         layers:
         - type: MapGridded
           longitude:
@@ -77,6 +80,7 @@ graphics:
         add_colorbar:
           label: NO2 Increment
         add_grid:
+        add_title: '{{experiment_tag_1}} - {{experiment_tag_2}}'
         layers:
         - type: MapGridded
           longitude:
@@ -93,7 +97,7 @@ graphics:
           vmax: 1e-11
 
 transforms:
-- equals: experiment_increment_1::increment::NO2-experiment_increment_2::increment::N02
+- equals: experiment_increment_1::increment::NO2-experiment_increment_2::increment::NO2
   for:
     variable: NO2
   new name: experiment_increment_1::increment::NO2_diff

--- a/src/swell/suites/compare/eva/comparison_jedi_log-geos_cf.yaml
+++ b/src/swell/suites/compare/eva/comparison_jedi_log-geos_cf.yaml
@@ -52,7 +52,7 @@ graphics:
             variable: JediLogTest_2::convergence::total_iteration
           y:
             variable: JediLogTest_2::convergence::residual_norm
-          color: 'blue'
+          color: 'red'
           label: '{{experiment_tag_2}} Residual norm'
 
       - add_xlabel: 'Total inner iteration number'
@@ -64,7 +64,7 @@ graphics:
             variable: JediLogTest_1::convergence::total_iteration
           y:
             variable: JediLogTest_1::convergence::norm_reduction
-          color: 'black'
+          color: 'blue'
           label: '{{experiment_tag_1}} Norm reduction'
 
         - type: LinePlot
@@ -72,7 +72,7 @@ graphics:
             variable: JediLogTest_2::convergence::total_iteration
           y:
             variable: JediLogTest_2::convergence::norm_reduction
-          color: 'blue'
+          color: 'green'
           label: '{{experiment_tag_2}} Norm reduction'
 
       - add_xlabel: 'Total inner iteration number'
@@ -84,7 +84,7 @@ graphics:
             variable: JediLogTest_1::convergence::total_iteration
           y:
             variable: JediLogTest_1::convergence::residual_norm_log
-          color: 'red'
+          color: 'black'
           label: '{{experiment_tag_1}} Log(residual norm)'
         - type: LinePlot
           x:
@@ -106,5 +106,5 @@ graphics:
             variable: JediLogTest_2::convergence::total_iteration
           y:
             variable: JediLogTest_2::convergence::norm_reduction_log
-          color: 'blue'
+          color: 'green'
           label: '{{experiment_tag_2}} Log norm reduction'

--- a/src/swell/suites/compare/eva/comparison_jedi_log-geos_cf.yaml
+++ b/src/swell/suites/compare/eva/comparison_jedi_log-geos_cf.yaml
@@ -1,0 +1,110 @@
+datasets:
+
+- type: JediLog
+  collection_name: JediLogTest_1
+  jedi_log_to_parse: '{{cycle_dir_1}}/jedi_variational_log.log'
+  data_to_parse:
+    convergence: true
+
+- type: JediLog
+  collection_name: JediLogTest_2
+  jedi_log_to_parse: '{{cycle_dir_2}}/jedi_variational_log.log'
+  data_to_parse:
+    convergence: true
+
+transforms:
+- transform: arithmetic
+  new name: JediLogTest_1::convergence::${variable}_log
+  equals: log(JediLogTest_1::convergence::${variable})
+  for:
+    variable: [residual_norm, norm_reduction]
+
+- transform: arithmetic
+  new name: JediLogTest_2::convergence::${variable}_log
+  equals: log(JediLogTest_2::convergence::${variable})
+  for:
+    variable: [residual_norm, norm_reduction]
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  - figure:
+      layout: [3,1]
+      figure size: [12,10]
+      title: 'Residual Norm and Norm Reduction Plots'
+      output name: '{{cycle_dir}}/eva/jedi_log/convergence/residual_norm_reduction.png'
+    plots:
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Residual norm'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: JediLogTest_1::convergence::total_iteration
+          y:
+            variable: JediLogTest_1::convergence::residual_norm
+          color: 'black'
+          label: '{{experiment_tag_1}} Residual norm'
+        - type: LinePlot
+          x:
+            variable: JediLogTest_2::convergence::total_iteration
+          y:
+            variable: JediLogTest_2::convergence::residual_norm
+          color: 'blue'
+          label: '{{experiment_tag_2}} Residual norm'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Log(norm reduction)'
+        add_legend: 
+        layers:
+        - type: LinePlot
+          x:
+            variable: JediLogTest_1::convergence::total_iteration
+          y:
+            variable: JediLogTest_1::convergence::norm_reduction
+          color: 'black'
+          label: '{{experiment_tag_1}} Norm reduction'
+
+        - type: LinePlot
+          x:
+            variable: JediLogTest_2::convergence::total_iteration
+          y:
+            variable: JediLogTest_2::convergence::norm_reduction
+          color: 'blue'
+          label: '{{experiment_tag_2}} Norm reduction'
+
+      - add_xlabel: 'Total inner iteration number'
+        add_ylabel: 'Log(reduction)'
+        add_legend:
+        layers:
+        - type: LinePlot
+          x:
+            variable: JediLogTest_1::convergence::total_iteration
+          y:
+            variable: JediLogTest_1::convergence::residual_norm_log
+          color: 'red'
+          label: '{{experiment_tag_1}} Log(residual norm)'
+        - type: LinePlot
+          x:
+            variable: JediLogTest_2::convergence::total_iteration
+          y:
+            variable: JediLogTest_2::convergence::residual_norm_log
+          color: 'red'
+          label: '{{experiment_tag_2}} Log(residual norm)'
+
+        - type: LinePlot
+          x:
+            variable: JediLogTest_1::convergence::total_iteration
+          y:
+            variable: JediLogTest_1::convergence::norm_reduction_log
+          color: 'blue'
+          label: '{{experiment_tag_1}} Log norm reduction'
+        - type: LinePlot
+          x:
+            variable: JediLogTest_2::convergence::total_iteration
+          y:
+            variable: JediLogTest_2::convergence::norm_reduction_log
+          color: 'blue'
+          label: '{{experiment_tag_2}} Log norm reduction'

--- a/src/swell/suites/compare/eva/comparison_observations-3dvar_cf-geos_cf.yaml
+++ b/src/swell/suites/compare/eva/comparison_observations-3dvar_cf-geos_cf.yaml
@@ -141,6 +141,7 @@ graphics:
       variables: *variables
     figure:
       layout: [2,1]
+      figure size: [60,30]
       title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
       output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}/jedi_hofx_vs_obs_{{instrument}}_${variable}.png'
       tight_layout:
@@ -206,6 +207,7 @@ graphics:
         number of bins rule: 'rice'
     figure:
       layout: [2,1]
+      figure size: [60,30]
       title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
       output name: '{{cycle_dir}}/eva/{{instrument}}/histogram/${variable}/ombg_oman_{{instrument}}_${variable}.png'
       tight_layout:
@@ -311,7 +313,7 @@ graphics:
       - type: vminvmaxcmap
         data variable: experiment_1::ombgPassedQc::${variable}
     figure:
-      figure size: [60,10]
+      figure size: [60,30]
       layout: [4,1]
       title: '{{instrument_title}} | Passed QC'
       output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/ombg_oman_{{instrument}}_${variable}.png'
@@ -415,7 +417,7 @@ graphics:
       - type: vminvmaxcmap
         data variable: experiment_1::EffectiveQC1::${variable}
     figure:
-      figure size: [40,10]
+      figure size: [40,20]
       layout: [2,1]
       title: '{{instrument_title}} | Passed QC'
       output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/effectiveQC_{{instrument}}_${variable}.png'
@@ -473,7 +475,7 @@ graphics:
       - type: vminvmaxcmap
         data variable: experiment_1::increment::${variable}
     figure:
-      figure size: [40,10]
+      figure size: [40,20]
       layout: [2,1]
       title: '{{instrument_title}} | Passed QC'
       output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/increment_{{instrument}}_${variable}.png'

--- a/src/swell/suites/compare/eva/comparison_observations-3dvar_cf-geos_cf.yaml
+++ b/src/swell/suites/compare/eva/comparison_observations-3dvar_cf-geos_cf.yaml
@@ -1,0 +1,523 @@
+datasets:
+
+- name: experiment_1
+  type: IodaObsSpace
+  filenames:
+    - {{obs_path_file_1}}
+  groups:
+    - name: ObsValue
+      variables: &variables {{simulated_variables}}
+    - name: hofx0
+    - name: hofx1
+    - name: ombg
+    - name: oman
+    - name: MetaData
+    - name: EffectiveQC0
+    - name: EffectiveQC1
+
+- name: experiment_2
+  type: IodaObsSpace
+  filenames:
+    - {{obs_path_file_2}}
+  groups:
+    - name: ObsValue
+      variables: *variables
+    - name: hofx0
+    - name: hofx1
+    - name: ombg
+    - name: oman
+    - name: MetaData
+    - name: EffectiveQC0
+    - name: EffectiveQC1
+
+transforms:
+
+# Generate Increment for JEDI
+- transform: arithmetic
+  new name: experiment_1::increment::${variable}
+  equals: experiment_1::ombg::${variable}-experiment::oman::${variable}
+  for:
+    variable: *variables
+
+- transform: arithmetic
+  new name: experiment_2::increment::${variable}
+  equals: experiment_2::ombg::${variable}-experiment::oman::${variable}
+  for:
+    variable: *variables
+
+# Generate hofx0 that passed QC for JEDI
+- transform: accept where
+  new name: experiment_1::hofx0PassedQc::${variable}
+  starting field: experiment_1::hofx0::${variable}
+  where:
+    - experiment_1::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+- transform: accept where
+  new name: experiment_2::hofx0PassedQc::${variable}
+  starting field: experiment_2::hofx0::${variable}
+  where:
+    - experiment_2::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate hofx1 that passed QC for JEDI
+- transform: accept where
+  new name: experiment_1::hofx1PassedQc::${variable}
+  starting field: experiment_1::hofx1::${variable}
+  where:
+    - experiment_1::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
+- transform: accept where
+  new name: experiment_2::hofx1PassedQc::${variable}
+  starting field: experiment_2::hofx1::${variable}
+  where:
+    - experiment_2::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate ombg that passed QC for JEDI
+- transform: accept where
+  new name: experiment_1::ombgPassedQc::${variable}
+  starting field: experiment_1::ombg::${variable}
+  where:
+    - experiment_1::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+
+- transform: accept where
+  new name: experiment_2::ombgPassedQc::${variable}
+  starting field: experiment_2::ombg::${variable}
+  where:
+    - experiment_2::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate oman that passed QC for JEDI
+- transform: accept where
+  new name: experiment_1::omanPassedQc::${variable}
+  starting field: experiment_1::oman::${variable}
+  where:
+    - experiment_1::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
+
+- transform: accept where
+  new name: experiment_2::omanPassedQc::${variable}
+  starting field: experiment_2::oman::${variable}
+  where:
+    - experiment_2::EffectiveQC1::${variable} == 0
+  for:
+    variable: *variables
+
+# Generate obs that passed QC for JEDI
+- transform: accept where
+  new name: experiment_1::ObsValuePassedQc::${variable}
+  starting field: experiment_1::ObsValue::${variable}
+  where:
+    - experiment_1::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+
+- transform: accept where
+  new name: experiment_2::ObsValuePassedQc::${variable}
+  starting field: experiment_2::ObsValue::${variable}
+  where:
+    - experiment_2::EffectiveQC0::${variable} == 0
+  for:
+    variable: *variables
+
+graphics:
+
+  plotting_backend: Emcpy
+  figure_list:
+
+  # Correlation scatter plots
+  # -------------------------
+
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+    figure:
+      layout: [2,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}/jedi_hofx_vs_obs_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Observation Value'
+        add_ylabel: 'JEDI h(x)'
+        add_grid:
+        add_title: '{{experiment_tag_1}}'
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          x:
+            variable: experiment_1::ObsValue::${variable}
+          y:
+            variable: experiment_1::hofx0PassedQc::${variable}
+          markersize: 5
+          color: 'black'
+          label: 'JEDI h(x)_0 versus obs (passed QC in JEDI)'
+        - type: Scatter
+          x:
+            variable: experiment_1::ObsValue::${variable}
+          y:
+            variable: experiment_1::hofx1PassedQc::${variable}
+          markersize: 5
+          color: 'red'
+          label: 'JEDI h(x)_1 versus obs (passed QC in JEDI)'
+
+      - add_xlabel: 'Observation Value'
+        add_ylabel: 'JEDI h(x)'
+        add_grid:
+        add_title: '{{experiment_tag_2}}'
+        add_legend:
+          loc: 'upper left'
+        layers:
+        - type: Scatter
+          x:
+            variable: experiment_2::ObsValue::${variable}
+          y:
+            variable: experiment_2::hofx0PassedQc::${variable}
+          markersize: 5
+          color: 'black'
+          label: 'JEDI h(x)_0 versus obs (passed QC in JEDI)'
+        - type: Scatter
+          x:
+            variable: experiment_2::ObsValue::${variable}
+          y:
+            variable: experiment_2::hofx1PassedQc::${variable}
+          markersize: 5
+          color: 'red'
+          label: 'JEDI h(x)_1 versus obs (passed QC in JEDI)'
+
+
+  # Histogram plots
+  # ---------------
+
+  # JEDI h(x) vs Observations
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: histogram_bins
+        data variable: experiment::omanPassedQc::${variable}
+        number of bins rule: 'rice'
+    figure:
+      layout: [2,1]
+      title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/histogram/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - add_xlabel: 'Difference'
+        add_ylabel: 'Count'
+        set_xlim: [-5e-4, 5e-4]
+        add_title: '{{experiment_tag_1}}'
+        add_legend:
+          loc: 'upper left'
+        statistics:
+          fields:
+            - field_name: experiment_1::ombgPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.10
+              kwargs:
+                color: 'black'
+                fontsize: 8
+                fontfamily: monospace
+            - field_name: experiment_1::omanPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.13
+              kwargs:
+                color: 'red'
+                fontsize: 8
+                fontfamily: monospace
+          statistics_variables:
+          - n
+          - min
+          - mean
+          - max
+          - std
+        layers:
+        - type: Histogram
+          data:
+            variable: experiment_1::ombgPassedQc::${variable}
+          color: 'red'
+          label: 'observations minus background '
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+        - type: Histogram
+          data:
+            variable: experiment_1::omanPassedQc::${variable}
+          color: 'blue'
+          label: 'observations minus analysis'
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+
+      - add_xlabel: 'Difference'
+        add_ylabel: 'Count'
+        set_xlim: [-5e-4, 5e-4]
+        add_title: '{{experiment_tag_2}}'
+        add_legend:
+          loc: 'upper left'
+        statistics:
+          fields:
+            - field_name: experiment_2::ombgPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.10
+              kwargs:
+                color: 'black'
+                fontsize: 8
+                fontfamily: monospace
+            - field_name: experiment_2::omanPassedQc::${variable}
+              xloc: 0.5
+              yloc: -0.13
+              kwargs:
+                color: 'red'
+                fontsize: 8
+                fontfamily: monospace
+          statistics_variables:
+          - n
+          - min
+          - mean
+          - max
+          - std
+        layers:
+        - type: Histogram
+          data:
+            variable: experiment_2::ombgPassedQc::${variable}
+          color: 'red'
+          label: 'observations minus background '
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+        - type: Histogram
+          data:
+            variable: experiment_2::omanPassedQc::${variable}
+          color: 'blue'
+          label: 'observations minus analysis'
+          bins: ${dynamic_bins}
+          alpha: 0.5
+          density: true
+
+  # Map plots
+  # ---------
+  # Increment
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment_1::ombgPassedQc::${variable}
+    figure:
+      figure size: [60,10]
+      layout: [4,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_title: '{{experiment_tag_1}}'
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        add_l
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment_1::MetaData::longitude
+          latitude:
+            variable: experiment_1::MetaData::latitude
+          data:
+            variable: experiment_1::ombgPassedQc::${variable}
+          markersize: 1
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_title: '{{experiment_tag_2}}'
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        add_l
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment_2::MetaData::longitude
+          latitude:
+            variable: experiment_2::MetaData::latitude
+          data:
+            variable: experiment_2::ombgPassedQc::${variable}
+          markersize: 1
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_title: '{{experiment_tag_1}}'
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment_1::MetaData::longitude
+          latitude:
+            variable: experiment_1::MetaData::latitude
+          data:
+            variable: experiment_1::omanPassedQc::${variable}
+          markersize: 1
+          label: OmBg
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_title: '{{experiment_tag_2}}'
+        add_colorbar:
+          label: ObsValue
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment_2::MetaData::longitude
+          latitude:
+            variable: experiment_2::MetaData::latitude
+          data:
+            variable: experiment_2::omanPassedQc::${variable}
+          markersize: 1
+          label: OmBg
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment_1::EffectiveQC1::${variable}
+    figure:
+      figure size: [40,10]
+      layout: [2,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/effectiveQC_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_title: '{{experiment_tag_1}}'
+        add_colorbar:
+          label: EffectiveQC1
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment_1::MetaData::longitude
+          latitude:
+            variable: experiment_1::MetaData::latitude
+          data:
+            variable: experiment_1::EffectiveQC1::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_title: '{{experiment_tag_2}}'
+        add_colorbar:
+          label: EffectiveQC1
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment_2::MetaData::longitude
+          latitude:
+            variable: experiment_2::MetaData::latitude
+          data:
+            variable: experiment_2::EffectiveQC1::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+  - batch figure:
+      variables: *variables
+    dynamic options:
+      - type: vminvmaxcmap
+        data variable: experiment::increment::${variable}
+    figure:
+      figure size: [40,10]
+      layout: [2,1]
+      title: '{{instrument_title}} | Passed QC'
+      output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/increment_{{instrument}}_${variable}.png'
+    plots:
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_title: '{{experiment_tag_1}}'
+        add_colorbar:
+          label: Increment (OmBg - OmAn)
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment_1::MetaData::longitude
+          latitude:
+            variable: experiment_1::MetaData::latitude
+          data:
+            variable: experiment_1::increment::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}
+
+      - mapping:
+          projection: plcarr
+          domain: global
+        add_map_features: ['coastline']
+        add_title: '{{experiment_tag_2}}'
+        add_colorbar:
+          label: Increment (OmBg - OmAn)
+        add_grid:
+        layers:
+        - type: MapScatter
+          longitude:
+            variable: experiment_2::MetaData::longitude
+          latitude:
+            variable: experiment_2::MetaData::latitude
+          data:
+            variable: experiment_2::increment::${variable}
+          markersize: 2
+          label: OmAn
+          colorbar: true
+          cmap: ${dynamic_cmap}
+          vmin: ${dynamic_vmin}
+          vmax: ${dynamic_vmax}

--- a/src/swell/suites/compare/eva/comparison_observations-3dvar_cf-geos_cf.yaml
+++ b/src/swell/suites/compare/eva/comparison_observations-3dvar_cf-geos_cf.yaml
@@ -35,13 +35,13 @@ transforms:
 # Generate Increment for JEDI
 - transform: arithmetic
   new name: experiment_1::increment::${variable}
-  equals: experiment_1::ombg::${variable}-experiment::oman::${variable}
+  equals: experiment_1::ombg::${variable}-experiment_1::oman::${variable}
   for:
     variable: *variables
 
 - transform: arithmetic
   new name: experiment_2::increment::${variable}
-  equals: experiment_2::ombg::${variable}-experiment::oman::${variable}
+  equals: experiment_2::ombg::${variable}-experiment_2::oman::${variable}
   for:
     variable: *variables
 
@@ -143,6 +143,7 @@ graphics:
       layout: [2,1]
       title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
       output name: '{{cycle_dir}}/eva/{{instrument}}/correlation_scatter/${variable}/jedi_hofx_vs_obs_{{instrument}}_${variable}.png'
+      tight_layout:
     plots:
       - add_xlabel: 'Observation Value'
         add_ylabel: 'JEDI h(x)'
@@ -201,12 +202,13 @@ graphics:
       variables: *variables
     dynamic options:
       - type: histogram_bins
-        data variable: experiment::omanPassedQc::${variable}
+        data variable: experiment_1::omanPassedQc::${variable}
         number of bins rule: 'rice'
     figure:
       layout: [2,1]
       title: 'Observations vs. JEDI h(x) | {{instrument_title}} | ${variable_title}'
       output name: '{{cycle_dir}}/eva/{{instrument}}/histogram/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+      tight_layout:
     plots:
       - add_xlabel: 'Difference'
         add_ylabel: 'Count'
@@ -313,6 +315,7 @@ graphics:
       layout: [4,1]
       title: '{{instrument_title}} | Passed QC'
       output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/ombg_oman_{{instrument}}_${variable}.png'
+      tight_layout:
     plots:
       - mapping:
           projection: plcarr
@@ -322,7 +325,6 @@ graphics:
         add_colorbar:
           label: ObsValue
         add_grid:
-        add_l
         layers:
         - type: MapScatter
           longitude:
@@ -346,7 +348,6 @@ graphics:
         add_colorbar:
           label: ObsValue
         add_grid:
-        add_l
         layers:
         - type: MapScatter
           longitude:
@@ -418,6 +419,7 @@ graphics:
       layout: [2,1]
       title: '{{instrument_title}} | Passed QC'
       output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/effectiveQC_{{instrument}}_${variable}.png'
+      tight_layout:
     plots:
       - mapping:
           projection: plcarr
@@ -469,12 +471,13 @@ graphics:
       variables: *variables
     dynamic options:
       - type: vminvmaxcmap
-        data variable: experiment::increment::${variable}
+        data variable: experiment_1::increment::${variable}
     figure:
       figure size: [40,10]
       layout: [2,1]
       title: '{{instrument_title}} | Passed QC'
       output name: '{{cycle_dir}}/eva/{{instrument}}/map_plots/${variable}/increment_{{instrument}}_${variable}.png'
+      tight_layout: 
     plots:
       - mapping:
           projection: plcarr

--- a/src/swell/suites/compare/suite_config.py
+++ b/src/swell/suites/compare/suite_config.py
@@ -57,6 +57,17 @@ class SuiteConfig(QuestionContainer, Enum):
 
     # --------------------------------------------------------------------------------------------------
 
+    compare_variational_cf = QuestionList(
+        list_name="compare_variational_cf",
+        questions=[
+            compare,
+            qd.comparison_log_type('variational'),
+            qd.model_components(['geos_cf']),
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------
+
     compare_fgat_marine = QuestionList(
         list_name="compare_fgat_marine",
         questions=[


### PR DESCRIPTION
## Description

This PR enables comparison tests for 3dvar_cf, same as the other variational suites in swell. 

To create a comparison suite, create an override yaml containing at least the following entry:
```yaml
comparison_experiment_paths:
 - /path/to/3dvar_cf_exp1/experiment.yaml
 - /path/to/3dvar_cf_exp2/experiment.yaml
```
(these can be the same paths for testing purposes)

then launch `swell create compare_variational_cf -o <override.yaml>`

The comparison suite checks the jedi log to ensure the `Residual norms` are identical between the two experiments. If they are not, the suite will run eva tasks generating plots of comparisons/differences. If you don't have a test case with differing residual norms, you can check out the plots by removing the fail condition for those tasks from the `flow.cylc` graph