### PR TITLE
Use bufr_query from jedi_bundle

### DIFF
--- a/src/swell/deployment/platforms/nccs_discover_cascade/modules
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/modules
@@ -20,6 +20,7 @@ module load soca-env
 module load gmao-swell-env/1.0.0
 module unload gsibec crtm fms
 module load fms/2024.02
+module unload bufr-query
 
 # JEDI Python Path
 # ----------------

--- a/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
@@ -8,13 +8,13 @@ existing_geos_gcm_source_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.6.0/
 
 existing_jedi_build_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_01152026/build-intel-release/
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_01152026_bufr/build-intel-release/
 
 existing_jedi_build_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/build/
 
 existing_jedi_source_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_01152026/
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_01152026_bufr/
 
 existing_jedi_source_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles/current_pinned_jedi_bundle/source/

--- a/src/swell/deployment/platforms/nccs_discover_sles15/modules
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/modules
@@ -20,6 +20,7 @@ module load soca-env
 module load gmao-swell-env/1.0.0
 module unload gsibec crtm fms
 module load fms/2024.02
+module unload bufr-query
 
 # JEDI Python Path
 # ----------------

--- a/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
@@ -8,13 +8,13 @@ existing_geos_gcm_source_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-GCMv12-rc12/
 
 existing_jedi_build_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_01152026/build-intel-release/
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_01152026_bufr/build-intel-release/
 
 existing_jedi_build_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/build/
 
 existing_jedi_source_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_01152026/
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_01152026_bufr/
 
 existing_jedi_source_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/source/

--- a/src/swell/tasks/bufr_to_ioda.py
+++ b/src/swell/tasks/bufr_to_ioda.py
@@ -271,7 +271,7 @@ class BufrToIoda(taskBase):
 
             # Jedi executable name (IODA Converter Name)
             # ------------------------------------------
-            jedi_executable = 'bufr2netcdf.x'
+            jedi_executable = os.path.join(self.experiment_path(), 'jedi_bundle', 'build', 'bin', 'bufr2netcdf.x')
             cli_execution_line = (f"{jedi_executable} --no-gather "
                                   f"{bufr_path_file} {bufr2ioda_conv_yaml}")
 

--- a/src/swell/tasks/bufr_to_ioda.py
+++ b/src/swell/tasks/bufr_to_ioda.py
@@ -271,7 +271,8 @@ class BufrToIoda(taskBase):
 
             # Jedi executable name (IODA Converter Name)
             # ------------------------------------------
-            jedi_executable = os.path.join(self.experiment_path(), 'jedi_bundle', 'build', 'bin', 'bufr2netcdf.x')
+            jedi_executable = os.path.join(self.experiment_path(), 'jedi_bundle',
+                                           'build', 'bin', 'bufr2netcdf.x')
             cli_execution_line = (f"{jedi_executable} --no-gather "
                                   f"{bufr_path_file} {bufr2ioda_conv_yaml}")
 


### PR DESCRIPTION
## Description

Uses build of JEDI with bufr-query installed (January 15 build), so we can control the installation through `jedi_bundle`. Zero diff from previous January 15 version. Tested with tier1 and convert_bufr suite