### PR TITLE
Restrict usage of MLS55 between 250 and 0.1 hPa

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mls55_aura.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mls55_aura.yaml
@@ -34,3 +34,13 @@ obs filters:
     threshold: 5.0
     action:
       name: reject
+  # restrict use of data between 200 to 0.1 hPa
+  - filter: Bounds Check
+    filter variables:
+    - name: ozoneProfile
+    test variables:
+    - name: MetaData/pressure
+    minvalue: 10
+    maxvalue: 20000
+    action:
+          name: reject

--- a/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mls55_aura.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_atmosphere/observations/mls55_aura.yaml
@@ -41,6 +41,6 @@ obs filters:
     test variables:
     - name: MetaData/pressure
     minvalue: 10
-    maxvalue: 20000
+    maxvalue: 25000
     action:
           name: reject


### PR DESCRIPTION
## Description

I noticed that JEDI / SWELL seems to not impose any restrictions on the levels of MLS55 that should be used. GSI control this via the "channels" of MLS55 in ozinfo. Channels is not something easily accessible for MLS55 in UFO, but we can impose bounds on pressure. 

This PR restricts use of MLS55 between 200 and 0.1 hPa.

Here is an illustration of how the data is presently being used:
<img width="905" height="641" alt="Screenshot 2026-06-22 at 2 43 21 PM" src="https://github.com/user-attachments/assets/07ba249f-9520-4546-b104-616287a67478" />

and here is an illustration of how the picture changes when the bounds in this PR are introduced.

 <img width="905" height="641" alt="Screenshot 2026-06-22 at 2 44 23 PM" src="https://github.com/user-attachments/assets/effac2d7-80c9-4697-ac23-e9d381b790d1" />

The Jo and nobs count originally are:

CostJo   : Nonlinear Jo(MLS55 AURA) = 23526.1, nobs = 30482, Jo/n = 0.771803, err = 0.243806
CostJo   : Nonlinear Jo = 23526.1
CostFunction: Nonlinear J = 23526.1
CostJo   : Nonlinear Jo(MLS55 AURA) = 7985.87, nobs = 30482, Jo/n = 0.261986, err = 0.243806
CostJo   : Nonlinear Jo = 7985.87
CostFunction: Nonlinear J = 7985.87

and this is how the numbers change:

CostJo   : Nonlinear Jo(MLS55 AURA) = 22916, nobs = 28797, Jo/n = 0.795779, err = 0.250611
CostJo   : Nonlinear Jo = 22916
CostFunction: Nonlinear J = 22916
CostJo   : Nonlinear Jo(MLS55 AURA) = 7564.25, nobs = 28797, Jo/n = 0.262675, err = 0.250611
CostJo   : Nonlinear Jo = 7564.25
CostFunction: Nonlinear J = 7564.25

## Dependencies

- None

## Impact


- none