### PR TITLE
[Draft] Set locations for x0054

### DIFF
--- a/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
@@ -35,4 +35,4 @@ swell_static_files:
   default_value: /discover/nobackup/projects/gmao/advda/SwellStaticFiles
 
 ioda_locations_not_in_r2d2:
-  default_value: /discover/nobackup/projects/gmao/dadev/rtodling/archive/542/prePP/ioda
+  default_value: /discover/nobackup/projects/gmao/dadev/rtodling/archive/544/x0054/ioda

--- a/src/swell/suites/3dfgat_atmos/flow.cylc
+++ b/src/swell/suites/3dfgat_atmos/flow.cylc
@@ -61,11 +61,11 @@
             {% if cycling_varbc %}
             # Cycling VarBC is active, biases from the previous cycle will be used
 
-            RunJediVariationalExecutable-{{model_component}}[-PT6H] => GetObservations-{{model_component}}
+            RunJediVariationalExecutable-{{model_component}}[-PT6H] => GetObsNotInR2d2-{{model_component}}?
             {% else %}
 
             # Cycling VarBC is inactive, static bias files will be used
-            GetObservations-{{model_component}}
+            GetObsNotInR2d2-{{model_component}}?
             {% endif %}
 
             # Perform staging that is cycle dependent
@@ -76,10 +76,9 @@
             CloneJedi[^] => StageJediCycle-{{model_component}}
             StageJediCycle-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GetBackgroundGeosExperiment-{{model_component}}? | GetBackground-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
-            GetObsNotInR2d2-{{model_component}}: fail? => GetObservations-{{model_component}}
-            GetObsNotInR2d2-{{model_component}}? | GetObservations-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
+            GetObsNotInR2d2-{{model_component}}: fail? => GetObservations-{{model_component}}?
             GenerateObservingSystemRecords-{{model_component}} => RenderJediObservations-{{model_component}}
-            GetObservations-{{model_component}} => RenderJediObservations-{{model_component}}
+            GetObsNotInR2d2-{{model_component}}? | GetObservations-{{model_component}}? => RenderJediObservations-{{model_component}}
 
             RenderJediObservations-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
 

--- a/src/swell/suites/3dfgat_atmos/suite_config.py
+++ b/src/swell/suites/3dfgat_atmos/suite_config.py
@@ -25,8 +25,8 @@ class SuiteConfig(QuestionContainer, Enum):
         list_name="3dfgat_atmos",
         questions=[
             sq.common,
-            qd.start_cycle_point("2025-12-30T06:00:00Z"),
-            qd.final_cycle_point("2025-12-30T12:00:00Z"),
+            qd.start_cycle_point("2025-11-30T00:00:00Z"),
+            qd.final_cycle_point("2025-11-30T06:00:00Z"),
             qd.jedi_build_method("use_existing"),
             qd.model_components(['geos_atmosphere']),
             qd.runahead_limit("P2"),

--- a/src/swell/suites/3dfgat_atmos/suite_config.py
+++ b/src/swell/suites/3dfgat_atmos/suite_config.py
@@ -25,8 +25,8 @@ class SuiteConfig(QuestionContainer, Enum):
         list_name="3dfgat_atmos",
         questions=[
             sq.common,
-            qd.start_cycle_point("2023-10-10T00:00:00Z"),
-            qd.final_cycle_point("2023-10-10T06:00:00Z"),
+            qd.start_cycle_point("2025-12-30T06:00:00Z"),
+            qd.final_cycle_point("2025-12-30T12:00:00Z"),
             qd.jedi_build_method("use_existing"),
             qd.model_components(['geos_atmosphere']),
             qd.runahead_limit("P2"),
@@ -39,8 +39,9 @@ class SuiteConfig(QuestionContainer, Enum):
                 "T18"
             ]),
             qd.horizontal_resolution("91"),
-            qd.geos_x_background_directory("/discover/nobackup/projects/gmao/"
-                                           "dadev/rtodling/archive/Restarts/JEDI/541x"),
+            qd.background_experiment("x0054"),
+            qd.geos_x_background_directory("/discover/nobackup/projects/gmao/dadev/rtodling/"
+                                           "archive/"),
             qd.window_type("4D"),
             qd.observations([
                 "aircraft_temperature",

--- a/src/swell/suites/3dvar_atmos/flow.cylc
+++ b/src/swell/suites/3dvar_atmos/flow.cylc
@@ -59,11 +59,11 @@
             {% if cycling_varbc %}
             # Cycling VarBC is active, biases from the previous cycle will be used
 
-            RunJediVariationalExecutable-{{model_component}}[-PT6H] => GetObservations-{{model_component}}
+            RunJediVariationalExecutable-{{model_component}}[-PT6H] => GetObsNotInR2d2-{{model_component}}?
             {% else %}
 
             # Cycling VarBC is inactive, static bias files will be used
-            GetObsNotInR2d2-{{model_component}}: fail? => GetObservations-{{model_component}}
+            GetObsNotInR2d2-{{model_component}}: fail? => GetObservations-{{model_component}}?
             {% endif %}
 
             # Perform staging that is cycle dependent
@@ -74,7 +74,7 @@
             CloneJedi[^] => StageJediCycle-{{model_component}}
             StageJediCycle-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GetBackgroundGeosExperiment-{{model_component}}? | GetBackground-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
-            GetObsNotInR2d2-{{model_component}}? | GetObservations-{{model_component}} => RenderJediObservations-{{model_component}}
+            GetObsNotInR2d2-{{model_component}}? | GetObservations-{{model_component}}? => RenderJediObservations-{{model_component}}
             RenderJediObservations-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
             GenerateObservingSystemRecords-{{model_component}} => RunJediVariationalExecutable-{{model_component}}
 

--- a/src/swell/suites/3dvar_atmos/suite_config.py
+++ b/src/swell/suites/3dvar_atmos/suite_config.py
@@ -25,8 +25,8 @@ class SuiteConfig(QuestionContainer, Enum):
         list_name="3dvar_atmos",
         questions=[
             sq.common,
-            qd.start_cycle_point("2023-10-10T00:00:00Z"),
-            qd.final_cycle_point("2023-10-10T06:00:00Z"),
+            qd.start_cycle_point("2025-11-30T00:00:00Z"),
+            qd.final_cycle_point("2025-11-30T06:00:00Z"),
             qd.runahead_limit("P2"),
             qd.jedi_build_method("use_existing"),
             qd.model_components(['geos_atmosphere']),
@@ -38,8 +38,9 @@ class SuiteConfig(QuestionContainer, Enum):
                 "T12",
                 "T18"
             ]),
+            qd.background_experiment("x0054"),
             qd.geos_x_background_directory("/discover/nobackup/projects/gmao/"
-                                           "dadev/rtodling/archive/Restarts/JEDI/541x"),
+                                           "dadev/rtodling/archive/"),
             qd.window_length("PT6H"),
             qd.window_type("3D"),
             qd.horizontal_resolution("91"),

--- a/src/swell/tasks/get_background_geos_experiment.py
+++ b/src/swell/tasks/get_background_geos_experiment.py
@@ -77,8 +77,13 @@ class GetBackgroundGeosExperiment(taskBase):
         # Define the source tar folder and file
         # -------------------------------------
         bkgr_tar_file = f'{background_experiment}.bkgcrst.{bkgr_exp_start_geos}.tar'
+        if background_experiment == 'x0054':
+            sub_directory = '544'
+        else:
+            sub_directory = horizontal_resolution
+
         bkgr_tar = os.path.join(geos_x_background_directory,
-                                horizontal_resolution,
+                                sub_directory,
                                 background_experiment,
                                 'rs',
                                 bkgr_exp_start_dto.strftime('Y%Y'),


### PR DESCRIPTION
#758

This PR sets locations for GetObsNotInR2d2 and GetBackgroundGeosExperiment according to #818. Obs files and backgrounds are fetched from these locations, though the variational executable is failing:

```
fv3jedi_io_cube_sphere_history_mod.read_fields.get_field_ncid_varid: Field KCBL_before_moist was not found in any files. Should only be present in at least one file that is read.
```

Comparing to the current default case in 2023, there seems to be some file types missing, including:

aircraft_temperature.*.acftbias
aircraft_temperature.*acftbias_cov
*.satbias_cov.nc4

So I'm not sure if thats the problem, or maybe we need to add some combining/renaming