### PR TITLE
Fix cylc stall if comparison success

### DIFF
--- a/src/swell/__init__.py
+++ b/src/swell/__init__.py
@@ -9,4 +9,4 @@ import os
 repo_directory = os.path.dirname(__file__)
 
 # Set the version for swell
-__version__ = '20260603'
+__version__ = '20260624'

--- a/src/swell/suites/compare/flow.cylc
+++ b/src/swell/suites/compare/flow.cylc
@@ -45,7 +45,7 @@
             JediLogComparison-{{model_component}}:fail? => comparison_fail?
             JediLogComparison-{{model_component}}[^]:fail? => EvaComparisonIncrement-{{model_component}}? => PublishComparisons?
             JediLogComparison-{{model_component}}[^]:fail? => EvaComparisonJediLog-{{model_component}}? => PublishComparisons?
-	    JediLogComparison-{{model_component}}[^]:fail? => EvaComparisonObservations-{{model_component}}? => PublishComparisons?
+            JediLogComparison-{{model_component}}[^]:fail? => EvaComparisonObservations-{{model_component}}? => PublishComparisons?
         {% endif %}
         {% endfor %}
         """

--- a/src/swell/suites/compare/flow.cylc
+++ b/src/swell/suites/compare/flow.cylc
@@ -72,6 +72,7 @@
 
     {% for model_component in model_components %}
     [[Pass]]
+        #cylc set ... --out skip tells Cylc: “this task is intentionally not going to run; mark it as skipped.”
         script = """
             cylc set $CYLC_WORKFLOW_ID//$datetime/EvaComparisonIncrement-{{model_component}} --out skip
             cylc set $CYLC_WORKFLOW_ID//$datetime/EvaComparisonJediLog-{{model_component}} --out skip

--- a/src/swell/suites/compare/flow.cylc
+++ b/src/swell/suites/compare/flow.cylc
@@ -41,9 +41,11 @@
             {% for path in comparison_experiment_paths %}
             JediOopsLogParser-{{model_component}}-{{ loop.index0 }}
             {% endfor %}
-            JediLogComparison-{{model_component}}[^]:fail? => EvaComparisonIncrement-{{model_component}} => PublishComparisons => comparison_fail
-            JediLogComparison-{{model_component}}[^]:fail? => EvaComparisonJediLog-{{model_component}} => PublishComparisons => comparison_fail
-	    JediLogComparison-{{model_component}}[^]:fail? => EvaComparisonObservations-{{model_component}} => PublishComparisons => comparison_fail
+            JediLogComparison-{{model_component}}? => Pass
+            JediLogComparison-{{model_component}}:fail? => comparison_fail?
+            JediLogComparison-{{model_component}}[^]:fail? => EvaComparisonIncrement-{{model_component}}? => PublishComparisons?
+            JediLogComparison-{{model_component}}[^]:fail? => EvaComparisonJediLog-{{model_component}}? => PublishComparisons?
+	    JediLogComparison-{{model_component}}[^]:fail? => EvaComparisonObservations-{{model_component}}? => PublishComparisons?
         {% endif %}
         {% endfor %}
         """
@@ -69,6 +71,14 @@
         script = "exit 1"
 
     {% for model_component in model_components %}
+    [[Pass]]
+        script = """
+            cylc set $CYLC_WORKFLOW_ID//$datetime/EvaComparisonIncrement-{{model_component}} --out skip
+            cylc set $CYLC_WORKFLOW_ID//$datetime/EvaComparisonJediLog-{{model_component}} --out skip
+            cylc set $CYLC_WORKFLOW_ID//$datetime/EvaComparisonObservations-{{model_component}} --out skip
+            cylc set $CYLC_WORKFLOW_ID//$datetime/PublishComparisons --out skip
+        """
+
     [[EvaComparisonIncrement-{{model_component}}]]
         script = "swell task EvaComparisonIncrement $config -d $datetime -m {{model_component}}"
 


### PR DESCRIPTION
## Description

This PR fixes an issue with the comparison suite, in which a successful comparison will cause a cylc stall as the scheduler is waiting for tasks that are never triggered. Also bumps the version to the latest tag