### PR TITLE
hofx4D for hofx_cf

### DIFF
--- a/docs/practical_examples/geos_cf/hofx_cf.md
+++ b/docs/practical_examples/geos_cf/hofx_cf.md
@@ -53,10 +53,37 @@ check_for_obs: false
 swell_static_files: /discover/nobackup/projects/gmao/geos_cf_dev/SwellStaticFiles
 ```
 
-`hofx_cf` does not add any `geos_cf`-specific overrides on top of these, so the `models.geos_cf` section
-of your generated `experiment.yaml` (window length, resolution, observations, etc.) will reflect the
-standard `geos_cf` question defaults. Inspect your own generated `experiment.yaml` for the exact values,
-and use an `override.yaml` (as above) to change them.
+The suite also sets these `geos_cf`-specific defaults:
+
+```yaml
+models:
+  geos_cf:
+    window_type: 3D
+    window_length: PT6H
+    background_frequency: PT3H
+    jedi_forecast_model: pseudo_model
+```
+
+The default 3D configuration uses a single background at the center of the window. To run H(x) over a
+4D window, set `window_type` to `4D` in your override file:
+
+```yaml
+models:
+  geos_cf:
+    window_type: 4D
+    window_length: PT6H
+    background_frequency: PT3H
+    jedi_forecast_model: pseudo_model
+```
+
+In 4D, the JEDI `PSEUDO` forecast model does not integrate GEOS-CF forward in time. Instead, it reads
+the precomputed backgrounds staged throughout the window, with one background for each
+`background_frequency` step. Adjust `window_length` and `background_frequency` together to match the
+available background times.
+
+Other values in the generated `models.geos_cf` section, such as resolution and observations, continue
+to use the standard `geos_cf` question defaults. Inspect your generated `experiment.yaml` for the exact
+values and use an `override.yaml` to change them.
 
 If you would like to change any of these parameters, it is suggested to copy `experiment.yaml`
 to `override.yaml`, make the desired configuration changes, then create the experiment again:
@@ -81,7 +108,8 @@ Executing this command will launch the experiment and bring up the TUI.
 For each cycle and each `model_component` (only `geos_cf` in this suite), the following tasks run, after
 `CloneJedi` and `BuildJedi`/`BuildJediByLinking` have completed:
 
-- `GetBackground`: fetch the background valid for the window.
+- `GetBackground`: fetch one background for a 3D window, or the sequence of precomputed backgrounds
+  needed at each `background_frequency` step for a 4D window.
 - `GetObservations`: fetch the observations for the window.
 - `StageJediCycle`: stage cycle-dependent files.
 - `RenderJediObservations`: render the JEDI observation configuration.

--- a/docs/practical_examples/geos_cf/hofx_cf.md
+++ b/docs/practical_examples/geos_cf/hofx_cf.md
@@ -60,8 +60,6 @@ models:
   geos_cf:
     window_type: 3D
     window_length: PT6H
-    background_frequency: PT3H
-    jedi_forecast_model: pseudo_model
 ```
 
 The default 3D configuration uses a single background at the center of the window. To run H(x) over a

--- a/src/swell/configuration/jedi/interfaces/geos_cf/model/pseudo_model.py
+++ b/src/swell/configuration/jedi/interfaces/geos_cf/model/pseudo_model.py
@@ -1,0 +1,33 @@
+# (C) Copyright 2021- United States Government as represented by the Administrator of the
+# National Aeronautics and Space Administration. All Rights Reserved.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+# --------------------------------------------------------------------------------------------------
+
+from collections.abc import Mapping
+from swell.configuration.jedi.interfaces.geos_cf.model.shared import field_io_names
+
+# --------------------------------------------------------------------------------------------------
+
+
+def pseudo_model(template_dict: Mapping) -> Mapping:
+
+    # The PSEUDO model reads pre-computed backgrounds rather than integrating a model. GetBackground
+    # stages one file per background_frequency step across the window, so tstep must match that
+    # frequency and the filename template must match the r2d2 target file name.
+    pseudo_model = {
+        'name': 'PSEUDO',
+        'tstep': template_dict['background_frequency'],
+        'filetype': 'cube sphere history',
+        'provider': 'geos',
+        'max allowable geometry difference': 0.1,
+        'datapath': template_dict['cycle_dir'],
+        'filename': 'bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4',
+        'field io names': field_io_names,
+    }
+
+    return pseudo_model
+
+# --------------------------------------------------------------------------------------------------

--- a/src/swell/configuration/jedi/interfaces/geos_cf/task_questions.yaml
+++ b/src/swell/configuration/jedi/interfaces/geos_cf/task_questions.yaml
@@ -34,6 +34,11 @@ horizontal_resolution:
   - 'c90'
   - 'c360'
 
+jedi_forecast_model:
+  default_value: pseudo_model
+  options:
+  - pseudo_model
+
 vertical_resolution:
   default_value: 72
   options:

--- a/src/swell/suites/hofx_cf/suite_config.py
+++ b/src/swell/suites/hofx_cf/suite_config.py
@@ -36,12 +36,8 @@ class SuiteConfig(QuestionContainer, Enum):
         ],
 
         geos_cf=[
-            # 3D uses a single background at the window centre; 4D propagates the window with the
-            # PSEUDO model, reading one background per background_frequency step.
             qd.window_type("3D"),
             qd.window_length("PT6H"),
-            qd.background_frequency("PT3H"),
-            qd.jedi_forecast_model("pseudo_model"),
         ]
     )
 

--- a/src/swell/suites/hofx_cf/suite_config.py
+++ b/src/swell/suites/hofx_cf/suite_config.py
@@ -36,6 +36,12 @@ class SuiteConfig(QuestionContainer, Enum):
         ],
 
         geos_cf=[
+            # 3D uses a single background at the window centre; 4D propagates the window with the
+            # PSEUDO model, reading one background per background_frequency step.
+            qd.window_type("3D"),
+            qd.window_length("PT6H"),
+            qd.background_frequency("PT3H"),
+            qd.jedi_forecast_model("pseudo_model"),
         ]
     )
 


### PR DESCRIPTION
## Description

This PR adds PSEUDO model for geos_cf so hofx4D can be executed for this model. 
Documentation has been updated to cotyre this new feature. 

The override `hofx4D.yaml` is added to `swell-config` repo: https://github.com/GEOS-ESM/swell-config/pull/3
