### PR TITLE
add override to download obs

### DIFF
--- a/docs/practical_examples/r2d2/r2d2_ingest.md
+++ b/docs/practical_examples/r2d2/r2d2_ingest.md
@@ -171,6 +171,30 @@ machine urs.earthdata.nasa.gov login <username> password <password>
 
 `DownloadObs` task places files in `<cycle_dir>/download/<obs_name>/`.
 
+#### Overriding download config per-observation
+
+`download_obs_config_overrides` lets you override fields of a
+`download_observations/<obs>.yaml` file from the experiment's suite config,
+without editing the source YAML. This is useful for switching a source's
+provider stream (e.g. NRTI vs. OFFL) on a per-experiment basis, or making any
+other one-off adjustment to a download config.
+
+Set it alongside `obs_to_download` in `suite_config.py`:
+
+```python
+qd.obs_to_download(['my_obs'])
+qd.download_obs_config_overrides({
+    'my_obs': {
+        's3_source': 'OFFL'
+    }
+})
+```
+
+Keys are observation names (matching `obs_to_download`); values are dicts of
+fields to override in that observation's download YAML. `DownloadObs` applies
+these overrides on top of the loaded YAML immediately before downloading, so
+any key present in the download YAML can be overridden this way.
+
 ### Step 4: Create the converter YAML
 
 Create `src/swell/configuration/jedi/interfaces/<model>/convert_observations/my_obs.yaml`:

--- a/src/swell/tasks/download_obs.py
+++ b/src/swell/tasks/download_obs.py
@@ -82,6 +82,7 @@ class DownloadObs(taskBase):
         obs_to_download = self.config.obs_to_download([])
         window_length = self.config.window_length()
         dry_run = self.config.dry_run(True)
+        download_obs_config_overrides = self.config.download_obs_config_overrides({})
 
         if dry_run:
             self.logger.info('DRY RUN MODE - No files will be downloaded')
@@ -109,6 +110,15 @@ class DownloadObs(taskBase):
 
             with open(config_path, 'r') as fh:
                 obs_config = yaml.safe_load(fh)
+
+            # Apply any per-obs overrides from the experiment config.
+            # This allows, e.g., switching s3_source from NRTI to OFFL
+            # via the experiment override YAML without editing source files.
+            if obs_name in download_obs_config_overrides:
+                obs_config.update(download_obs_config_overrides[obs_name])
+                self.logger.info(
+                    f'  Applied download_obs_config_overrides for {obs_name}: '
+                    f'{download_obs_config_overrides[obs_name]}')
 
             downloaded, failed = self._download_obs(
                 obs_config, obs_name,

--- a/src/swell/tasks/task_questions.py
+++ b/src/swell/tasks/task_questions.py
@@ -221,6 +221,7 @@ class TaskQuestions(QuestionContainer, Enum):
     DownloadObs = QuestionList(
         list_name="DownloadObs",
         questions=[
+            qd.download_obs_config_overrides(),
             qd.dry_run(),
             qd.obs_to_download(),
             qd.window_length(),

--- a/src/swell/utilities/question_defaults.py
+++ b/src/swell/utilities/question_defaults.py
@@ -1070,6 +1070,21 @@ class QuestionDefaults():
     # --------------------------------------------------------------------------------------------------
 
     @dataclass
+    class download_obs_config_overrides(TaskQuestion):
+        default_value: dict = mutable_field({})
+        question_name: str = "download_obs_config_overrides"
+        ask_question: bool = False
+        models: List[str] = mutable_field([
+            "all_models"
+        ])
+        prompt: str = ("Per-observation config overrides applied on top of the "
+                       "download_observations/<obs>.yaml file. Keys are obs names; "
+                       "values are dicts of fields to override (e.g. s3_source).")
+        widget_type: WType = WType.STRING
+
+    # --------------------------------------------------------------------------------------------------
+
+    @dataclass
     class converter_path(TaskQuestion):
         default_value: str = ""
         question_name: str = "converter_path"


### PR DESCRIPTION
Resolves https://github.com/GEOS-ESM/swell/issues/890

It can be tested with https://github.com/GEOS-ESM/swell-config/pull/2

doing `swell create ingest_obs_cf -o <path>/swell-config/geos_cf/ingest_obs_geoscfv3.yaml`


