### PR TITLE
bugfix for when obs provider is in override

### DIFF
--- a/src/swell/configuration/jedi/observation_ioda_names.yaml
+++ b/src/swell/configuration/jedi/observation_ioda_names.yaml
@@ -544,7 +544,7 @@ ioda instrument names:
   - ioda name: tempo_no2_tropo
     full name: TEMPO tropospheric column NO2
     inst type: retrieval
-    provider :  nasa_v3 #nasa_v4
+    provider : nasa_v4
   - ioda name: tempo_no2_total
     full name: TEMPO total column NO2
     inst type: retrieval

--- a/src/swell/suites/r2d2_ingest/suite_config.py
+++ b/src/swell/suites/r2d2_ingest/suite_config.py
@@ -62,11 +62,8 @@ class SuiteConfig(QuestionContainer, Enum):
                                 'tropomi_s5p_co_total', 'tempo_no2_tropo']),
             qd.obs_to_ingest(['omps_o3_nm_total', 'tropomi_s5p_no2_tropo',
                               'tropomi_s5p_co_total', 'tempo_no2_tropo']),
-            qd.converter_path(
-                "/discover/nobackup/projects/jcsda/s2127/maryamao/"
-                "jedi-bundle/build-intel-1.9/bin/"
             ),
-            qd.dry_run(False),
+            qd.dry_run(True),
             qd.store_as_symlink(False),
         ]
     )
@@ -85,8 +82,8 @@ class SuiteConfig(QuestionContainer, Enum):
         geos_cf=[
             qd.dry_run(True),
             qd.background_source_path(),
-            qd.background_experiment(),
-            qd.horizontal_resolution(),
+            qd.background_experiment('geos_cf_oper'),
+            qd.horizontal_resolution('c360'),
             qd.store_as_symlink(True),
         ]
     )

--- a/src/swell/suites/r2d2_ingest/suite_config.py
+++ b/src/swell/suites/r2d2_ingest/suite_config.py
@@ -62,7 +62,6 @@ class SuiteConfig(QuestionContainer, Enum):
                                 'tropomi_s5p_co_total', 'tempo_no2_tropo']),
             qd.obs_to_ingest(['omps_o3_nm_total', 'tropomi_s5p_no2_tropo',
                               'tropomi_s5p_co_total', 'tempo_no2_tropo']),
-            ),
             qd.dry_run(True),
             qd.store_as_symlink(False),
         ]

--- a/src/swell/tasks/ingest_obs.py
+++ b/src/swell/tasks/ingest_obs.py
@@ -83,6 +83,11 @@ class IngestObs(taskBase):
         # Read observation ioda names (for provider lookup)
         self.ioda_names_list = get_ioda_names_list()
 
+        # Per-observation provider overrides from the experiment configuration.
+        # Values here take precedence over the defaults in
+        # observation_ioda_names.yaml.
+        self.observation_providers = self.config.observation_providers(default={})
+
         # Get window parameters
         window_length = self.config.window_length()
 
@@ -162,7 +167,8 @@ class IngestObs(taskBase):
         failed = []
 
         provider = get_provider_for_observation(
-            obs_name, self.ioda_names_list, self.logger)
+            obs_name, self.ioda_names_list, self.logger,
+            provider_overrides=self.observation_providers)
 
         acquisition_method = config.get('acquisition_method')  # 'cp', 's3', or 'local'
 

--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -518,6 +518,7 @@ class TaskQuestions(QuestionContainer, Enum):
         questions=[
             qd.dry_run(),
             qd.obs_to_ingest(),
+            qd.observation_providers(),
             qd.window_length(),
             qd.store_as_symlink(),
         ]


### PR DESCRIPTION
## Description

The observation provider specified in the override wasn’t being picked up. This PR fixes that issue and corrects some of the default values for ingest_obs_cf.
