### PR TITLE
5day window, background frequency and bug fix

### DIFF
--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/adt_jason3.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/adt_jason3.yaml
@@ -8,9 +8,11 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.adt_jason3.{{window_begin}}.nc4'
+{% if 'letkf' in suite_to_run %}
   distribution:
     name: Halo
     halo size: 3500.0e3
+{% endif %}
   simulated variables: [absoluteDynamicTopography]
 obs operator:
   name: ADT
@@ -41,6 +43,7 @@ obs filters:
   - variable: { name: GeoVaLs/sea_ice_area_fraction}
     maxvalue: 0.00001
 {% endif %}
+{% if 'letkf' in suite_to_run %}
 obs localizations:
 - localization method: Rossby
   base value: 100.0e3
@@ -48,3 +51,4 @@ obs localizations:
   min grid mult: 2.0
   min value: 200.0e3
   max value: 900.0e3
+{% endif %}

--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/adt_sentinel6a.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/adt_sentinel6a.yaml
@@ -8,9 +8,11 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.adt_sentinel6a.{{window_begin}}.nc4'
+{% if 'letkf' in suite_to_run %}
   distribution:
     name: Halo
     halo size: 3500.0e3
+{% endif %}
   simulated variables: [absoluteDynamicTopography]
 obs operator:
   name: ADT
@@ -41,6 +43,7 @@ obs filters:
   - variable: { name: GeoVaLs/sea_ice_area_fraction}
     maxvalue: 0.00001
 {% endif %}
+{% if 'letkf' in suite_to_run %}
 obs localizations:
 - localization method: Rossby
   base value: 100.0e3
@@ -48,3 +51,4 @@ obs localizations:
   min grid mult: 2.0
   min value: 200.0e3
   max value: 900.0e3
+{% endif %}

--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/insitu_profile_argo.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/insitu_profile_argo.yaml
@@ -8,9 +8,11 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.insitu_profile_argo.{{window_begin}}.nc4'
+{% if 'letkf' in suite_to_run %}
   distribution:
     name: Halo
     halo size: 3500.0e3
+{% endif %}
   simulated variables: [waterTemperature, salinity]
 obs operator:
   name: Composite
@@ -59,6 +61,7 @@ obs filters:
   where:
   - variable: {name: GeoVaLs/distance_from_coast}
     minvalue: 100e3
+{% if 'letkf' in suite_to_run %}
 obs localizations:
 - localization method: Rossby
   base value: 100.0e3
@@ -66,3 +69,4 @@ obs localizations:
   min grid mult: 2.0
   min value: 200.0e3
   max value: 900.0e3
+{% endif %}

--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/sss_smos.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/sss_smos.yaml
@@ -8,9 +8,11 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.sss_smos.{{window_begin}}.nc4'
+{% if 'letkf' in suite_to_run %}
   distribution:
     name: Halo
     halo size: 3500.0e3
+{% endif %}
   simulated variables: [seaSurfaceSalinity]
 obs operator:
   name: Identity
@@ -43,6 +45,7 @@ obs filters:
   where:
   - variable: {name: GeoVaLs/distance_from_coast}
     minvalue: 100e3
+{% if 'letkf' in suite_to_run %}
 obs localizations:
 - localization method: Rossby
   base value: 100.0e3
@@ -50,3 +53,4 @@ obs localizations:
   min grid mult: 2.0
   min value: 200.0e3
   max value: 900.0e3
+{% endif %}

--- a/src/swell/configuration/jedi/interfaces/geos_marine/observations/sst_viirs_n20_l3u.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_marine/observations/sst_viirs_n20_l3u.yaml
@@ -8,9 +8,11 @@ obs space:
     engine:
       type: H5File
       obsfile: '{{cycle_dir}}/{{experiment_id}}.sst_viirs_n20_l3u.{{window_begin}}.nc4'
+{% if 'letkf' in suite_to_run %}
   distribution:
     name: Halo
     halo size: 3500.0e3
+{% endif %}
   simulated variables: [seaSurfaceTemperature]
 get values:
   time interpolation: linear
@@ -53,6 +55,7 @@ obs filters:
   - variable: { name: GeoVaLs/sea_ice_area_fraction}
     maxvalue: 0.00001
 {% endif %}
+{% if 'letkf' in suite_to_run %}
 obs localizations:
 - localization method: Rossby
   base value: 100.0e3
@@ -60,3 +63,4 @@ obs localizations:
   min grid mult: 2.0
   min value: 200.0e3
   max value: 900.0e3
+{% endif %}

--- a/src/swell/suites/3dfgat_marine_cycle/suite_config.py
+++ b/src/swell/suites/3dfgat_marine_cycle/suite_config.py
@@ -141,8 +141,6 @@ class SuiteConfig(QuestionContainer, Enum):
                 "insitu_profile_tao",
                 "icec_amsr2_north",
                 "icec_amsr2_south",
-                "icec_nsidc_nh",
-                "icec_nsidc_sh",
                 "sst_ostia",
                 "sss_smos",
                 "sss_smapv5",
@@ -151,10 +149,63 @@ class SuiteConfig(QuestionContainer, Enum):
                 "sst_avhrrf_mc_l3u",
                 "sst_viirs_n20_l3u",
                 "sst_viirs_npp_l3u",
-                "temp_profile_xbt"
             ]),
             qd.number_of_iterations([50]),
             qd.background_time_offset("P1DT12H"),
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------
+
+    _3dfgat_marine_cycle_5day = QuestionList(
+        list_name="3dfgat_marine_cycle_5day",
+        questions=[
+            _3dfgat_marine_cycle_tier2,
+            qd.start_cycle_point("2023-01-08T12:00:00Z"),
+            qd.final_cycle_point("2023-02-27T12:00:00Z"),
+            qd.forecast_duration("P10D"),
+            qd.geos_homdir("/discover/nobackup/projects/gmao/soca/dardag/GEOS_FORWARD/GEOS_v12_rc20/"
+                           "dataatm_025deg_om4_swell"),
+        ],
+        geos_marine=[
+            qd.cycle_times([
+                "P5D",
+            ]),
+            qd.marine_models([
+                "mom6",
+            ]),
+            qd.observations([
+                "adt_cryosat2n",
+                "adt_jason3",
+                "adt_jason3n",
+                "adt_saral",
+                "adt_sentinel3a",
+                "adt_sentinel3b",
+                "adt_sentinel6a",
+                "adt_swot_nadir",
+                "insitu_profile_argo",
+                "insitu_profile_ctd",
+                "insitu_profile_pirata",
+                "insitu_profile_rama",
+                "insitu_profile_tao",
+                "sss_smos",
+                "sss_smapv5",
+                "sst_avhrrf_mb_l3u",
+                "sst_avhrrf_mc_l3u",
+                "sst_viirs_n20_l3u",
+                "sst_viirs_npp_l3u",
+            ]),
+            qd.analysis_variables([
+                "sea_water_salinity",
+                "sea_water_potential_temperature",
+                "sea_surface_height_above_geoid",
+                "sea_water_cell_thickness",
+            ]),
+            qd.window_length("P5D"),
+            qd.background_frequency("PT12H"),
+            qd.mom6_iau_nhours("PT18H"),
+            qd.background_time_offset("P7DT12H"),
+            qd.number_of_iterations([75]),
         ]
     )
 

--- a/src/swell/suites/3dfgat_marine_cycle/suite_config.py
+++ b/src/swell/suites/3dfgat_marine_cycle/suite_config.py
@@ -164,8 +164,8 @@ class SuiteConfig(QuestionContainer, Enum):
             qd.start_cycle_point("2023-01-08T12:00:00Z"),
             qd.final_cycle_point("2023-02-27T12:00:00Z"),
             qd.forecast_duration("P10D"),
-            qd.geos_homdir("/discover/nobackup/projects/gmao/soca/dardag/GEOS_FORWARD/GEOS_v12_rc20/"
-                           "dataatm_025deg_om4_swell"),
+            qd.geos_homdir("/discover/nobackup/projects/gmao/soca/dardag/GEOS_FORWARD/"
+                           "GEOS_v12_rc20/dataatm_025deg_om4_swell"),
         ],
         geos_marine=[
             qd.cycle_times([

--- a/src/swell/suites/3dvar_marine/suite_config.py
+++ b/src/swell/suites/3dvar_marine/suite_config.py
@@ -112,3 +112,21 @@ class SuiteConfig(QuestionContainer, Enum):
     )
 
     # --------------------------------------------------------------------------------------------------
+
+    _3dvar_marine_5day = QuestionList(
+        list_name="3dvar_marine_5day",
+        questions=[
+            _3dvar_marine,
+            qd.start_cycle_point("2023-01-07T12:00:00Z"),
+            qd.final_cycle_point("2023-01-17T12:00:00Z"),
+            qd.forecast_duration("P10D"),
+        ],
+        geos_marine=[
+            qd.cycle_times(['T120']),
+            qd.window_length("P5D"),
+            qd.background_frequency("PT12H"),
+            qd.background_time_offset("P7DT12H"),
+        ]
+    )
+
+    # --------------------------------------------------------------------------------------------------

--- a/src/swell/suites/suite_questions.py
+++ b/src/swell/suites/suite_questions.py
@@ -45,6 +45,7 @@ class SuiteQuestions(QuestionContainer, Enum):
             qd.r2d2_server(),
             qd.r2d2_datastore(),
             qd.skip_r2d2(),
+            qd.suite_to_run(),
         ]
     )
 

--- a/src/swell/tasks/eva_observations.py
+++ b/src/swell/tasks/eva_observations.py
@@ -50,6 +50,9 @@ class EvaObservations(taskBase):
         self.jedi_rendering.add_key('crtm_coeff_dir', self.config.crtm_coeff_dir(None))
         self.jedi_rendering.add_key('window_begin', window_begin)
 
+        # Needed for localization templating
+        self.jedi_rendering.add_key('suite_to_run', self.config.suite_to_run())
+
         # Get the model
         # -------------
         model = self.get_model()

--- a/src/swell/tasks/get_coupled_geos_restart.py
+++ b/src/swell/tasks/get_coupled_geos_restart.py
@@ -21,7 +21,8 @@ class GetCoupledGeosRestart(taskBase):
     # ----------------------------------------------------------------------------------------------
 
     def execute(self) -> None:
-        """Copies coupled GEOS restart files to the forecast directory.
+        """Copies coupled GEOS restart files to the forecast directory. Coupled here indicate that the
+        simulation involves both the atmosphere and marine (MOM6 + CICE6) components.
 
         The files copied include:
         - *_rst files (including atmosphere and tile interface files)

--- a/src/swell/tasks/get_coupled_geos_restart.py
+++ b/src/swell/tasks/get_coupled_geos_restart.py
@@ -21,8 +21,8 @@ class GetCoupledGeosRestart(taskBase):
     # ----------------------------------------------------------------------------------------------
 
     def execute(self) -> None:
-        """Copies coupled GEOS restart files to the forecast directory. Coupled here indicate that the
-        simulation involves both the atmosphere and marine (MOM6 + CICE6) components.
+        """Copies coupled GEOS restart files to the forecast directory. Coupled here indicate that
+        the simulation involves both the atmosphere and marine (MOM6 + CICE6) components.
 
         The files copied include:
         - *_rst files (including atmosphere and tile interface files)

--- a/src/swell/tasks/get_observations.py
+++ b/src/swell/tasks/get_observations.py
@@ -261,6 +261,9 @@ class GetObservations(taskBase):
         self.jedi_rendering.add_key('window_begin', window_begin)
         self.jedi_rendering.add_key('marine_models', self.config.marine_models(None))
 
+        # Needed for localization templating
+        self.jedi_rendering.add_key('suite_to_run', self.config.suite_to_run())
+
         # Read observation ioda names
         ioda_names_list = get_ioda_names_list()
 

--- a/src/swell/tasks/prep_coupled_geos_run_dir.py
+++ b/src/swell/tasks/prep_coupled_geos_run_dir.py
@@ -67,7 +67,7 @@ class PrepCoupledGeosRunDir(taskBase):
         # ----------------
         self.get_static()
 
-        # Modify ice_in and diag_table to allow different DA windows without changing the GEOSgcm 
+        # Modify ice_in and diag_table to allow different DA windows without changing the GEOSgcm
         # experiment directory
         # --------------------------------
         bkgr_freq = self.config.get_key_for_model('background_frequency', 'geos_marine', 'PT00')

--- a/src/swell/tasks/prep_coupled_geos_run_dir.py
+++ b/src/swell/tasks/prep_coupled_geos_run_dir.py
@@ -32,11 +32,12 @@ class PrepCoupledGeosRunDir(taskBase):
         As the name suggests, this task is geared towards coupled GEOSgcm simulations but
         the only difference between this and dataOcean ones should be in the get_static() method.
 
-        xx) Changes HOMDIR and EXPDIR in gcm_run.j to point to the forecast directory
-        xx) Provides consistency for GEOSgcm version by copying GEOSgcm.x from EXPDIR
-        xx) (Optional) Checks GEOSDIR, GEOSBIN, GEOSETC, GEOSUTIL are consistent with
+        01) Changes HOMDIR and EXPDIR in gcm_run.j to point to the forecast directory
+        02) Provides consistency for GEOSgcm version by copying GEOSgcm.x from EXPDIR
+        03) Modifies ice_in and diag_table files to match background_frequency
+        xx) (Not active) (Optional) Checks GEOSDIR, GEOSBIN, GEOSETC, GEOSUTIL are consistent with
             experiment.yaml value if the override switch is on
-        xx) Modifies CAP.rc according to cycle_date and forecast_duration
+        04) Modifies CAP.rc according to cycle_date and forecast_duration
         """
 
         # These links were created in get_*_geos_restart task. This step will copy experiment
@@ -66,14 +67,20 @@ class PrepCoupledGeosRunDir(taskBase):
         # ----------------
         self.get_static()
 
+        # Modify ice_in and diag_table to allow different DA windows without changing the GEOSgcm 
+        # experiment directory
+        # --------------------------------
+        bkgr_freq = self.config.get_key_for_model('background_frequency', 'geos_marine', 'PT00')
+        self.geos.process_icein(bkgr_freq)
+        self.geos.process_diag_table(bkgr_freq)
+
         # IAU augment for MOM6
         # --------------------
-        if 'geos_marine' == self.get_model():
-            self.mom6_iau()
+        self.mom6_iau()
 
         # Modify input.nml if not cold start (default)
         # --------------------------------------------
-        self.geos.process_nml()
+        self.geos.process_inputnml()
 
         # Parse .rc files and convert bool.s to Python format
         # ---------------------------------------------------
@@ -124,7 +131,7 @@ class PrepCoupledGeosRunDir(taskBase):
         #         else:
         #             outfile.write(line)
 
-        # TODO: Still need to rewrite CAP.rc here for now to make sure END_TIME is long enough
+        # Still need to rewrite CAP.rc here for now to ensure END_TIME is long enough
         self.cap_dict = self.rewrite_cap(self.cap_dict, self.forecast_dir('CAP.rc'))
 
         self.agcm_dict = self.geos.parse_rc(self.forecast_dir('AGCM.rc'))

--- a/src/swell/tasks/prep_coupled_geos_run_dir.py
+++ b/src/swell/tasks/prep_coupled_geos_run_dir.py
@@ -68,9 +68,9 @@ class PrepCoupledGeosRunDir(taskBase):
         self.get_static()
 
         # Modify ice_in and diag_table to allow different DA windows without changing the GEOSgcm
-        # experiment directory
+        # experiment directory. If background frequency is not available, use default PT3H
         # --------------------------------
-        bkgr_freq = self.config.get_key_for_model('background_frequency', 'geos_marine', 'PT00')
+        bkgr_freq = self.config.get_key_for_model('background_frequency', 'geos_marine', 'PT3H')
         self.geos.process_icein(bkgr_freq)
         self.geos.process_diag_table(bkgr_freq)
 

--- a/src/swell/tasks/prep_coupled_geos_run_dir.py
+++ b/src/swell/tasks/prep_coupled_geos_run_dir.py
@@ -24,7 +24,7 @@ class PrepCoupledGeosRunDir(taskBase):
     def execute(self) -> None:
 
         """
-        Copies GEOS HOMDIR files to the cycle forecast directory to prepare before executing
+        Copies GEOS HOMDIR files to the GEOSfcm forecast directory and prepares it before executing
         gcm_run.j.
         Modifies certain resource files using python's re package according to cycle_date such as:
         CAP.rc, AGCM.rc, input.nml, and gcm_run.j.

--- a/src/swell/tasks/render_jedi_observations.py
+++ b/src/swell/tasks/render_jedi_observations.py
@@ -49,6 +49,9 @@ class RenderJediObservations(taskBase):
         self.jedi_rendering.add_key('crtm_coeff_dir', crtm_coeff_dir)
         self.jedi_rendering.add_key('marine_models', marine_models)
 
+        # Needed for localization templating
+        self.jedi_rendering.add_key('suite_to_run', self.config.suite_to_run())
+
         cwd = os.getcwd()
 
         if self.config.mock_experiment(False):

--- a/src/swell/tasks/save_obs_diags.py
+++ b/src/swell/tasks/save_obs_diags.py
@@ -89,7 +89,7 @@ class SaveObsDiags(taskBase):
                     experiment=self.config.r2d2_experiment_id(),
                     observation_type=name,
                     file_extension=obs_path_file.split('.')[-1],
-                    window_length='PT6H',
+                    window_length=window_length,
                     window_start=window_begin,
                     source_file=obs_path_file,
                     member=-9999,

--- a/src/swell/tasks/save_obs_diags.py
+++ b/src/swell/tasks/save_obs_diags.py
@@ -53,6 +53,9 @@ class SaveObsDiags(taskBase):
         self.jedi_rendering.add_key('crtm_coeff_dir', crtm_coeff_dir)
         self.jedi_rendering.add_key('window_begin', window_begin)
 
+        # Needed for localization templating
+        self.jedi_rendering.add_key('suite_to_run', self.config.suite_to_run())
+
         # Loop over observation operators
         # -------------------------------
         for observation in observations:

--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -475,6 +475,7 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.obs_experiment(),
             qd.observation_providers(),
             qd.observing_system_records_path(),
+            qd.suite_to_run(),
             qd.window_length(),
         ]
     )
@@ -658,6 +659,7 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.background_time_offset(),
             qd.observing_system_records_path(),
             qd.observations(),
+            qd.suite_to_run(),
             qd.window_length(),
             qd.mock_experiment()
         ]

--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -475,7 +475,6 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.obs_experiment(),
             qd.observation_providers(),
             qd.observing_system_records_path(),
-            qd.suite_to_run(),
             qd.window_length(),
         ]
     )
@@ -659,7 +658,6 @@ class TaskQuestions(QuestionContainer, Enum):
             qd.background_time_offset(),
             qd.observing_system_records_path(),
             qd.observations(),
-            qd.suite_to_run(),
             qd.window_length(),
             qd.mock_experiment()
         ]
@@ -909,7 +907,7 @@ class TaskQuestions(QuestionContainer, Enum):
         questions=[
             background_crtm_obs,
             qd.window_length(),
-            qd.marine_models()
+            qd.marine_models(),
         ]
     )
 

--- a/src/swell/test/jedi_configs/jedi_3dfgat_marine_cycle_config.yaml
+++ b/src/swell/test/jedi_configs/jedi_3dfgat_marine_cycle_config.yaml
@@ -152,9 +152,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.adt_jason3.20210701T090000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - absoluteDynamicTopography
       obs operator:
@@ -189,13 +186,6 @@ cost function:
         - variable:
             name: GeoVaLs/sea_ice_area_fraction
           maxvalue: 1e-05
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: adt_jason3
     - obs space:
         name: adt_saral
@@ -342,9 +332,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.insitu_profile_argo.20210701T090000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - waterTemperature
         - salinity
@@ -392,13 +379,6 @@ cost function:
         - variable:
             name: GeoVaLs/distance_from_coast
           minvalue: 100000.0
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: insitu_profile_argo
     - obs space:
         name: icec_amsr2_north
@@ -655,9 +635,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.sss_smos.20210701T090000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - seaSurfaceSalinity
       obs operator:
@@ -695,13 +672,6 @@ cost function:
         - variable:
             name: GeoVaLs/distance_from_coast
           minvalue: 100000.0
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: sss_smos
     - obs space:
         name: sss_smapv5
@@ -873,9 +843,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.sst_viirs_n20_l3u.20210701T090000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - seaSurfaceTemperature
       get values:
@@ -921,13 +888,6 @@ cost function:
         - variable:
             name: GeoVaLs/sea_ice_area_fraction
           maxvalue: 1e-05
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: sst_viirs_n20_l3u
     - obs space:
         name: temp_profile_xbt

--- a/src/swell/test/jedi_configs/jedi_3dvar_marine_config.yaml
+++ b/src/swell/test/jedi_configs/jedi_3dvar_marine_config.yaml
@@ -121,9 +121,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.adt_jason3.20210701T000000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - absoluteDynamicTopography
       obs operator:
@@ -153,13 +150,6 @@ cost function:
         - variable:
             name: GeoVaLs/distance_from_coast
           minvalue: 100000.0
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: adt_jason3
     - obs space:
         name: adt_saral
@@ -291,9 +281,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.insitu_profile_argo.20210701T000000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - waterTemperature
         - salinity
@@ -341,13 +328,6 @@ cost function:
         - variable:
             name: GeoVaLs/distance_from_coast
           minvalue: 100000.0
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: insitu_profile_argo
     - obs space:
         name: sst_ostia
@@ -405,9 +385,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.sss_smos.20210701T000000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - seaSurfaceSalinity
       obs operator:
@@ -445,13 +422,6 @@ cost function:
         - variable:
             name: GeoVaLs/distance_from_coast
           minvalue: 100000.0
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: sss_smos
     - obs space:
         name: sss_smapv5
@@ -613,9 +583,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.sst_viirs_n20_l3u.20210701T000000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - seaSurfaceTemperature
       get values:
@@ -656,13 +623,6 @@ cost function:
               - ObsError/seaSurfaceTemperature
               coefs:
               - 1.0
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: sst_viirs_n20_l3u
     - obs space:
         name: temp_profile_xbt

--- a/src/swell/test/jedi_configs/jedi_3dvar_marine_cycle_config.yaml
+++ b/src/swell/test/jedi_configs/jedi_3dvar_marine_cycle_config.yaml
@@ -121,9 +121,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.adt_jason3.20210701T090000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - absoluteDynamicTopography
       obs operator:
@@ -153,13 +150,6 @@ cost function:
         - variable:
             name: GeoVaLs/distance_from_coast
           minvalue: 100000.0
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: adt_jason3
     - obs space:
         name: adt_saral
@@ -291,9 +281,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.insitu_profile_argo.20210701T090000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - waterTemperature
         - salinity
@@ -341,13 +328,6 @@ cost function:
         - variable:
             name: GeoVaLs/distance_from_coast
           minvalue: 100000.0
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: insitu_profile_argo
     - obs space:
         name: sst_ostia
@@ -405,9 +385,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.sss_smos.20210701T090000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - seaSurfaceSalinity
       obs operator:
@@ -445,13 +422,6 @@ cost function:
         - variable:
             name: GeoVaLs/distance_from_coast
           minvalue: 100000.0
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: sss_smos
     - obs space:
         name: sss_smapv5
@@ -613,9 +583,6 @@ cost function:
           engine:
             type: H5File
             obsfile: cycle_dir/experiment_id.sst_viirs_n20_l3u.20210701T090000Z.nc4
-        distribution:
-          name: Halo
-          halo size: 3500000.0
         simulated variables:
         - seaSurfaceTemperature
       get values:
@@ -656,13 +623,6 @@ cost function:
               - ObsError/seaSurfaceTemperature
               coefs:
               - 1.0
-      obs localizations:
-      - localization method: Rossby
-        base value: 100000.0
-        rossby mult: 1.0
-        min grid mult: 2.0
-        min value: 200000.0
-        max value: 900000.0
       observation_name: sst_viirs_n20_l3u
     - obs space:
         name: temp_profile_xbt

--- a/src/swell/utilities/config.py
+++ b/src/swell/utilities/config.py
@@ -64,6 +64,12 @@ class Config():
         self.__final_cycle_point__ = experiment_dict.get('final_cycle_point')
         self.__suite_to_run__ = experiment_dict.get('suite_to_run')
 
+        # Create getter methods for suite-level variables so they can be used without
+        # adding them to task_questions
+        for suite_var in ['experiment_root', 'experiment_id', 'platform',
+                          'start_cycle_point', 'final_cycle_point', 'suite_to_run']:
+            setattr(self, suite_var, self.get(suite_var))
+
         # If experiment_dict contains models key add the model components to the object
         if 'models' in experiment_dict.keys():
             self.__model_components__ = list(experiment_dict['models'].keys())

--- a/src/swell/utilities/geos.py
+++ b/src/swell/utilities/geos.py
@@ -12,6 +12,7 @@ import f90nml
 import glob
 import isodate
 import os
+import re
 from typing import Tuple, Optional
 
 from swell.utilities.datetime_util import datetime_formats
@@ -309,7 +310,7 @@ class Geos():
 
     # ----------------------------------------------------------------------------------------------
 
-    def process_nml(
+    def process_inputnml(
         self,
         combine_fvcore: bool = False,
         cold_restart: bool = False
@@ -340,6 +341,92 @@ class Geos():
             nml_comb.update(nml2)
 
         with open(os.path.join(self.forecast_dir, 'input.nml'), 'w') as f:
+            f90nml.write(nml_comb, f, sort=False)
+
+    # ----------------------------------------------------------------------------------------------
+
+    def process_diag_table(
+        self,
+        bkg_freq: str = "PT00",
+    ) -> None:
+        """
+        Adjusts the GEOS diag_table history entry to match the background frequency.
+
+        This file is not a namelist, so the change is implemented as a targeted text rewrite
+        for the history template line that uses the background interval.
+
+        TODO: In newer FMS version, a YAML file is used for diag_table, so this should be more
+        straightforward to set eventually.
+
+        Args:
+            bkg_freq (str): Frequency for background processing. Default "PT00" is not used.
+        """
+
+        diag_table_path = os.path.join(self.forecast_dir, 'diag_table')
+        if not os.path.exists(diag_table_path):
+            self.logger.abort(f"diag_table not found: {diag_table_path}")
+
+        bkg_duration = isodate.parse_duration(bkg_freq)
+        bkg_hours = int(bkg_duration.total_seconds() / 3600)
+
+        self.logger.info(f"Updating diag_table history frequency with background frequency: {bkg_freq}")
+
+        with open(diag_table_path, 'r') as infile:
+            content = infile.read()
+
+        pattern = re.compile(
+            r'("his%4yr%2mo%2dy%2hr"\s*,\s*)(\d+)(\s*,\s*"hours"\s*,\s*\d+\s*,\s*"hours"\s*,\s*"time"\s*,\s*)(\d+)(\s*,\s*"hours")'
+        )
+        updated_content, count = pattern.subn(
+            lambda match: (
+                f"{match.group(1)}{bkg_hours}{match.group(3)}{bkg_hours}{match.group(5)}"
+            ),
+            content,
+        )
+
+        if count == 0:
+            pattern = re.compile(r'("his%4yr%2mo%2dy%2hr"\s*,\s*)(\d+)(\s*,\s*"hours")')
+            updated_content, count = pattern.subn(
+                lambda match: f"{match.group(1)}{bkg_hours}{match.group(3)}",
+                content,
+            )
+
+        if count == 0:
+            self.logger.warning('No diag_table history entry matched the expected pattern')
+            return
+
+        with open(diag_table_path, 'w') as outfile:
+            outfile.write(updated_content)
+
+    # --------------------------------------------------------------------------------------------------
+
+    def process_icein(
+        self,
+        bkg_freq: str = "PT00",
+    ) -> None:
+        """
+        Adjusts the ice_in namelist file for history output to match the background frequency.
+
+        Args:
+            bkg_freq (str): Frequency for background processing. Defaults to "PT00".
+        """
+
+        # Make sure icein.nml is set up properly for hot/cold restart
+        nml_comb = f90nml.read(os.path.join(self.forecast_dir, 'ice_in'))
+
+        # Convert background frequency to hours for histfreq_n
+        bkg_duration = isodate.parse_duration(bkg_freq)
+        bkg_hours = int(bkg_duration.total_seconds() / 3600)
+
+        self.logger.info(f"Updating ice_in history frequency with background frequency: {bkg_freq}")
+
+        # Replace `h` with background frequency
+        # histfreq = 'h', 'd', 'x', 'x', 'x'
+        # histfreq_n = 6, 1, 1, 1, 1
+        nml_comb['setup_nml']['histfreq'] = ['h', 'd', 'x', 'x', 'x']
+        nml_comb['setup_nml']['histfreq_n'][0] = bkg_hours
+
+        with open(os.path.join(self.forecast_dir, 'ice_in'), 'w') as f:
             f90nml.write(nml_comb, f, sort=False)
 
     # --------------------------------------------------------------------------------------------------

--- a/src/swell/utilities/geos.py
+++ b/src/swell/utilities/geos.py
@@ -369,13 +369,15 @@ class Geos():
         bkg_duration = isodate.parse_duration(bkg_freq)
         bkg_hours = int(bkg_duration.total_seconds() / 3600)
 
-        self.logger.info(f"Updating diag_table history frequency with background frequency: {bkg_freq}")
+        self.logger.info(f"Change diag_table history frequency to background frequency: {bkg_freq}")
 
         with open(diag_table_path, 'r') as infile:
             content = infile.read()
 
         pattern = re.compile(
-            r'("his%4yr%2mo%2dy%2hr"\s*,\s*)(\d+)(\s*,\s*"hours"\s*,\s*\d+\s*,\s*"hours"\s*,\s*"time"\s*,\s*)(\d+)(\s*,\s*"hours")'
+            r'("his%4yr%2mo%2dy%2hr"\s*,\s*)(\d+)'
+            r'(\s*,\s*"hours"\s*,\s*\d+\s*,\s*"hours"\s*,\s*"time"\s*,\s*)'
+            r'(\d+)(\s*,\s*"hours")'
         )
         updated_content, count = pattern.subn(
             lambda match: (

--- a/src/swell/utilities/question_defaults.py
+++ b/src/swell/utilities/question_defaults.py
@@ -272,6 +272,15 @@ class QuestionDefaults():
     # --------------------------------------------------------------------------------------------------
 
     @dataclass
+    class suite_to_run(SuiteQuestion):
+        default_value: str = "test"
+        question_name: str = "suite_to_run"
+        prompt: str = "Record of the suite being executed"
+        widget_type: WType = WType.STRING
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
     class window_type(SuiteQuestion):
         default_value: str = "defer_to_model"
         question_name: str = "window_type"

--- a/src/swell/utilities/render_jedi_interface_files.py
+++ b/src/swell/utilities/render_jedi_interface_files.py
@@ -130,6 +130,7 @@ class JediConfigRendering():
             'skip_ensemble_hofx',
             'swell_static_files',
             'start_cycle_point',
+            'suite_to_run',
             'total_processors',
             'vertical_localization_apply_log_transform',
             'vertical_localization_function',


### PR DESCRIPTION
I've been testing 5day configurations, they still don't work due to memory constraints but I'm making a PR because of the IAU fix.

Also adds capability to edit `diag_table` and `ice_in` automatically depending on the `background_frequency`. This allows switching between 6-h, 1-day or 5-day DA windows without changing the `geos_homdir`

Introduces `suite_to_run` as a renderable key. This is needed for some LETKF (ensemble) specific entries in observation YAMLs

Important: While adding some simple features I noticed a bug in terms if MOM6 IAU, so this fixes that as well.