### PR TITLE
Update location of CRTM coeffs for 2.4.1 CRTM (fix atms-n21)

### DIFF
--- a/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_cascade/task_questions.yaml
@@ -1,5 +1,5 @@
 crtm_coeff_dir:
-  default_value: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1/
+  default_value: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1/
 
 existing_geos_gcm_build_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-v11.6.0/install-SLES15

--- a/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
@@ -8,13 +8,13 @@ existing_geos_gcm_source_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-GCMv12-rc12/
 
 existing_jedi_build_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_07162026/build-intel-release/
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_07162026_gsibec1.4.3/build-intel-release/
 
 existing_jedi_build_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/build/
 
 existing_jedi_source_directory:
-  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_07162026/
+  default_value: /discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_07162026_gsibec1.4.3/
 
 existing_jedi_source_directory_pinned:
   default_value: /discover/nobackup/projects/gmao/advda/jedi_bundles_sles15/current_pinned_jedi_bundle/source/

--- a/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
+++ b/src/swell/deployment/platforms/nccs_discover_sles15/task_questions.yaml
@@ -1,5 +1,5 @@
 crtm_coeff_dir:
-  default_value: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1/
+  default_value: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1/
 
 existing_geos_gcm_build_path:
   default_value: /discover/nobackup/projects/gmao/SIteam/Models/GEOSgcm-GCMv12-rc12/install

--- a/src/swell/test/code_tests/missing_obs_test.py
+++ b/src/swell/test/code_tests/missing_obs_test.py
@@ -32,7 +32,7 @@ jedi_rendering.add_key('window_begin', '20211211T210000Z')
 jedi_rendering.add_key('background_time', '20211211T150000Z')
 jedi_rendering.add_key('crtm_coeff_dir',
                        '/discover/nobackup/projects/gmao/advda/SwellStaticFiles/' +
-                       'jedi/crtm_coefficients/2.4.1/')
+                       'jedi/crtm_coefficients/2.4.1-1/')
 jedi_rendering.set_obs_records_path(path_to_observing_sys_yamls)
 
 # Test 1: Observation file does not exist

--- a/src/swell/test/jedi_configs/jedi_3dfgat_atmos_config.yaml
+++ b/src/swell/test/jedi_configs/jedi_3dfgat_atmos_config.yaml
@@ -991,7 +991,7 @@ cost function:
         obs options:
           Sensor_ID: airs_aqua
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -2099,7 +2099,7 @@ cost function:
         obs options:
           Sensor_ID: amsr2_gcom-w1
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -2405,7 +2405,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_aqua
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -2657,7 +2657,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_metop-b
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -2909,7 +2909,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_metop-c
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -3161,7 +3161,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_n15
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -3413,7 +3413,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_n18
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -3665,7 +3665,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_n19
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -3917,7 +3917,7 @@ cost function:
         obs options:
           Sensor_ID: atms_n20
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -4183,7 +4183,7 @@ cost function:
         obs options:
           Sensor_ID: atms_npp
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -4449,7 +4449,7 @@ cost function:
         obs options:
           Sensor_ID: avhrr3_metop-b
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -4712,7 +4712,7 @@ cost function:
         obs options:
           Sensor_ID: avhrr3_n18
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -4975,7 +4975,7 @@ cost function:
         obs options:
           Sensor_ID: avhrr3_n19
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -5238,7 +5238,7 @@ cost function:
         obs options:
           Sensor_ID: cris-fsr_n20
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -6789,7 +6789,7 @@ cost function:
         obs options:
           Sensor_ID: cris-fsr_npp
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -8347,7 +8347,7 @@ cost function:
         obs options:
           Sensor_ID: gmi_gpm
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -9029,7 +9029,7 @@ cost function:
         obs options:
           Sensor_ID: iasi_metop-b
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -11140,7 +11140,7 @@ cost function:
         obs options:
           Sensor_ID: iasi_metop-c
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -13258,7 +13258,7 @@ cost function:
         obs options:
           Sensor_ID: mhs_metop-b
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -13702,7 +13702,7 @@ cost function:
         obs options:
           Sensor_ID: mhs_metop-c
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -14146,7 +14146,7 @@ cost function:
         obs options:
           Sensor_ID: mhs_n19
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -18430,7 +18430,7 @@ cost function:
         obs options:
           Sensor_ID: ssmis_f17
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       obs bias:
         input file: cycle_dir/ssmis_f17.20231009T150000Z.satbias.nc4
         output file: cycle_dir/ssmis_f17.20231009T210000Z.satbias.nc4

--- a/src/swell/test/jedi_configs/jedi_3dvar_atmos_config.yaml
+++ b/src/swell/test/jedi_configs/jedi_3dvar_atmos_config.yaml
@@ -976,7 +976,7 @@ cost function:
         obs options:
           Sensor_ID: airs_aqua
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -2084,7 +2084,7 @@ cost function:
         obs options:
           Sensor_ID: amsr2_gcom-w1
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -2390,7 +2390,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_aqua
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -2642,7 +2642,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_metop-b
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -2894,7 +2894,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_metop-c
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -3146,7 +3146,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_n15
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -3398,7 +3398,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_n18
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -3650,7 +3650,7 @@ cost function:
         obs options:
           Sensor_ID: amsua_n19
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -3902,7 +3902,7 @@ cost function:
         obs options:
           Sensor_ID: atms_n20
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -4168,7 +4168,7 @@ cost function:
         obs options:
           Sensor_ID: atms_npp
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -4434,7 +4434,7 @@ cost function:
         obs options:
           Sensor_ID: avhrr3_metop-b
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -4697,7 +4697,7 @@ cost function:
         obs options:
           Sensor_ID: avhrr3_n18
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -4960,7 +4960,7 @@ cost function:
         obs options:
           Sensor_ID: avhrr3_n19
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -5223,7 +5223,7 @@ cost function:
         obs options:
           Sensor_ID: cris-fsr_n20
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -6774,7 +6774,7 @@ cost function:
         obs options:
           Sensor_ID: cris-fsr_npp
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -8332,7 +8332,7 @@ cost function:
         obs options:
           Sensor_ID: gmi_gpm
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -9014,7 +9014,7 @@ cost function:
         obs options:
           Sensor_ID: iasi_metop-b
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -11125,7 +11125,7 @@ cost function:
         obs options:
           Sensor_ID: iasi_metop-c
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -13243,7 +13243,7 @@ cost function:
         obs options:
           Sensor_ID: mhs_metop-b
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -13687,7 +13687,7 @@ cost function:
         obs options:
           Sensor_ID: mhs_metop-c
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -14131,7 +14131,7 @@ cost function:
         obs options:
           Sensor_ID: mhs_n19
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
         linear obs operator:
           Absorbers:
           - H2O
@@ -18415,7 +18415,7 @@ cost function:
         obs options:
           Sensor_ID: ssmis_f17
           EndianType: little_endian
-          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+          CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       obs bias:
         input file: cycle_dir/ssmis_f17.20231009T150000Z.satbias.nc4
         output file: cycle_dir/ssmis_f17.20231009T210000Z.satbias.nc4

--- a/src/swell/test/jedi_configs/jedi_hofx_config.yaml
+++ b/src/swell/test/jedi_configs/jedi_hofx_config.yaml
@@ -916,7 +916,7 @@ observations:
       obs options:
         Sensor_ID: airs_aqua
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -2028,7 +2028,7 @@ observations:
       obs options:
         Sensor_ID: amsr2_gcom-w1
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -2338,7 +2338,7 @@ observations:
       obs options:
         Sensor_ID: amsua_aqua
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -2594,7 +2594,7 @@ observations:
       obs options:
         Sensor_ID: amsua_metop-b
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -2850,7 +2850,7 @@ observations:
       obs options:
         Sensor_ID: amsua_metop-c
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -3106,7 +3106,7 @@ observations:
       obs options:
         Sensor_ID: amsua_n15
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -3362,7 +3362,7 @@ observations:
       obs options:
         Sensor_ID: amsua_n18
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -3618,7 +3618,7 @@ observations:
       obs options:
         Sensor_ID: amsua_n19
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -3874,7 +3874,7 @@ observations:
       obs options:
         Sensor_ID: atms_n20
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -4144,7 +4144,7 @@ observations:
       obs options:
         Sensor_ID: atms_npp
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -4414,7 +4414,7 @@ observations:
       obs options:
         Sensor_ID: avhrr3_metop-b
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -4681,7 +4681,7 @@ observations:
       obs options:
         Sensor_ID: avhrr3_n18
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -4948,7 +4948,7 @@ observations:
       obs options:
         Sensor_ID: avhrr3_n19
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -5215,7 +5215,7 @@ observations:
       obs options:
         Sensor_ID: cris-fsr_n20
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -6770,7 +6770,7 @@ observations:
       obs options:
         Sensor_ID: cris-fsr_npp
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -8332,7 +8332,7 @@ observations:
       obs options:
         Sensor_ID: gmi_gpm
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -9022,7 +9022,7 @@ observations:
       obs options:
         Sensor_ID: iasi_metop-b
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -11137,7 +11137,7 @@ observations:
       obs options:
         Sensor_ID: iasi_metop-c
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -13259,7 +13259,7 @@ observations:
       obs options:
         Sensor_ID: mhs_metop-b
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -13707,7 +13707,7 @@ observations:
       obs options:
         Sensor_ID: mhs_metop-c
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -14155,7 +14155,7 @@ observations:
       obs options:
         Sensor_ID: mhs_n19
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -18479,7 +18479,7 @@ observations:
       obs options:
         Sensor_ID: ssmis_f17
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
     obs bias:
       input file: cycle_dir/ssmis_f17.20231009T150000Z.satbias.nc4
       output file: cycle_dir/ssmis_f17.20231009T210000Z.satbias.nc4

--- a/src/swell/test/jedi_configs/jedi_localensembleda_config.yaml
+++ b/src/swell/test/jedi_configs/jedi_localensembleda_config.yaml
@@ -2084,7 +2084,7 @@ observations:
       obs options:
         Sensor_ID: amsua_aqua
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -2343,7 +2343,7 @@ observations:
       obs options:
         Sensor_ID: amsua_n15
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -2602,7 +2602,7 @@ observations:
       obs options:
         Sensor_ID: amsua_n18
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -2861,7 +2861,7 @@ observations:
       obs options:
         Sensor_ID: amsua_n19
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -3127,7 +3127,7 @@ observations:
       obs options:
         Sensor_ID: amsr2_gcom-w1
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -3440,7 +3440,7 @@ observations:
       obs options:
         Sensor_ID: atms_n20
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -3713,7 +3713,7 @@ observations:
       obs options:
         Sensor_ID: atms_npp
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -3986,7 +3986,7 @@ observations:
       obs options:
         Sensor_ID: avhrr3_metop-b
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -4256,7 +4256,7 @@ observations:
       obs options:
         Sensor_ID: avhrr3_n18
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -4526,7 +4526,7 @@ observations:
       obs options:
         Sensor_ID: avhrr3_n19
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -6330,7 +6330,7 @@ observations:
       obs options:
         Sensor_ID: mhs_metop-b
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -6781,7 +6781,7 @@ observations:
       obs options:
         Sensor_ID: mhs_metop-c
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -7232,7 +7232,7 @@ observations:
       obs options:
         Sensor_ID: mhs_n19
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -8196,7 +8196,7 @@ observations:
       obs options:
         Sensor_ID: ssmis_f17
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
     obs bias:
       input file: cycle_dir/ssmis_f17.20231009T210000Z.satbias.nc4
       output file: cycle_dir/ssmis_f17.20231009T210000Z.satbias.nc4
@@ -8963,7 +8963,7 @@ observations:
       obs options:
         Sensor_ID: amsua_metop-b
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O
@@ -9222,7 +9222,7 @@ observations:
       obs options:
         Sensor_ID: amsua_metop-c
         EndianType: little_endian
-        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1//
+        CoefficientPath: /discover/nobackup/projects/gmao/advda/SwellStaticFiles/jedi/crtm_coefficients/2.4.1-1//
       linear obs operator:
         Absorbers:
         - H2O


### PR DESCRIPTION
## Description

This updates the location of the CRTM coeffs - it also syncs w/ GEOS-JEDI points to. The actual files live in fvInput - no longer in StaticFiles.

However, the new update 2.4.1-1 only differs very few ways from the original - see readme in the directory - also here:

The files here are those from CRTM-2.4.1 as found, for example, under:

/gpfsm/dnb05/projects/p61/SwellStaticFiles/jedi/crtm_coefficients/2.4.1

which are used by JEDI tests circa Oct 2024.

When replacing the version of CRTM (2.4.0) in the GMAO NCEP_Shared/NCEP_crtm
with 2.4.1-jedi-1 used in JEDI the following became known issues:

1) The two files in subdir Little_Endian/Ori had to be moved out of the way 
   and replaced with files being used by other GMAO systems, e.g., M21C
   For consistency these two files will be added to the Swell version - with
   slightly different names so that Swell/JEDI can point and use exactly the 
   files that GSI uses; and thus for there to be full consistency between
   JEDI and GSI when it comes to CRTM.

2) The is presently (03 Oct 2024) issue associated w/ reading the HIRS4 files
   in the directory here. It is believe a minor change to the source code 
   should accommodate for reading the files here.

3) The atms_n21.SpcCoeff.bin has been replaced with the same file from: v3.1.2.0

## Dependencies

- [ ] waiting on physical creation of location to hold files.

## Impact

- all atmos applications
