### PR TITLE
Remove injection for JediOopsLogParser

### DIFF
--- a/src/swell/tasks/jedi_oops_log_parser.py
+++ b/src/swell/tasks/jedi_oops_log_parser.py
@@ -27,14 +27,15 @@ class JediOopsLogParser(taskBase):
 
         log_type = self.config.comparison_log_type()
 
-        # Build the command
-        command = ['fgrep', '"Residual norm"'] + [
-                os.path.join(cycle_dir, f'jedi_{log_type}_log.log')]
-        command = ' '.join(command)
+        log_path = os.path.join(cycle_dir, f'jedi_{log_type}_log.log')
 
-        # Run the fgrep command
-        output = subprocess.run(command, capture_output=True, text=True, shell=True, check=True)
-        results = output.stdout
+        with open(log_path, 'r') as f:
+            lines = f.readlines()
+
+        results = []
+        for line in lines:
+            if 'Residual norm' in line:
+                results.append(line.strip())
 
         # Write the output file
         with open(output_file, 'w') as f:
@@ -42,7 +43,7 @@ class JediOopsLogParser(taskBase):
             f.write(f'Model: {model}\n')
             f.write(f'Cycle: {cycle_time}\n\n')
             f.write(f'RESULTS:\n')
-            f.write(results)
+            f.write('\n'.join(results))
 
     def execute(self) -> None:
 

--- a/src/swell/tasks/jedi_oops_log_parser.py
+++ b/src/swell/tasks/jedi_oops_log_parser.py
@@ -9,7 +9,6 @@
 
 
 import os
-import subprocess
 
 from swell.tasks.base.task_base import taskBase
 


### PR DESCRIPTION
## Description

Very minor PR removing shell injection for single task. I'm not really sure why but this never worked with `shell=False`, even though it's not doing any kind of wildcard expansion or anything. I just switched it to python logic.